### PR TITLE
Powerset iterator adaptor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,7 @@ harness = false
 [[bench]]
 name = "bench1"
 harness = false
+
+[[bench]]
+name = "combinations"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,7 @@ harness = false
 [[bench]]
 name = "combinations"
 harness = false
+
+[[bench]]
+name = "powerset"
+harness = false

--- a/benches/combinations.rs
+++ b/benches/combinations.rs
@@ -1,0 +1,125 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use itertools::Itertools;
+
+// approximate 100_000 iterations for each combination
+const N1: usize = 100_000;
+const N2: usize = 448;
+const N3: usize = 86;
+const N4: usize = 41;
+const N14: usize = 21;
+
+fn comb_for1(c: &mut Criterion) {
+    c.bench_function("comb for1", move |b| {
+        b.iter(|| {
+            for i in 0..N1 {
+                black_box(vec![i]);
+            }
+        })
+    });
+}
+
+fn comb_for2(c: &mut Criterion) {
+    c.bench_function("comb for2", move |b| {
+        b.iter(|| {
+            for i in 0..N2 {
+                for j in (i + 1)..N2 {
+                    black_box(vec![i, j]);
+                }
+            }
+        })
+    });
+}
+
+fn comb_for3(c: &mut Criterion) {
+    c.bench_function("comb for3", move |b| {
+        b.iter(|| {
+            for i in 0..N3 {
+                for j in (i + 1)..N3 {
+                    for k in (j + 1)..N3 {
+                        black_box(vec![i, j, k]);
+                    }
+                }
+            }
+        })
+    });
+}
+
+fn comb_for4(c: &mut Criterion) {
+    c.bench_function("comb for4", move |b| {
+        b.iter(|| {
+            for i in 0..N4 {
+                for j in (i + 1)..N4 {
+                    for k in (j + 1)..N4 {
+                        for l in (k + 1)..N4 {
+                            black_box(vec![i, j, k, l]);
+                        }
+                    }
+                }
+            }
+        })
+    });
+}
+
+fn comb_c1(c: &mut Criterion) {
+    c.bench_function("comb c1", move |b| {
+        b.iter(|| {
+            for combo in (0..N1).combinations(1) {
+                black_box(combo);
+            }
+        })
+    });
+}
+
+fn comb_c2(c: &mut Criterion) {
+    c.bench_function("comb c2", move |b| {
+        b.iter(|| {
+            for combo in (0..N2).combinations(2) {
+                black_box(combo);
+            }
+        })
+    });
+}
+
+fn comb_c3(c: &mut Criterion) {
+    c.bench_function("comb c3", move |b| {
+        b.iter(|| {
+            for combo in (0..N3).combinations(3) {
+                black_box(combo);
+            }
+        })
+    });
+}
+
+fn comb_c4(c: &mut Criterion) {
+    c.bench_function("comb c4", move |b| {
+        b.iter(|| {
+            for combo in (0..N4).combinations(4) {
+                black_box(combo);
+            }
+        })
+    });
+}
+
+fn comb_c14(c: &mut Criterion) {
+    c.bench_function("comb c14", move |b| {
+        b.iter(|| {
+            for combo in (0..N14).combinations(14) {
+                black_box(combo);
+            }
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    comb_for1,
+    comb_for2,
+    comb_for3,
+    comb_for4,
+    comb_c1,
+    comb_c2,
+    comb_c3,
+    comb_c4,
+    comb_c14,
+);
+criterion_main!(benches);

--- a/benches/powerset.rs
+++ b/benches/powerset.rs
@@ -1,0 +1,44 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use itertools::Itertools;
+
+// Keep aggregate generated elements the same, regardless of powerset length.
+const TOTAL_ELEMENTS: usize = 1 << 12;
+const fn calc_iters(n: usize) -> usize {
+    TOTAL_ELEMENTS / (1 << n)
+}
+
+fn powerset_n(c: &mut Criterion, n: usize) {
+    let id = format!("powerset {}", n);
+    c.bench_function(id.as_str(), move |b| {
+        b.iter(|| {
+            for _ in 0..calc_iters(n) {
+                for elt in (0..n).powerset() {
+                    black_box(elt);
+                }
+            }
+        })
+    });
+}
+
+fn powerset_0(c: &mut Criterion) { powerset_n(c, 0); }
+
+fn powerset_1(c: &mut Criterion) { powerset_n(c, 1); }
+
+fn powerset_2(c: &mut Criterion) { powerset_n(c, 2); }
+
+fn powerset_4(c: &mut Criterion) { powerset_n(c, 4); }
+
+fn powerset_8(c: &mut Criterion) { powerset_n(c, 8); }
+
+fn powerset_12(c: &mut Criterion) { powerset_n(c, 12); }
+
+criterion_group!(
+    benches,
+    powerset_0,
+    powerset_1,
+    powerset_2,
+    powerset_4,
+    powerset_8,
+    powerset_12,
+);
+criterion_main!(benches);

--- a/benches/tuple_combinations.rs
+++ b/benches/tuple_combinations.rs
@@ -7,8 +7,8 @@ const N2: usize = 448;
 const N3: usize = 86;
 const N4: usize = 41;
 
-fn comb_for1(c: &mut Criterion) {
-    c.bench_function("comb for1", move |b| {
+fn tuple_comb_for1(c: &mut Criterion) {
+    c.bench_function("tuple comb for1", move |b| {
         b.iter(|| {
             for i in 0..N1 {
                 black_box(i);
@@ -17,8 +17,8 @@ fn comb_for1(c: &mut Criterion) {
     });
 }
 
-fn comb_for2(c: &mut Criterion) {
-    c.bench_function("comb for2", move |b| {
+fn tuple_comb_for2(c: &mut Criterion) {
+    c.bench_function("tuple comb for2", move |b| {
         b.iter(|| {
             for i in 0..N2 {
                 for j in (i + 1)..N2 {
@@ -29,8 +29,8 @@ fn comb_for2(c: &mut Criterion) {
     });
 }
 
-fn comb_for3(c: &mut Criterion) {
-    c.bench_function("comb for3", move |b| {
+fn tuple_comb_for3(c: &mut Criterion) {
+    c.bench_function("tuple comb for3", move |b| {
         b.iter(|| {
             for i in 0..N3 {
                 for j in (i + 1)..N3 {
@@ -43,8 +43,8 @@ fn comb_for3(c: &mut Criterion) {
     });
 }
 
-fn comb_for4(c: &mut Criterion) {
-    c.bench_function("comb for4", move |b| {
+fn tuple_comb_for4(c: &mut Criterion) {
+    c.bench_function("tuple comb for4", move |b| {
         b.iter(|| {
             for i in 0..N4 {
                 for j in (i + 1)..N4 {
@@ -59,8 +59,8 @@ fn comb_for4(c: &mut Criterion) {
     });
 }
 
-fn comb_c1(c: &mut Criterion) {
-    c.bench_function("comb c1", move |b| {
+fn tuple_comb_c1(c: &mut Criterion) {
+    c.bench_function("tuple comb c1", move |b| {
         b.iter(|| {
             for (i,) in (0..N1).tuple_combinations() {
                 black_box(i);
@@ -69,8 +69,8 @@ fn comb_c1(c: &mut Criterion) {
     });
 }
 
-fn comb_c2(c: &mut Criterion) {
-    c.bench_function("comb c2", move |b| {
+fn tuple_comb_c2(c: &mut Criterion) {
+    c.bench_function("tuple comb c2", move |b| {
         b.iter(|| {
             for (i, j) in (0..N2).tuple_combinations() {
                 black_box(i + j);
@@ -79,8 +79,8 @@ fn comb_c2(c: &mut Criterion) {
     });
 }
 
-fn comb_c3(c: &mut Criterion) {
-    c.bench_function("comb c3", move |b| {
+fn tuple_comb_c3(c: &mut Criterion) {
+    c.bench_function("tuple comb c3", move |b| {
         b.iter(|| {
             for (i, j, k) in (0..N3).tuple_combinations() {
                 black_box(i + j + k);
@@ -89,8 +89,8 @@ fn comb_c3(c: &mut Criterion) {
     });
 }
 
-fn comb_c4(c: &mut Criterion) {
-    c.bench_function("comb c4", move |b| {
+fn tuple_comb_c4(c: &mut Criterion) {
+    c.bench_function("tuple comb c4", move |b| {
         b.iter(|| {
             for (i, j, k, l) in (0..N4).tuple_combinations() {
                 black_box(i + j + k + l);
@@ -101,13 +101,13 @@ fn comb_c4(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    comb_for1,
-    comb_for2,
-    comb_for3,
-    comb_for4,
-    comb_c1,
-    comb_c2,
-    comb_c3,
-    comb_c4,
+    tuple_comb_for1,
+    tuple_comb_for2,
+    tuple_comb_for3,
+    tuple_comb_for4,
+    tuple_comb_c1,
+    tuple_comb_c2,
+    tuple_comb_c3,
+    tuple_comb_c4,
 );
 criterion_main!(benches);

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -53,6 +53,10 @@ impl<I: Iterator> Combinations<I> {
     #[inline]
     pub fn n(&self) -> usize { self.pool.len() }
 
+    /// Returns a reference to the source iterator.
+    #[inline]
+    pub(crate) fn src(&self) -> &I { &self.pool.it }
+
     /// Resets this `Combinations` back to an initial state for combinations of length
     /// `k` over the same pool data source. If `k` is larger than the current length
     /// of the data pool an attempt is made to prefill the pool so that it holds `k`

--- a/src/lazy_buffer.rs
+++ b/src/lazy_buffer.rs
@@ -24,10 +24,6 @@ where
         self.buffer.len()
     }
 
-    pub fn is_done(&self) -> bool {
-        self.done
-    }
-
     pub fn get_next(&mut self) -> bool {
         if self.done {
             return false;
@@ -42,6 +38,17 @@ where
                 self.done = true;
                 false
             }
+        }
+    }
+
+    pub fn prefill(&mut self, len: usize) {
+        let buffer_len = self.buffer.len();
+
+        if !self.done && len > buffer_len {
+            let delta = len - buffer_len;
+
+            self.buffer.extend(self.it.by_ref().take(delta));
+            self.done = self.buffer.len() < len;
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,8 @@ pub mod structs {
     pub use crate::permutations::Permutations;
     pub use crate::process_results_impl::ProcessResults;
     #[cfg(feature = "use_alloc")]
+    pub use crate::powerset::Powerset;
+    #[cfg(feature = "use_alloc")]
     pub use crate::put_back_n_impl::PutBackN;
     #[cfg(feature = "use_alloc")]
     pub use crate::rciter_impl::RcIter;
@@ -207,6 +209,8 @@ mod peek_nth;
 mod peeking_take_while;
 #[cfg(feature = "use_alloc")]
 mod permutations;
+#[cfg(feature = "use_alloc")]
+mod powerset;
 mod process_results_impl;
 #[cfg(feature = "use_alloc")]
 mod put_back_n_impl;
@@ -1404,6 +1408,42 @@ pub trait Itertools : Iterator {
               Self::Item: Clone
     {
         permutations::permutations(self, k)
+    }
+
+    /// Return an iterator that iterates through the powerset of the elements from an
+    /// iterator.
+    ///
+    /// Iterator element type is `Vec<Self::Item>`. The iterator produces a new `Vec`
+    /// per iteration, and clones the iterator elements.
+    ///
+    /// The powerset of a set contains all subsets including the empty set and the full
+    /// input set. A powerset has length _2^n_ where _n_ is the length of the input
+    /// set.
+    ///
+    /// Each `Vec` produced by this iterator represents a subset of the elements
+    /// produced by the source iterator.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let sets = (1..4).powerset().collect::<Vec<_>>();
+    /// itertools::assert_equal(sets, vec![
+    ///     vec![],
+    ///     vec![1],
+    ///     vec![2],
+    ///     vec![3],
+    ///     vec![1, 2],
+    ///     vec![1, 3],
+    ///     vec![2, 3],
+    ///     vec![1, 2, 3],
+    /// ]);
+    /// ```
+    #[cfg(feature = "use_alloc")]
+    fn powerset(self) -> Powerset<Self>
+        where Self: Sized,
+              Self::Item: Clone,
+    {
+        powerset::powerset(self)
     }
 
     /// Return an iterator adaptor that pads the sequence to a minimum length of

--- a/src/powerset.rs
+++ b/src/powerset.rs
@@ -1,7 +1,9 @@
 use std::fmt;
+use std::usize;
 use alloc::vec::Vec;
 
 use super::combinations::{Combinations, combinations};
+use super::size_hint;
 
 /// An iterator to iterate through the powerset of the elements from an iterator.
 ///
@@ -10,20 +12,22 @@ use super::combinations::{Combinations, combinations};
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Powerset<I: Iterator> {
     combs: Combinations<I>,
+    // Iterator `position` (equal to count of yielded elements).
+    pos: usize,
 }
 
 impl<I> Clone for Powerset<I>
     where I: Clone + Iterator,
           I::Item: Clone,
 {
-    clone_fields!(combs);
+    clone_fields!(combs, pos);
 }
 
 impl<I> fmt::Debug for Powerset<I>
     where I: Iterator + fmt::Debug,
           I::Item: fmt::Debug,
 {
-    debug_fmt_fields!(Powerset, combs);
+    debug_fmt_fields!(Powerset, combs, pos);
 }
 
 /// Create a new `Powerset` from a clonable iterator.
@@ -31,7 +35,10 @@ pub fn powerset<I>(src: I) -> Powerset<I>
     where I: Iterator,
           I::Item: Clone,
 {
-    Powerset { combs: combinations(src, 0) }
+    Powerset {
+        combs: combinations(src, 0),
+        pos: 0,
+    }
 }
 
 impl<I> Iterator for Powerset<I>
@@ -43,14 +50,34 @@ impl<I> Iterator for Powerset<I>
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(elt) = self.combs.next() {
+            self.pos = self.pos.saturating_add(1);
             Some(elt)
         } else if self.combs.k() < self.combs.n()
             || self.combs.k() == 0
         {
             self.combs.reset(self.combs.k() + 1);
-            self.combs.next()
+            self.combs.next().map(|elt| {
+                self.pos = self.pos.saturating_add(1);
+                elt
+            })
         } else {
             None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // Total bounds for source iterator.
+        let src_total = size_hint::add_scalar(self.combs.src().size_hint(), self.combs.n());
+
+        // Total bounds for self ( length(powerset(set) == 2 ^ length(set) )
+        let self_total = size_hint::pow_scalar_base(2, src_total);
+
+        if self.pos < usize::MAX {
+            // Subtract count of elements already yielded from total.
+            size_hint::sub_scalar(self_total, self.pos)
+        } else {
+            // Fallback: self.pos is saturated and no longer reliable.
+            (0, self_total.1)
         }
     }
 }

--- a/src/powerset.rs
+++ b/src/powerset.rs
@@ -1,0 +1,56 @@
+use std::fmt;
+use alloc::vec::Vec;
+
+use super::combinations::{Combinations, combinations};
+
+/// An iterator to iterate through the powerset of the elements from an iterator.
+///
+/// See [`.powerset()`](../trait.Itertools.html#method.powerset) for more
+/// information.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct Powerset<I: Iterator> {
+    combs: Combinations<I>,
+}
+
+impl<I> Clone for Powerset<I>
+    where I: Clone + Iterator,
+          I::Item: Clone,
+{
+    clone_fields!(combs);
+}
+
+impl<I> fmt::Debug for Powerset<I>
+    where I: Iterator + fmt::Debug,
+          I::Item: fmt::Debug,
+{
+    debug_fmt_fields!(Powerset, combs);
+}
+
+/// Create a new `Powerset` from a clonable iterator.
+pub fn powerset<I>(src: I) -> Powerset<I>
+    where I: Iterator,
+          I::Item: Clone,
+{
+    Powerset { combs: combinations(src, 0) }
+}
+
+impl<I> Iterator for Powerset<I>
+    where
+        I: Iterator,
+        I::Item: Clone,
+{
+    type Item = Vec<I::Item>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(elt) = self.combs.next() {
+            Some(elt)
+        } else if self.combs.k() < self.combs.n()
+            || self.combs.k() == 0
+        {
+            self.combs.reset(self.combs.k() + 1);
+            self.combs.next()
+        } else {
+            None
+        }
+    }
+}

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -3,6 +3,7 @@
 
 use std::usize;
 use std::cmp;
+use std::u32;
 
 /// **SizeHint** is the return type of **Iterator::size_hint()**.
 pub type SizeHint = (usize, Option<usize>);
@@ -71,6 +72,20 @@ pub fn mul_scalar(sh: SizeHint, x: usize) -> SizeHint {
     let (mut low, mut hi) = sh;
     low = low.saturating_mul(x);
     hi = hi.and_then(|elt| elt.checked_mul(x));
+    (low, hi)
+}
+
+/// Raise `base` correctly by a **`SizeHint`** exponent.
+#[inline]
+pub fn pow_scalar_base(base: usize, exp: SizeHint) -> SizeHint {
+    let exp_low = cmp::min(exp.0, u32::MAX as usize) as u32;
+    let low = base.saturating_pow(exp_low);
+
+    let hi = exp.1.and_then(|exp| {
+        let exp_hi = cmp::min(exp, u32::MAX as usize) as u32;
+        base.checked_pow(exp_hi)
+    });
+
     (low, hi)
 }
 

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -908,6 +908,13 @@ quickcheck! {
 }
 
 quickcheck! {
+    fn size_powerset(it: Iter<u8, Exact>) -> bool {
+        // Powerset cardinality gets large very quickly, limit input to keep test fast.
+        correct_size_hint(it.take(12).powerset())
+    }
+}
+
+quickcheck! {
     fn size_unique(it: Iter<i8>) -> bool {
         correct_size_hint(it.unique())
     }

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -765,6 +765,23 @@ fn combinations_with_replacement() {
 }
 
 #[test]
+fn powerset() {
+    it::assert_equal((0..0).powerset(), vec![vec![]]);
+    it::assert_equal((0..1).powerset(), vec![vec![], vec![0]]);
+    it::assert_equal((0..2).powerset(), vec![vec![], vec![0], vec![1], vec![0, 1]]);
+    it::assert_equal((0..3).powerset(), vec![
+        vec![],
+        vec![0], vec![1], vec![2],
+        vec![0, 1], vec![0, 2], vec![1, 2],
+        vec![0, 1, 2]
+    ]);
+
+    assert_eq!((0..4).powerset().count(), 1 << 4);
+    assert_eq!((0..8).powerset().count(), 1 << 8);
+    assert_eq!((0..16).powerset().count(), 1 << 16);
+}
+
+#[test]
 fn diff_mismatch() {
     let a = vec![1, 2, 3, 4];
     let b = vec![1.0, 5.0, 3.0, 4.0];


### PR DESCRIPTION
Implements a [powerset](https://en.wikipedia.org/wiki/Power_set) iterator adaptor that iterates over all subsets of the input iterator's elements. Returns vectors representing these subsets. Internally uses `Combinations` of increasing length.

I've taken the strategy of using a 'position' field that acts both as a means to to detect the special case of the first element and also allows optimal `size_hint()` implementation.

Additionally there is a commit to improve performance that alters `Combinations` implementation slightly. I've added Combinations benchmark as a stand-alone commit to allow checking for performance regressions. `Powerset` performance after this commit improves some cases (with small sizes of `n`) by 10-30%

This is my first attempt at a Rust contribution, happy to put in whatever discussion/work to get this merged. Cheers!