### PR TITLE
make all_equal() faster

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -731,3 +731,34 @@ fn cartesian_product_nested_for(b: &mut test::Bencher)
         sum
     })
 }
+
+#[bench]
+fn all_equal(b: &mut test::Bencher) {
+    let mut xs = vec![0; 5_000_000];
+    xs.extend(vec![1; 5_000_000]);
+
+    b.iter(|| xs.iter().all_equal())
+}
+
+#[bench]
+fn all_equal_for(b: &mut test::Bencher) {
+    let mut xs = vec![0; 5_000_000];
+    xs.extend(vec![1; 5_000_000]);
+
+    b.iter(|| {
+        for &x in &xs {
+            if x != xs[0] {
+                return false;
+            }
+        }
+        true
+    })
+}
+
+#[bench]
+fn all_equal_default(b: &mut test::Bencher) {
+    let mut xs = vec![0; 5_000_000];
+    xs.extend(vec![1; 5_000_000]);
+
+    b.iter(|| xs.iter().dedup().nth(1).is_none())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1333,9 +1333,13 @@ pub trait Itertools : Iterator {
     /// assert!(data.into_iter().all_equal());
     /// ```
     fn all_equal(&mut self) -> bool
-        where Self::Item: PartialEq,
+        where Self: Sized,
+              Self::Item: PartialEq,
     {
-        self.dedup().nth(1).is_none()
+        match self.next() {
+            None => true,
+            Some(a) => self.all(|x| a == x),
+        }
     }
 
     /// Consume the first `n` elements from the iterator eagerly,

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -116,6 +116,7 @@ fn dedup_by() {
 
 #[test]
 fn all_equal() {
+    assert!("".chars().all_equal());
     assert!(!"AABBCCC".chars().all_equal());
     assert!("AAAAAAA".chars().all_equal());
     for (_key, mut sub) in &"AABBCCC".chars().group_by(|&x| x) {

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -117,6 +117,7 @@ fn dedup_by() {
 #[test]
 fn all_equal() {
     assert!("".chars().all_equal());
+    assert!("A".chars().all_equal());
     assert!(!"AABBCCC".chars().all_equal());
     assert!("AAAAAAA".chars().all_equal());
     for (_key, mut sub) in &"AABBCCC".chars().group_by(|&x| x) {


### PR DESCRIPTION
Hello!
This PR adresses #282 issue. Variant with `dedup` does not short circuit, but one with `all` does.
I have also added some benchmarks and test for an empty iterator.
```
test all_equal                                ... bench:     999,832 ns/iter (+/- 217,245)
test all_equal_default                        ... bench:   4,814,277 ns/iter (+/- 315,335)
test all_equal_for                            ... bench:   2,096,174 ns/iter (+/- 165,596)
```

Let me know, what do you think.