### PR TITLE
Express KMerge in terms of KMergeBy

### DIFF
--- a/src/kmerge_impl.rs
+++ b/src/kmerge_impl.rs
@@ -226,6 +226,15 @@ pub fn kmerge_by<I, F>(iterable: I, mut less_than: F)
     KMergeBy { heap: heap, less_than: less_than }
 }
 
+impl<I, F> Clone for KMergeBy<I, F>
+    where I: Iterator + Clone,
+          I::Item: Clone,
+          F: Clone,
+{
+    fn clone(&self) -> KMergeBy<I, F> {
+        clone_fields!(KMergeBy, self, heap, less_than)
+    }
+}
 
 impl<I, F> Iterator for KMergeBy<I, F>
     where I: Iterator,


### PR DESCRIPTION
This is a follow up to https://github.com/rust-itertools/itertools/pull/360:
* First, I brought `KMergeBy` in line with `KMerge` by `impl Clone` (if possible).
* Then, I substitute `KMerge` by a specialized `KMergeBy`.
* At last, I express `kmerge` in terms of `kmerge_by`.