### PR TITLE
Add {min,max}_set(_by{_key)?)? functions

### DIFF
--- a/src/extrema_set.rs
+++ b/src/extrema_set.rs
@@ -1,0 +1,42 @@
+/// Implementation guts for `min_set`, `min_set_by`, and `min_set_by_key`.
+pub fn min_set_impl<I, K, F, L>(mut it: I,
+                                mut key_for: F,
+                                mut lt: L) -> Option<Vec<I::Item>>
+    where I: Iterator,
+          F: FnMut(&I::Item) -> K,
+          L: FnMut(&I::Item, &I::Item, &K, &K) -> bool,
+{
+    let (mut result, mut current_key) = match it.next() {
+        None => return None,
+        Some(element) => {
+            let key = key_for(&element);
+            (vec![element], key)
+        }
+    };
+
+    for element in it {
+        let key = key_for(&element);
+        if lt(&element, &result[0], &key, &current_key) {
+            result.clear();
+            result.push(element);
+            current_key = key;
+        } else if !lt(&result[0], &element, &current_key, &key) {
+            result.push(element);
+        }
+    }
+
+    Some(result)
+}
+
+/// Implementation guts for `ax_set`, `max_set_by`, and `max_set_by_key`.
+pub fn max_set_impl<I, K, F, L>(it: I,
+                                key_for: F,
+                                mut lt: L) -> Option<Vec<I::Item>>
+    where I: Iterator,
+          F: FnMut(&I::Item) -> K,
+          L: FnMut(&I::Item, &I::Item, &K, &K) -> bool,
+{
+    min_set_impl(it, key_for, |it1, it2, key1, key2| lt(it2, it1, key2, key1))
+}
+
+

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -671,6 +671,54 @@ fn diff_shorter() {
 }
 
 #[test]
+fn extrema_set() {
+    use std::cmp::Ordering;
+
+    // A peculiar type: Equality compares both tuple items, but ordering only the
+    // first item. Used to distinguish equal elements.
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct Val(u32, u32);
+
+    impl PartialOrd<Val> for Val {
+        fn partial_cmp(&self, other: &Val) -> Option<Ordering> {
+            self.0.partial_cmp(&other.0)
+        }
+    }
+
+    impl Ord for Val {
+        fn cmp(&self, other: &Val) -> Ordering {
+            self.0.cmp(&other.0)
+        }
+    }
+
+    assert_eq!(None::<Option<u32>>.iter().min_set(), None);
+    assert_eq!(None::<Option<u32>>.iter().max_set(), None);
+
+    assert_eq!(Some(1u32).iter().min_set(), Some(vec![&1]));
+    assert_eq!(Some(1u32).iter().max_set(), Some(vec![&1]));
+
+    let data = vec![Val(0, 1), Val(2, 0), Val(0, 2), Val(1, 0), Val(2, 1)];
+
+    let min_set = data.iter().min_set().unwrap();
+    assert_eq!(min_set, vec![&Val(0, 1), &Val(0, 2)]);
+
+    let min_set_by_key = data.iter().min_set_by_key(|v| v.1).unwrap();
+    assert_eq!(min_set_by_key, vec![&Val(2, 0), &Val(1, 0)]);
+
+    let min_set_by = data.iter().min_set_by(|x, y| x.1.cmp(&y.1)).unwrap();
+    assert_eq!(min_set_by, vec![&Val(2, 0), &Val(1, 0)]);
+
+    let max_set = data.iter().max_set().unwrap();
+    assert_eq!(max_set, vec![&Val(2, 0), &Val(2, 1)]);
+
+    let max_set_by_key = data.iter().max_set_by_key(|v| v.1).unwrap();
+    assert_eq!(max_set_by_key, vec![&Val(0, 2)]);
+
+    let max_set_by = data.iter().max_set_by(|x, y| x.1.cmp(&y.1)).unwrap();
+    assert_eq!(max_set_by, vec![&Val(0, 2)]);
+}
+
+#[test]
 fn minmax() {
     use std::cmp::Ordering;
     use it::MinMaxResult;


### PR DESCRIPTION
The function min_set returns a Vec of all the minimum values. All variants for max and with key extraction and comparison functions are added also.

Since the functions need to return an unknown number of values and the values are not known until the iterator is finished, the function needs to allocate memory. Therefore Vec is used for returning the values. From the guidelines for itertools, this also makes it unlikely to be included in the standard library.

The reason for adding these functions is that I often find situations where I want to know all the minimum values. 

The naming is not optimal; `min_set` indicates that a set is returned while a `Vec` is returned. Another name is `all_min`, but I think that is less explanatory and not as discoverable. YMMV.

While an empty `Vec` could be used to handle the case of an empty iterator, I think that it is more safe to push that check into the type-system.