### PR TITLE
FEAT: implement .all_unique()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@ use std::iter::{IntoIterator};
 use std::cmp::Ordering;
 use std::fmt;
 #[cfg(feature = "use_std")]
+use std::collections::HashSet;
+#[cfg(feature = "use_std")]
 use std::hash::Hash;
 #[cfg(feature = "use_std")]
 use std::fmt::Write;
@@ -1225,6 +1227,30 @@ pub trait Itertools : Iterator {
         where Self::Item: PartialEq,
     {
         self.dedup().nth(1).is_none()
+    }
+
+    /// Check whether all elements are unique (non equal).
+    ///
+    /// Empty iterators are considered to have unique elements:
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let data = vec![1, 2, 3, 4, 1, 5];
+    /// assert!(!data.iter().all_unique());
+    /// assert!(data[0..4].iter().all_unique());
+    /// assert!(data[1..6].iter().all_unique());
+    ///
+    /// let data : Option<usize> = None;
+    /// assert!(data.into_iter().all_unique());
+    /// ```
+    #[cfg(feature = "use_std")]
+    fn all_unique(&mut self) -> bool
+        where Self: Sized,
+              Self::Item: Eq + Hash
+    {
+        let mut used = HashSet::new();
+        self.all(move |elt| used.insert(elt))
     }
 
     /// Consume the first `n` elements from the iterator eagerly,

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -109,6 +109,13 @@ fn all_equal() {
 }
 
 #[test]
+fn all_unique() {
+    assert!("ABCDEFGH".chars().all_unique());
+    assert!(!"ABCDEFGA".chars().all_unique());
+    assert!(::std::iter::empty::<usize>().all_unique());
+}
+
+#[test]
 fn test_put_back_n() {
     let xs = [0, 1, 1, 1, 2, 1, 3, 3];
     let mut pb = put_back_n(xs.iter().cloned());


### PR DESCRIPTION
In day 4 of the Advent of Code 2017 (https://adventofcode.com/),
`all_unique()` would have been useful. It is already present
in some languages such as Factor's `all-unique?`.