### PR TITLE
feat: add combinations_with_replacement

### DIFF
--- a/benches/combinations_with_replacement.rs
+++ b/benches/combinations_with_replacement.rs
@@ -1,0 +1,34 @@
+#![feature(test)]
+
+extern crate itertools;
+extern crate test;
+
+use itertools::Itertools;
+use test::{black_box, Bencher};
+
+#[bench]
+fn comb_replacement_n10_k5(b: &mut Bencher) {
+    b.iter(|| {
+        for i in (0..10).combinations_with_replacement(5) {
+            black_box(i);
+        }
+    });
+}
+
+#[bench]
+fn comb_replacement_n5_k10(b: &mut Bencher) {
+    b.iter(|| {
+        for i in (0..5).combinations_with_replacement(10) {
+            black_box(i);
+        }
+    });
+}
+
+#[bench]
+fn comb_replacement_n10_k10(b: &mut Bencher) {
+    b.iter(|| {
+        for i in (0..10).combinations_with_replacement(10) {
+            black_box(i);
+        }
+    });
+}

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -1,6 +1,6 @@
-
-use std::ops::Index;
 use std::fmt;
+
+use super::lazy_buffer::LazyBuffer;
 
 /// An iterator to iterate through all the `n`-length combinations in an iterator.
 ///
@@ -98,68 +98,3 @@ impl<I> Iterator for Combinations<I>
         Some(result)
     }
 }
-
-#[derive(Debug)]
-struct LazyBuffer<I: Iterator> {
-    it: I,
-    done: bool,
-    buffer: Vec<I::Item>,
-}
-
-impl<I> LazyBuffer<I>
-    where I: Iterator
-{
-    pub fn new(it: I) -> LazyBuffer<I> {
-        let mut it = it;
-        let mut buffer = Vec::new();
-        let done;
-        if let Some(first) = it.next() {
-            buffer.push(first);
-            done = false;
-        } else {
-            done = true;
-        }
-        LazyBuffer {
-            it: it,
-            done: done,
-            buffer: buffer,
-        }
-    }
-
-    pub fn len(&self) -> usize {
-        self.buffer.len()
-    }
-
-    pub fn is_done(&self) -> bool {
-        self.done
-    }
-
-    pub fn get_next(&mut self) -> bool {
-        if self.done {
-            return false;
-        }
-        let next_item = self.it.next();
-        match next_item {
-            Some(x) => {
-                self.buffer.push(x);
-                true
-            }
-            None => {
-                self.done = true;
-                false
-            }
-        }
-    }
-}
-
-impl<I> Index<usize> for LazyBuffer<I>
-    where I: Iterator,
-          I::Item: Sized
-{
-    type Output = I::Item;
-
-    fn index<'b>(&'b self, _index: usize) -> &'b I::Item {
-        self.buffer.index(_index)
-    }
-}
-

--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -1,0 +1,87 @@
+/// An iterator to iterate through all the `n`-length combinations in an iterator, with replacement.
+///
+/// See [`.combinations_with_replacement()`](../trait.Itertools.html#method.combinations_with_replacement) for more information.
+#[derive(Debug, Clone)]
+pub struct CombinationsWithReplacement<I: Iterator> {
+    n: usize,
+    indices: Vec<usize>,
+    max_index: usize,
+    pool: Vec<I::Item>,
+    first: bool,
+    empty: bool,
+}
+
+impl<I> CombinationsWithReplacement<I>
+where
+    I: Iterator,
+    I::Item: Clone,
+{
+    /// Map the current mask over the pool to get an output combination
+    fn current(&self) -> Vec<I::Item> {
+        self.indices.iter().map(|i| self.pool[*i].clone()).collect()
+    }
+}
+
+/// Create a new `CombinationsWithReplacement` from a clonable iterator.
+pub fn combinations_with_replacement<I>(iter: I, n: usize) -> CombinationsWithReplacement<I>
+where
+    I: Iterator,
+{
+    let indices: Vec<usize> = vec![0; n];
+    let pool: Vec<I::Item> = iter.collect();
+    let empty = n == 0 || pool.len() == 0;
+    let max_index = if empty { 0 } else { pool.len() - 1 };
+
+    CombinationsWithReplacement {
+        n,
+        indices: indices,
+        max_index,
+        pool: pool,
+        first: true,
+        empty,
+    }
+}
+
+impl<I> Iterator for CombinationsWithReplacement<I>
+where
+    I: Iterator,
+    I::Item: Clone,
+{
+    type Item = Vec<I::Item>;
+    fn next(&mut self) -> Option<Self::Item> {
+        // If this is the first iteration
+        if self.first {
+            // In empty edge cases, stop iterating immediately
+            return if self.empty {
+                None
+            // Otherwise, yield the initial state
+            } else {
+                self.first = false;
+                Some(self.current())
+            };
+        }
+
+        // Work out where we need to update our indices
+        let mut increment: Option<(usize, usize)> = None;
+        for (i, indices_int) in self.indices.iter().enumerate().rev() {
+            if indices_int < &self.max_index {
+                increment = Some((i, indices_int + 1));
+                break;
+            }
+        }
+
+        match increment {
+            // If we can update the indices further
+            Some((increment_from, increment_value)) => {
+                // We need to update the rightmost non-max value
+                // and all those to the right
+                for indices_index in increment_from..self.indices.len() {
+                    self.indices[indices_index] = increment_value
+                }
+                Some(self.current())
+            }
+            // Otherwise, we're done
+            None => None,
+        }
+    }
+}

--- a/src/lazy_buffer.rs
+++ b/src/lazy_buffer.rs
@@ -1,0 +1,67 @@
+use std::ops::Index;
+
+#[derive(Debug, Clone)]
+pub struct LazyBuffer<I: Iterator> {
+    it: I,
+    done: bool,
+    buffer: Vec<I::Item>,
+}
+
+impl<I> LazyBuffer<I>
+where
+    I: Iterator,
+{
+    pub fn new(it: I) -> LazyBuffer<I> {
+        let mut it = it;
+        let mut buffer = Vec::new();
+        let done;
+        if let Some(first) = it.next() {
+            buffer.push(first);
+            done = false;
+        } else {
+            done = true;
+        }
+        LazyBuffer {
+            it: it,
+            done: done,
+            buffer: buffer,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.done
+    }
+
+    pub fn get_next(&mut self) -> bool {
+        if self.done {
+            return false;
+        }
+        let next_item = self.it.next();
+        match next_item {
+            Some(x) => {
+                self.buffer.push(x);
+                true
+            }
+            None => {
+                self.done = true;
+                false
+            }
+        }
+    }
+}
+
+impl<I> Index<usize> for LazyBuffer<I>
+where
+    I: Iterator,
+    I::Item: Sized,
+{
+    type Output = I::Item;
+
+    fn index<'b>(&'b self, _index: usize) -> &'b I::Item {
+        self.buffer.index(_index)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,8 @@ mod groupbylazy;
 mod intersperse;
 #[cfg(feature = "use_std")]
 mod kmerge_impl;
+#[cfg(feature = "use_std")]
+mod lazy_buffer;
 mod merge_join;
 mod minmax;
 #[cfg(feature = "use_std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ pub mod structs {
     pub use adaptors::MultiProduct;
     #[cfg(feature = "use_std")]
     pub use combinations::Combinations;
+    #[cfg(feature = "use_std")]
     pub use combinations_with_replacement::CombinationsWithReplacement;
     pub use cons_tuples_impl::ConsTuples;
     pub use exactly_one_err::ExactlyOneError;
@@ -160,6 +161,7 @@ mod concat_impl;
 mod cons_tuples_impl;
 #[cfg(feature = "use_std")]
 mod combinations;
+#[cfg(feature = "use_std")]
 mod combinations_with_replacement;
 mod exactly_one_err;
 mod diff;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ pub mod structs {
     pub use adaptors::MultiProduct;
     #[cfg(feature = "use_std")]
     pub use combinations::Combinations;
+    pub use combinations_with_replacement::CombinationsWithReplacement;
     pub use cons_tuples_impl::ConsTuples;
     pub use exactly_one_err::ExactlyOneError;
     pub use format::{Format, FormatWith};
@@ -159,6 +160,7 @@ mod concat_impl;
 mod cons_tuples_impl;
 #[cfg(feature = "use_std")]
 mod combinations;
+mod combinations_with_replacement;
 mod exactly_one_err;
 mod diff;
 mod format;
@@ -1129,6 +1131,34 @@ pub trait Itertools : Iterator {
               Self::Item: Clone
     {
         combinations::combinations(self, n)
+    }
+
+    /// Return an iterator that iterates over the `n`-length combinations of
+    /// the elements from an iterator, with replacement.
+    ///
+    /// Iterator element type is `Vec<Self::Item>`. The iterator produces a new Vec per iteration,
+    /// and clones the iterator elements.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let it = (1..4).combinations_with_replacement(2);
+    /// itertools::assert_equal(it, vec![
+    ///     vec![1, 1],
+    ///     vec![1, 2],
+    ///     vec![1, 3],
+    ///     vec![2, 2],
+    ///     vec![2, 3],
+    ///     vec![3, 3],
+    ///     ]);
+    /// ```
+    #[cfg(feature = "use_std")]
+    fn combinations_with_replacement(self, n: usize) -> CombinationsWithReplacement<Self>
+    where
+        Self: Sized,
+        Self::Item: Clone,
+    {
+        combinations_with_replacement::combinations_with_replacement(self, n)
     }
 
     /// Return an iterator adaptor that pads the sequence to a minimum length of

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -567,6 +567,12 @@ fn combinations() {
     it::assert_equal((0..1).combinations(1), vec![vec![0]]);
     it::assert_equal((0..2).combinations(1), vec![vec![0], vec![1]]);
     it::assert_equal((0..2).combinations(2), vec![vec![0, 1]]);
+
+    // Infinite iterator should work, even though it doesn't really make sense
+    let mut infinite_combinations = (0..).combinations(2);
+    assert_eq!(infinite_combinations.next(), Some(vec![0, 1]));
+    assert_eq!(infinite_combinations.next(), Some(vec![0, 2]));
+    assert_eq!(infinite_combinations.next(), Some(vec![0, 3]));
 }
 
 #[test]
@@ -609,6 +615,12 @@ fn combinations_with_replacement() {
         (0..0).combinations_with_replacement(2),
         <Vec<Vec<_>>>::new(),
     );
+
+    // Infinite iterator should work, even though it doesn't really make sense
+    let mut infinite_combinations = (0..).combinations_with_replacement(2);
+    assert_eq!(infinite_combinations.next(), Some(vec![0, 0]));
+    assert_eq!(infinite_combinations.next(), Some(vec![0, 1]));
+    assert_eq!(infinite_combinations.next(), Some(vec![0, 2]));
 }
 
 #[test]

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -584,6 +584,34 @@ fn combinations_zero() {
 }
 
 #[test]
+fn combinations_with_replacement() {
+    // Pool smaller than n
+    it::assert_equal((0..1).combinations_with_replacement(2), vec![vec![0, 0]]);
+    // Pool larger than n
+    it::assert_equal(
+        (0..3).combinations_with_replacement(2),
+        vec![
+            vec![0, 0],
+            vec![0, 1],
+            vec![0, 2],
+            vec![1, 1],
+            vec![1, 2],
+            vec![2, 2],
+        ],
+    );
+    // Zero size
+    it::assert_equal(
+        (0..3).combinations_with_replacement(0),
+        <Vec<Vec<_>>>::new(),
+    );
+    // Empty pool
+    it::assert_equal(
+        (0..0).combinations_with_replacement(2),
+        <Vec<Vec<_>>>::new(),
+    );
+}
+
+#[test]
 fn diff_mismatch() {
     let a = vec![1, 2, 3, 4];
     let b = vec![1.0, 5.0, 3.0, 4.0];


### PR DESCRIPTION
As part of a personal project, I wanted to generate combinations of a set `n` of length `k`, but where elements may be repeated (i.e. may be present more than once in the output). I was not able to find an implementation of this in Rust anywhere - please correct me if I'm wrong!

The `CombinationsWithReplacement` iterator consumes a given `Iterator` of `Clone`-able items, and yields combinations of type `Vec<I::Item>` (the same api as `Combinations`). Suggestions for a more concise name welcome.

The algorithm is based on [this Stackoverflow question](https://stackoverflow.com/questions/127704/algorithm-to-return-all-combinations-of-k-elements-from-n) and [sample C code](https://stackoverflow.com/questions/561/how-to-use-combinations-of-sets-as-test-data#794)