### PR TITLE
Add "Null", a type to discard FromIterator results without allocating.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ extern crate core as std;
 
 pub use either::Either;
 
-use std::iter::{IntoIterator};
+use std::iter::{FromIterator, IntoIterator};
 use std::cmp::Ordering;
 use std::fmt;
 #[cfg(feature = "use_std")]
@@ -1910,5 +1910,23 @@ impl<T> FoldWhile<T> {
             FoldWhile::Continue(_) => false,
             FoldWhile::Done(_) => true,
         }
+    }
+}
+
+/// A type that can be used to call `collect` on an iterator, discarding any
+/// items that are produced.
+///
+/// It implements `FromIterator` by exhausting the iterator and returning
+/// only the zero-sized `Null`.
+///
+/// This can be useful when dealing with a function that generically produces
+/// a result using `collect` into anything that implements `FromIterator`, but
+/// the iterator should only be exhausted for its side effect.
+pub struct Null;
+
+impl<T> FromIterator<T> for Null {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        for _ in iter.into_iter() { } // Need to exhaust the iterator.
+        Null
     }
 }

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -684,3 +684,12 @@ fn fold_while() {
     assert_eq!(sum, 15);
 }
 
+#[test]
+fn null_side_effect() {
+    let mut v = vec![];
+    {
+        let iter = (0..5).map(|i| v.push(i));
+        let _ = iter.collect::<it::Null>();
+    }
+    assert_eq!(v, [0, 1, 2, 3, 4]);
+}


### PR DESCRIPTION
I've found this useful a few times when making the iterator yield zero-sized items was not easily possible.

Not sure about the name...