### PR TITLE
Either crate style methods for EitherOrBoth

### DIFF
--- a/src/either_or_both.rs
+++ b/src/either_or_both.rs
@@ -1,5 +1,7 @@
 use EitherOrBoth::*;
 
+use either::Either;
+
 /// Value that either holds a single A or B, or both.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum EitherOrBoth<A, B> {
@@ -22,11 +24,35 @@ impl<A, B> EitherOrBoth<A, B> {
         self.as_ref().right().is_some()
     }
 
+    /// If Left, return true otherwise, return false.
+    /// Exclusive version of [`has_left`].
+    pub fn is_left(&self) -> bool {
+        match *self {
+            Left(_) => true,
+            _ => false,
+        }
+    }
+
+    /// If Right, return true otherwise, return false.
+    /// Exclusive version of [`has_right`].
+    pub fn is_right(&self) -> bool {
+        match *self {
+            Right(_) => true,
+            _ => false,
+        }
+    }
+
+    /// If Right, return true otherwise, return false.
+    /// Equivalent to `self.as_ref().both().is_some()`.
+    pub fn is_both(&self) -> bool {
+        self.as_ref().both().is_some()
+    }
+
     /// If `Left`, or `Both`, return `Some` with the left value, otherwise, return `None`.
     pub fn left(self) -> Option<A> {
         match self {
             Left(left) | Both(left, _) => Some(left),
-            _ => None
+            _ => None,
         }
     }
 
@@ -34,7 +60,15 @@ impl<A, B> EitherOrBoth<A, B> {
     pub fn right(self) -> Option<B> {
         match self {
             Right(right) | Both(_, right) => Some(right),
-            _ => None
+            _ => None,
+        }
+    }
+
+    /// If Both, return `Some` tuple containing left and right.
+    pub fn both(self) -> Option<(A, B)> {
+        match self {
+            Both(a, b) => Some((a, b)),
+            _ => None,
         }
     }
 
@@ -53,6 +87,104 @@ impl<A, B> EitherOrBoth<A, B> {
             Left(ref mut left) => Left(left),
             Right(ref mut right) => Right(right),
             Both(ref mut left, ref mut right) => Both(left, right),
+        }
+    }
+
+    /// Convert `EitherOrBoth<A, B>` to `EitherOrBoth<B, A>`.
+    pub fn flip(self) -> EitherOrBoth<B, A> {
+        match self {
+            Left(a) => Right(a),
+            Right(b) => Left(b),
+            Both(a, b) => Both(b, a),
+        }
+    }
+
+    /// Apply the function `f` on the value `a` in `Left(a)` or `Both(a, b)` variants. If it is
+    /// present rewrapping the result in `self`'s original variant.
+    pub fn map_left<F, M>(self, f: F) -> EitherOrBoth<M, B>
+    where
+        F: FnOnce(A) -> M,
+    {
+        match self {
+            Both(a, b) => Both(f(a), b),
+            Left(a) => Left(f(a)),
+            Right(b) => Right(b),
+        }
+    }
+
+    /// Apply the function `f` on the value `b` in `Right(b)` or `Both(a, b)` variants.
+    /// If it is present rewrapping the result in `self`'s original variant.
+    pub fn map_right<F, M>(self, f: F) -> EitherOrBoth<A, M>
+    where
+        F: FnOnce(B) -> M,
+    {
+        match self {
+            Left(a) => Left(a),
+            Right(b) => Right(f(b)),
+            Both(a, b) => Both(a, f(b)),
+        }
+    }
+
+    /// Apply the functions `f` and `g` on the value `a` and `b` respectively;
+    /// found in `Left(a)`, `Right(b)`, or `Both(a, b)` variants.
+    /// The Result is rewrapped `self`'s original variant.
+    pub fn map_any<F, L, G, R>(self, f: F, g: G) -> EitherOrBoth<L, R>
+    where
+        F: FnOnce(A) -> L,
+        G: FnOnce(B) -> R,
+    {
+        match self {
+            Left(a) => Left(f(a)),
+            Right(b) => Right(g(b)),
+            Both(a, b) => Both(f(a), g(b)),
+        }
+    }
+
+    /// Apply the function `f` on the value `b` in `Right(b)` or `Both(a, _)` variants if it is
+    /// present.
+    pub fn left_and_then<F, L>(self, f: F) -> EitherOrBoth<L, B>
+    where
+        F: FnOnce(A) -> EitherOrBoth<L, B>,
+    {
+        match self {
+            Left(a) | Both(a, _) => f(a),
+            Right(b) => Right(b),
+        }
+    }
+
+    /// Apply the function `f` on the value `a`
+    /// in `Left(a)` or `Both(a, _)` variants if it is present.
+    pub fn right_and_then<F, R>(self, f: F) -> EitherOrBoth<A, R>
+    where
+        F: FnOnce(B) -> EitherOrBoth<A, R>,
+    {
+        match self {
+            Left(a) => Left(a),
+            Right(b) | Both(_, b) => f(b),
+        }
+    }
+}
+
+impl<T> EitherOrBoth<T, T> {
+    /// Return either value of left, right, or the product of `f` applied where `Both` are present.
+    pub fn reduce<F>(self, f: F) -> T
+    where
+        F: FnOnce(T, T) -> T,
+    {
+        match self {
+            Left(a) => a,
+            Right(b) => b,
+            Both(a, b) => f(a, b),
+        }
+    }
+}
+
+impl<A, B> Into<Option<Either<A, B>>> for EitherOrBoth<A, B> {
+    fn into(self) -> Option<Either<A, B>> {
+        match self {
+            EitherOrBoth::Left(l) => Some(Either::Left(l)),
+            EitherOrBoth::Right(r) => Some(Either::Right(r)),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
I have recently been using `zip_longest`. Without Functors or lens it's a bit of a pain. 
@bluss's [either crate](https://crates.io/crates/either) has methods to make dealing with either variants nicer, so I added some of them. I attempted to make the naming and implementation as similar as possible, but there are a few differences.

A fallible method of converting `EitherOrBoth` into an `either` would be very useful providing exclusive (not including `Both` variant) methods. Converting should probably wait for https://github.com/rust-lang/rust/issues/33417.