### PR TITLE
add rustfmt support to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,11 @@ sudo: false
 matrix:
   include:
     - rust: 1.24.0
-    - rust: stable
+    - name: Rust stable
+      rust: stable
+      before_script:
+        - rustup component add rustfmt
+        - cargo fmt -- --check
     - rust: beta
     - rust: nightly
       env:

--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -1,15 +1,16 @@
 #![feature(test)]
 
 extern crate test;
-#[macro_use] extern crate itertools;
+#[macro_use]
+extern crate itertools;
 
-use test::{black_box};
 use itertools::Itertools;
+use test::black_box;
 
 use itertools::free::cloned;
 
-use std::iter::repeat;
 use std::cmp;
+use std::iter::repeat;
 use std::ops::Add;
 
 mod extra;
@@ -17,26 +18,27 @@ mod extra;
 use extra::ZipSlices;
 
 #[bench]
-fn slice_iter(b: &mut test::Bencher)
-{
+fn slice_iter(b: &mut test::Bencher) {
     let xs: Vec<_> = repeat(1i32).take(20).collect();
-    b.iter(|| for elt in xs.iter() {
-        test::black_box(elt);
+    b.iter(|| {
+        for elt in xs.iter() {
+            test::black_box(elt);
+        }
     })
 }
 
 #[bench]
-fn slice_iter_rev(b: &mut test::Bencher)
-{
+fn slice_iter_rev(b: &mut test::Bencher) {
     let xs: Vec<_> = repeat(1i32).take(20).collect();
-    b.iter(|| for elt in xs.iter().rev() {
-        test::black_box(elt);
+    b.iter(|| {
+        for elt in xs.iter().rev() {
+            test::black_box(elt);
+        }
     })
 }
 
 #[bench]
-fn zip_default_zip(b: &mut test::Bencher)
-{
+fn zip_default_zip(b: &mut test::Bencher) {
     let xs = vec![0; 1024];
     let ys = vec![0; 768];
     let xs = black_box(xs);
@@ -51,8 +53,7 @@ fn zip_default_zip(b: &mut test::Bencher)
 }
 
 #[bench]
-fn zipdot_i32_default_zip(b: &mut test::Bencher)
-{
+fn zipdot_i32_default_zip(b: &mut test::Bencher) {
     let xs = vec![2; 1024];
     let ys = vec![2; 768];
     let xs = black_box(xs);
@@ -68,8 +69,7 @@ fn zipdot_i32_default_zip(b: &mut test::Bencher)
 }
 
 #[bench]
-fn zipdot_f32_default_zip(b: &mut test::Bencher)
-{
+fn zipdot_f32_default_zip(b: &mut test::Bencher) {
     let xs = vec![2f32; 1024];
     let ys = vec![2f32; 768];
     let xs = black_box(xs);
@@ -85,8 +85,7 @@ fn zipdot_f32_default_zip(b: &mut test::Bencher)
 }
 
 #[bench]
-fn zip_default_zip3(b: &mut test::Bencher)
-{
+fn zip_default_zip3(b: &mut test::Bencher) {
     let xs = vec![0; 1024];
     let ys = vec![0; 768];
     let zs = vec![0; 766];
@@ -104,8 +103,7 @@ fn zip_default_zip3(b: &mut test::Bencher)
 }
 
 #[bench]
-fn zip_slices_ziptuple(b: &mut test::Bencher)
-{
+fn zip_slices_ziptuple(b: &mut test::Bencher) {
     let xs = vec![0; 1024];
     let ys = vec![0; 768];
 
@@ -120,8 +118,7 @@ fn zip_slices_ziptuple(b: &mut test::Bencher)
 }
 
 #[bench]
-fn zipslices(b: &mut test::Bencher)
-{
+fn zipslices(b: &mut test::Bencher) {
     let xs = vec![0; 1024];
     let ys = vec![0; 768];
     let xs = black_box(xs);
@@ -136,8 +133,7 @@ fn zipslices(b: &mut test::Bencher)
 }
 
 #[bench]
-fn zipslices_mut(b: &mut test::Bencher)
-{
+fn zipslices_mut(b: &mut test::Bencher) {
     let xs = vec![0; 1024];
     let ys = vec![0; 768];
     let xs = black_box(xs);
@@ -152,8 +148,7 @@ fn zipslices_mut(b: &mut test::Bencher)
 }
 
 #[bench]
-fn zipdot_i32_zipslices(b: &mut test::Bencher)
-{
+fn zipdot_i32_zipslices(b: &mut test::Bencher) {
     let xs = vec![2; 1024];
     let ys = vec![2; 768];
     let xs = black_box(xs);
@@ -169,8 +164,7 @@ fn zipdot_i32_zipslices(b: &mut test::Bencher)
 }
 
 #[bench]
-fn zipdot_f32_zipslices(b: &mut test::Bencher)
-{
+fn zipdot_f32_zipslices(b: &mut test::Bencher) {
     let xs = vec![2f32; 1024];
     let ys = vec![2f32; 768];
     let xs = black_box(xs);
@@ -185,10 +179,8 @@ fn zipdot_f32_zipslices(b: &mut test::Bencher)
     })
 }
 
-
 #[bench]
-fn zip_checked_counted_loop(b: &mut test::Bencher)
-{
+fn zip_checked_counted_loop(b: &mut test::Bencher) {
     let xs = vec![0; 1024];
     let ys = vec![0; 768];
     let xs = black_box(xs);
@@ -210,8 +202,7 @@ fn zip_checked_counted_loop(b: &mut test::Bencher)
 }
 
 #[bench]
-fn zipdot_i32_checked_counted_loop(b: &mut test::Bencher)
-{
+fn zipdot_i32_checked_counted_loop(b: &mut test::Bencher) {
     let xs = vec![2; 1024];
     let ys = vec![2; 768];
     let xs = black_box(xs);
@@ -233,8 +224,7 @@ fn zipdot_i32_checked_counted_loop(b: &mut test::Bencher)
 }
 
 #[bench]
-fn zipdot_f32_checked_counted_loop(b: &mut test::Bencher)
-{
+fn zipdot_f32_checked_counted_loop(b: &mut test::Bencher) {
     let xs = vec![2f32; 1024];
     let ys = vec![2f32; 768];
     let xs = black_box(xs);
@@ -256,8 +246,7 @@ fn zipdot_f32_checked_counted_loop(b: &mut test::Bencher)
 }
 
 #[bench]
-fn zipdot_f32_checked_counted_unrolled_loop(b: &mut test::Bencher)
-{
+fn zipdot_f32_checked_counted_unrolled_loop(b: &mut test::Bencher) {
     let xs = vec![2f32; 1024];
     let ys = vec![2f32; 768];
     let xs = black_box(xs);
@@ -301,8 +290,7 @@ fn zipdot_f32_checked_counted_unrolled_loop(b: &mut test::Bencher)
 }
 
 #[bench]
-fn zip_unchecked_counted_loop(b: &mut test::Bencher)
-{
+fn zip_unchecked_counted_loop(b: &mut test::Bencher) {
     let xs = vec![0; 1024];
     let ys = vec![0; 768];
     let xs = black_box(xs);
@@ -312,18 +300,17 @@ fn zip_unchecked_counted_loop(b: &mut test::Bencher)
         let len = cmp::min(xs.len(), ys.len());
         for i in 0..len {
             unsafe {
-            let x = *xs.get_unchecked(i);
-            let y = *ys.get_unchecked(i);
-            test::black_box(x);
-            test::black_box(y);
+                let x = *xs.get_unchecked(i);
+                let y = *ys.get_unchecked(i);
+                test::black_box(x);
+                test::black_box(y);
             }
         }
     })
 }
 
 #[bench]
-fn zipdot_i32_unchecked_counted_loop(b: &mut test::Bencher)
-{
+fn zipdot_i32_unchecked_counted_loop(b: &mut test::Bencher) {
     let xs = vec![2; 1024];
     let ys = vec![2; 768];
     let xs = black_box(xs);
@@ -334,9 +321,9 @@ fn zipdot_i32_unchecked_counted_loop(b: &mut test::Bencher)
         let mut s = 0i32;
         for i in 0..len {
             unsafe {
-            let x = *xs.get_unchecked(i);
-            let y = *ys.get_unchecked(i);
-            s += x * y;
+                let x = *xs.get_unchecked(i);
+                let y = *ys.get_unchecked(i);
+                s += x * y;
             }
         }
         s
@@ -344,8 +331,7 @@ fn zipdot_i32_unchecked_counted_loop(b: &mut test::Bencher)
 }
 
 #[bench]
-fn zipdot_f32_unchecked_counted_loop(b: &mut test::Bencher)
-{
+fn zipdot_f32_unchecked_counted_loop(b: &mut test::Bencher) {
     let xs = vec![2.; 1024];
     let ys = vec![2.; 768];
     let xs = black_box(xs);
@@ -356,9 +342,9 @@ fn zipdot_f32_unchecked_counted_loop(b: &mut test::Bencher)
         let mut s = 0f32;
         for i in 0..len {
             unsafe {
-            let x = *xs.get_unchecked(i);
-            let y = *ys.get_unchecked(i);
-            s += x * y;
+                let x = *xs.get_unchecked(i);
+                let y = *ys.get_unchecked(i);
+                s += x * y;
             }
         }
         s
@@ -366,8 +352,7 @@ fn zipdot_f32_unchecked_counted_loop(b: &mut test::Bencher)
 }
 
 #[bench]
-fn zip_unchecked_counted_loop3(b: &mut test::Bencher)
-{
+fn zip_unchecked_counted_loop3(b: &mut test::Bencher) {
     let xs = vec![0; 1024];
     let ys = vec![0; 768];
     let zs = vec![0; 766];
@@ -379,12 +364,12 @@ fn zip_unchecked_counted_loop3(b: &mut test::Bencher)
         let len = cmp::min(xs.len(), cmp::min(ys.len(), zs.len()));
         for i in 0..len {
             unsafe {
-            let x = *xs.get_unchecked(i);
-            let y = *ys.get_unchecked(i);
-            let z = *zs.get_unchecked(i);
-            test::black_box(x);
-            test::black_box(y);
-            test::black_box(z);
+                let x = *xs.get_unchecked(i);
+                let y = *ys.get_unchecked(i);
+                let z = *zs.get_unchecked(i);
+                test::black_box(x);
+                test::black_box(y);
+                test::black_box(z);
             }
         }
     })
@@ -464,9 +449,7 @@ fn equal(b: &mut test::Bencher) {
     let l = data.len();
     let alpha = test::black_box(&data[1..]);
     let beta = test::black_box(&data[..l - 1]);
-    b.iter(|| {
-        itertools::equal(alpha, beta)
-    })
+    b.iter(|| itertools::equal(alpha, beta))
 }
 
 #[bench]
@@ -490,9 +473,7 @@ fn merge_default(b: &mut test::Bencher) {
     }
     let data1 = test::black_box(data1);
     let data2 = test::black_box(data2);
-    b.iter(|| {
-        data1.iter().merge(&data2).count()
-    })
+    b.iter(|| data1.iter().merge(&data2).count())
 }
 
 #[bench]
@@ -516,9 +497,7 @@ fn merge_by_cmp(b: &mut test::Bencher) {
     }
     let data1 = test::black_box(data1);
     let data2 = test::black_box(data2);
-    b.iter(|| {
-        data1.iter().merge_by(&data2, PartialOrd::le).count()
-    })
+    b.iter(|| data1.iter().merge_by(&data2, PartialOrd::le).count())
 }
 
 #[bench]
@@ -542,9 +521,7 @@ fn merge_by_lt(b: &mut test::Bencher) {
     }
     let data1 = test::black_box(data1);
     let data2 = test::black_box(data2);
-    b.iter(|| {
-        data1.iter().merge_by(&data2, |a, b| a <= b).count()
-    })
+    b.iter(|| data1.iter().merge_by(&data2, |a, b| a <= b).count())
 }
 
 #[bench]
@@ -569,9 +546,7 @@ fn kmerge_default(b: &mut test::Bencher) {
     let data1 = test::black_box(data1);
     let data2 = test::black_box(data2);
     let its = &[data1.iter(), data2.iter()];
-    b.iter(|| {
-        its.iter().cloned().kmerge().count()
-    })
+    b.iter(|| its.iter().cloned().kmerge().count())
 }
 
 #[bench]
@@ -594,7 +569,7 @@ fn kmerge_tenway(b: &mut test::Bencher) {
     while rest.len() > 0 {
         let chunk_len = 1 + rng(&mut state) % 512;
         let chunk_len = cmp::min(rest.len(), chunk_len as usize);
-        let (fst, tail) = {rest}.split_at_mut(chunk_len);
+        let (fst, tail) = { rest }.split_at_mut(chunk_len);
         fst.sort();
         chunks.push(fst.iter().cloned());
         rest = tail;
@@ -602,55 +577,43 @@ fn kmerge_tenway(b: &mut test::Bencher) {
 
     // println!("Chunk lengths: {}", chunks.iter().format_with(", ", |elt, f| f(&elt.len())));
 
-    b.iter(|| {
-        chunks.iter().cloned().kmerge().count()
-    })
+    b.iter(|| chunks.iter().cloned().kmerge().count())
 }
 
-
 fn fast_integer_sum<I>(iter: I) -> I::Item
-    where I: IntoIterator,
-          I::Item: Default + Add<Output=I::Item>
+where
+    I: IntoIterator,
+    I::Item: Default + Add<Output = I::Item>,
 {
     iter.into_iter().fold(<_>::default(), |x, y| x + y)
 }
 
-
 #[bench]
 fn step_vec_2(b: &mut test::Bencher) {
     let v = vec![0; 1024];
-    b.iter(|| {
-        fast_integer_sum(cloned(v.iter().step(2)))
-    });
+    b.iter(|| fast_integer_sum(cloned(v.iter().step(2))));
 }
 
 #[bench]
 fn step_vec_10(b: &mut test::Bencher) {
     let v = vec![0; 1024];
-    b.iter(|| {
-        fast_integer_sum(cloned(v.iter().step(10)))
-    });
+    b.iter(|| fast_integer_sum(cloned(v.iter().step(10))));
 }
 
 #[bench]
 fn step_range_2(b: &mut test::Bencher) {
     let v = black_box(0..1024);
-    b.iter(|| {
-        fast_integer_sum(v.clone().step(2))
-    });
+    b.iter(|| fast_integer_sum(v.clone().step(2)));
 }
 
 #[bench]
 fn step_range_10(b: &mut test::Bencher) {
     let v = black_box(0..1024);
-    b.iter(|| {
-        fast_integer_sum(v.clone().step(10))
-    });
+    b.iter(|| fast_integer_sum(v.clone().step(10)));
 }
 
 #[bench]
-fn cartesian_product_iterator(b: &mut test::Bencher)
-{
+fn cartesian_product_iterator(b: &mut test::Bencher) {
     let xs = vec![0; 16];
 
     b.iter(|| {
@@ -665,8 +628,7 @@ fn cartesian_product_iterator(b: &mut test::Bencher)
 }
 
 #[bench]
-fn cartesian_product_fold(b: &mut test::Bencher)
-{
+fn cartesian_product_fold(b: &mut test::Bencher) {
     let xs = vec![0; 16];
 
     b.iter(|| {
@@ -681,8 +643,7 @@ fn cartesian_product_fold(b: &mut test::Bencher)
 }
 
 #[bench]
-fn multi_cartesian_product_iterator(b: &mut test::Bencher)
-{
+fn multi_cartesian_product_iterator(b: &mut test::Bencher) {
     let xs = [vec![0; 16], vec![0; 16], vec![0; 16]];
 
     b.iter(|| {
@@ -697,8 +658,7 @@ fn multi_cartesian_product_iterator(b: &mut test::Bencher)
 }
 
 #[bench]
-fn multi_cartesian_product_fold(b: &mut test::Bencher)
-{
+fn multi_cartesian_product_fold(b: &mut test::Bencher) {
     let xs = [vec![0; 16], vec![0; 16], vec![0; 16]];
 
     b.iter(|| {
@@ -713,8 +673,7 @@ fn multi_cartesian_product_fold(b: &mut test::Bencher)
 }
 
 #[bench]
-fn cartesian_product_nested_for(b: &mut test::Bencher)
-{
+fn cartesian_product_nested_for(b: &mut test::Bencher) {
     let xs = vec![0; 16];
 
     b.iter(|| {

--- a/benches/extra/mod.rs
+++ b/benches/extra/mod.rs
@@ -1,4 +1,2 @@
-
-
 pub use self::zipslices::ZipSlices;
 mod zipslices;

--- a/benches/extra/zipslices.rs
+++ b/benches/extra/zipslices.rs
@@ -46,8 +46,9 @@ impl<'a, 'b, A, B> ZipSlices<&'a [A], &'b [B]> {
 }
 
 impl<T, U> ZipSlices<T, U>
-    where T: Slice,
-          U: Slice
+where
+    T: Slice,
+    U: Slice,
 {
     /// Create a new `ZipSlices` from slices `a` and `b`.
     ///
@@ -67,8 +68,9 @@ impl<T, U> ZipSlices<T, U>
 }
 
 impl<T, U> Iterator for ZipSlices<T, U>
-    where T: Slice,
-          U: Slice
+where
+    T: Slice,
+    U: Slice,
 {
     type Item = (T::Item, U::Item);
 
@@ -80,9 +82,7 @@ impl<T, U> Iterator for ZipSlices<T, U>
             } else {
                 let i = self.index;
                 self.index += 1;
-                Some((
-                    self.t.get_unchecked(i),
-                    self.u.get_unchecked(i)))
+                Some((self.t.get_unchecked(i), self.u.get_unchecked(i)))
             }
         }
     }
@@ -95,8 +95,9 @@ impl<T, U> Iterator for ZipSlices<T, U>
 }
 
 impl<T, U> DoubleEndedIterator for ZipSlices<T, U>
-    where T: Slice,
-          U: Slice
+where
+    T: Slice,
+    U: Slice,
 {
     #[inline(always)]
     fn next_back(&mut self) -> Option<Self::Item> {
@@ -106,22 +107,23 @@ impl<T, U> DoubleEndedIterator for ZipSlices<T, U>
             } else {
                 self.len -= 1;
                 let i = self.len;
-                Some((
-                    self.t.get_unchecked(i),
-                    self.u.get_unchecked(i)))
+                Some((self.t.get_unchecked(i), self.u.get_unchecked(i)))
             }
         }
     }
 }
 
 impl<T, U> ExactSizeIterator for ZipSlices<T, U>
-    where T: Slice,
-          U: Slice
-{}
+where
+    T: Slice,
+    U: Slice,
+{
+}
 
 unsafe impl<T, U> Slice for ZipSlices<T, U>
-    where T: Slice,
-          U: Slice
+where
+    T: Slice,
+    U: Slice,
 {
     type Item = (T::Item, U::Item);
 
@@ -130,8 +132,7 @@ unsafe impl<T, U> Slice for ZipSlices<T, U>
     }
 
     unsafe fn get_unchecked(&mut self, i: usize) -> Self::Item {
-        (self.t.get_unchecked(i),
-         self.u.get_unchecked(i))
+        (self.t.get_unchecked(i), self.u.get_unchecked(i))
     }
 }
 
@@ -152,7 +153,9 @@ pub unsafe trait Slice {
 unsafe impl<'a, T> Slice for &'a [T] {
     type Item = &'a T;
     #[inline(always)]
-    fn len(&self) -> usize { (**self).len() }
+    fn len(&self) -> usize {
+        (**self).len()
+    }
     #[inline(always)]
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a T {
         debug_assert!(i < self.len());
@@ -163,7 +166,9 @@ unsafe impl<'a, T> Slice for &'a [T] {
 unsafe impl<'a, T> Slice for &'a mut [T] {
     type Item = &'a mut T;
     #[inline(always)]
-    fn len(&self) -> usize { (**self).len() }
+    fn len(&self) -> usize {
+        (**self).len()
+    }
     #[inline(always)]
     unsafe fn get_unchecked(&mut self, i: usize) -> &'a mut T {
         debug_assert!(i < self.len());
@@ -174,7 +179,6 @@ unsafe impl<'a, T> Slice for &'a mut [T] {
 
 #[test]
 fn zipslices() {
-
     let xs = [1, 2, 3, 4, 5, 6];
     let ys = [1, 2, 3, 7];
     ::itertools::assert_equal(ZipSlices::new(&xs, &ys), xs.iter().zip(&ys));
@@ -186,4 +190,3 @@ fn zipslices() {
     }
     ::itertools::assert_equal(&xs, &ys);
 }
-

--- a/benches/fold_specialization.rs
+++ b/benches/fold_specialization.rs
@@ -1,14 +1,15 @@
 #![feature(test)]
 
-extern crate test;
 extern crate itertools;
+extern crate test;
 
 use itertools::Itertools;
 
 struct Unspecialized<I>(I);
 
 impl<I> Iterator for Unspecialized<I>
-where I: Iterator
+where
+    I: Iterator,
 {
     type Item = I::Item;
 
@@ -30,8 +31,7 @@ mod specialization {
         use super::*;
 
         #[bench]
-        fn external(b: &mut test::Bencher)
-        {
+        fn external(b: &mut test::Bencher) {
             let arr = [1; 1024];
 
             b.iter(|| {
@@ -44,23 +44,17 @@ mod specialization {
         }
 
         #[bench]
-        fn internal_specialized(b: &mut test::Bencher)
-        {
+        fn internal_specialized(b: &mut test::Bencher) {
             let arr = [1; 1024];
 
-            b.iter(|| {
-                arr.into_iter().intersperse(&0).fold(0, |acc, x| acc + x)
-            })
+            b.iter(|| arr.into_iter().intersperse(&0).fold(0, |acc, x| acc + x))
         }
 
         #[bench]
-        fn internal_unspecialized(b: &mut test::Bencher)
-        {
+        fn internal_unspecialized(b: &mut test::Bencher) {
             let arr = [1; 1024];
 
-            b.iter(|| {
-                Unspecialized(arr.into_iter().intersperse(&0)).fold(0, |acc, x| acc + x)
-            })
+            b.iter(|| Unspecialized(arr.into_iter().intersperse(&0)).fold(0, |acc, x| acc + x))
         }
     }
 }

--- a/benches/tree_fold1.rs
+++ b/benches/tree_fold1.rs
@@ -1,18 +1,19 @@
 #![feature(test)]
 
-extern crate test;
 extern crate itertools;
+extern crate test;
 
-use itertools::Itertools;
 use itertools::cloned;
+use itertools::Itertools;
 use test::Bencher;
 
-trait IterEx : Iterator {
+trait IterEx: Iterator {
     // Another efficient implementation against which to compare,
     // but needs `std` so is less desirable.
     fn tree_fold1_vec<F>(self, mut f: F) -> Option<Self::Item>
-        where F: FnMut(Self::Item, Self::Item) -> Self::Item,
-              Self: Sized,
+    where
+        F: FnMut(Self::Item, Self::Item) -> Self::Item,
+        Self: Sized,
     {
         let hint = self.size_hint().0;
         let cap = std::mem::size_of::<usize>() * 8 - hint.leading_zeros() as usize;
@@ -27,99 +28,97 @@ trait IterEx : Iterator {
         stack.into_iter().fold1(f)
     }
 }
-impl<T:Iterator> IterEx for T {}
+impl<T: Iterator> IterEx for T {}
 
 macro_rules! def_benchs {
     ($N:expr,
      $FUN:ident,
      $BENCH_NAME:ident,
-     ) => (
+     ) => {
         mod $BENCH_NAME {
-        use super::*;
+            use super::*;
 
-        #[bench]
-        fn sum(b: &mut Bencher) {
-            let v: Vec<u32> = (0.. $N).collect();
-            b.iter(|| {
-                cloned(&v).$FUN(|x, y| x + y)
-            });
-        }
+            #[bench]
+            fn sum(b: &mut Bencher) {
+                let v: Vec<u32> = (0..$N).collect();
+                b.iter(|| cloned(&v).$FUN(|x, y| x + y));
+            }
 
-        #[bench]
-        fn complex_iter(b: &mut Bencher) {
-            let u = (3..).take($N / 2);
-            let v = (5..).take($N / 2);
-            let it = u.chain(v);
+            #[bench]
+            fn complex_iter(b: &mut Bencher) {
+                let u = (3..).take($N / 2);
+                let v = (5..).take($N / 2);
+                let it = u.chain(v);
 
-            b.iter(|| {
-                it.clone().map(|x| x as f32).$FUN(f32::atan2)
-            });
-        }
+                b.iter(|| it.clone().map(|x| x as f32).$FUN(f32::atan2));
+            }
 
-        #[bench]
-        fn string_format(b: &mut Bencher) {
-            // This goes quadratic with linear `fold1`, so use a smaller
-            // size to not waste too much time in travis.  The allocations
-            // in here are so expensive anyway that it'll still take
-            // way longer per iteration than the other two benchmarks.
-            let v: Vec<u32> = (0.. ($N/4)).collect();
-            b.iter(|| {
-                cloned(&v).map(|x| x.to_string()).$FUN(|x, y| format!("{} + {}", x, y))
-            });
+            #[bench]
+            fn string_format(b: &mut Bencher) {
+                // This goes quadratic with linear `fold1`, so use a smaller
+                // size to not waste too much time in travis.  The allocations
+                // in here are so expensive anyway that it'll still take
+                // way longer per iteration than the other two benchmarks.
+                let v: Vec<u32> = (0..($N / 4)).collect();
+                b.iter(|| {
+                    cloned(&v)
+                        .map(|x| x.to_string())
+                        .$FUN(|x, y| format!("{} + {}", x, y))
+                });
+            }
         }
-        }
-    )
+    };
 }
 
-def_benchs!{
+def_benchs! {
     10_000,
     fold1,
     fold1_10k,
 }
 
-def_benchs!{
+def_benchs! {
     10_000,
     tree_fold1,
     tree_fold1_stack_10k,
 }
 
-def_benchs!{
+def_benchs! {
     10_000,
     tree_fold1_vec,
     tree_fold1_vec_10k,
 }
 
-def_benchs!{
+def_benchs! {
     100,
     fold1,
     fold1_100,
 }
 
-def_benchs!{
+def_benchs! {
     100,
     tree_fold1,
     tree_fold1_stack_100,
 }
 
-def_benchs!{
+def_benchs! {
     100,
     tree_fold1_vec,
     tree_fold1_vec_100,
 }
 
-def_benchs!{
+def_benchs! {
     8,
     fold1,
     fold1_08,
 }
 
-def_benchs!{
+def_benchs! {
     8,
     tree_fold1,
     tree_fold1_stack_08,
 }
 
-def_benchs!{
+def_benchs! {
     8,
     tree_fold1_vec,
     tree_fold1_vec_08,

--- a/benches/tuple_combinations.rs
+++ b/benches/tuple_combinations.rs
@@ -1,10 +1,10 @@
 #![feature(test)]
 
-extern crate test;
 extern crate itertools;
+extern crate test;
 
-use test::{black_box, Bencher};
 use itertools::Itertools;
+use test::{black_box, Bencher};
 
 // approximate 100_000 iterations for each combination
 const N1: usize = 100_000;

--- a/benches/tuples.rs
+++ b/benches/tuples.rs
@@ -1,10 +1,10 @@
 #![feature(test)]
 
-extern crate test;
 extern crate itertools;
+extern crate test;
 
-use test::Bencher;
 use itertools::Itertools;
+use test::Bencher;
 
 fn s1(a: u32) -> u32 {
     a
@@ -38,7 +38,7 @@ fn sum_s4(s: &[u32]) -> u32 {
     s4(s[0], s[1], s[2], s[3])
 }
 
-fn sum_t1(s: &(&u32, )) -> u32 {
+fn sum_t1(s: &(&u32,)) -> u32 {
     s1(*s.0)
 }
 
@@ -64,10 +64,10 @@ macro_rules! def_benchs {
      $WINDOWS:ident;
      $FOR_CHUNKS:ident,
      $FOR_WINDOWS:ident
-     ) => (
+     ) => {
         #[bench]
         fn $FOR_CHUNKS(b: &mut Bencher) {
-            let v: Vec<u32> = (0.. $N * 1_000).collect();
+            let v: Vec<u32> = (0..$N * 1_000).collect();
             let mut s = 0;
             b.iter(|| {
                 let mut j = 0;
@@ -93,7 +93,7 @@ macro_rules! def_benchs {
 
         #[bench]
         fn $TUPLES(b: &mut Bencher) {
-            let v: Vec<u32> = (0.. $N * 1_000).collect();
+            let v: Vec<u32> = (0..$N * 1_000).collect();
             let mut s = 0;
             b.iter(|| {
                 for x in v.iter().tuples() {
@@ -105,7 +105,7 @@ macro_rules! def_benchs {
 
         #[bench]
         fn $CHUNKS(b: &mut Bencher) {
-            let v: Vec<u32> = (0.. $N * 1_000).collect();
+            let v: Vec<u32> = (0..$N * 1_000).collect();
             let mut s = 0;
             b.iter(|| {
                 for x in v.chunks($N) {
@@ -138,10 +138,10 @@ macro_rules! def_benchs {
                 s
             });
         }
-    )
+    };
 }
 
-def_benchs!{
+def_benchs! {
     1;
     sum_t1,
     tuple_chunks_1,
@@ -153,7 +153,7 @@ def_benchs!{
     for_windows_1
 }
 
-def_benchs!{
+def_benchs! {
     2;
     sum_t2,
     tuple_chunks_2,
@@ -165,7 +165,7 @@ def_benchs!{
     for_windows_2
 }
 
-def_benchs!{
+def_benchs! {
     3;
     sum_t3,
     tuple_chunks_3,
@@ -177,7 +177,7 @@ def_benchs!{
     for_windows_3
 }
 
-def_benchs!{
+def_benchs! {
     4;
     sum_t4,
     tuple_chunks_4,

--- a/examples/iris.rs
+++ b/examples/iris.rs
@@ -5,7 +5,6 @@
 /// Iterators and itertools functionality are used throughout.
 ///
 ///
-
 extern crate itertools;
 
 use itertools::Itertools;
@@ -39,7 +38,10 @@ impl FromStr for Iris {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut iris = Iris { name: "".into(), data: [0.; 4] };
+        let mut iris = Iris {
+            name: "".into(),
+            data: [0.; 4],
+        };
         let mut parts = s.split(",").map(str::trim);
 
         // using Iterator::by_ref()
@@ -49,7 +51,7 @@ impl FromStr for Iris {
         if let Some(name) = parts.next() {
             iris.name = name.into();
         } else {
-            return Err(ParseError::Other("Missing name"))
+            return Err(ParseError::Other("Missing name"));
         }
         Ok(iris)
     }
@@ -57,12 +59,13 @@ impl FromStr for Iris {
 
 fn main() {
     // using Itertools::fold_results to create the result of parsing
-    let irises = DATA.lines()
-                     .map(str::parse)
-                     .fold_results(Vec::new(), |mut v, iris: Iris| {
-                         v.push(iris);
-                         v
-                     });
+    let irises = DATA
+        .lines()
+        .map(str::parse)
+        .fold_results(Vec::new(), |mut v, iris: Iris| {
+            v.push(iris);
+            v
+        });
     let mut irises = match irises {
         Err(e) => {
             println!("Error parsing: {:?}", e);
@@ -81,16 +84,15 @@ fn main() {
     // using Itertools::group_by
     for (species, species_group) in &irises.iter().group_by(|iris| &iris.name) {
         // assign a plot symbol
-        symbolmap.entry(species).or_insert_with(|| {
-            plot_symbols.next().unwrap()
-        });
+        symbolmap
+            .entry(species)
+            .or_insert_with(|| plot_symbols.next().unwrap());
         println!("{} (symbol={})", species, symbolmap[species]);
 
         for iris in species_group {
             // using Itertools::format for lazy formatting
             println!("{:>3.1}", iris.data.iter().format(", "));
         }
-
     }
 
     // Look at all combinations of the four columns

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -13,27 +13,34 @@ use Itertools;
 /// for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct MultiProduct<I>(Vec<MultiProductIter<I>>)
-    where I: Iterator + Clone,
-          I::Item: Clone;
+where
+    I: Iterator + Clone,
+    I::Item: Clone;
 
 /// Create a new cartesian product iterator over an arbitrary number
 /// of iterators of the same type.
 ///
 /// Iterator element is of type `Vec<H::Item::Item>`.
 pub fn multi_cartesian_product<H>(iters: H) -> MultiProduct<<H::Item as IntoIterator>::IntoIter>
-    where H: Iterator,
-          H::Item: IntoIterator,
-          <H::Item as IntoIterator>::IntoIter: Clone,
-          <H::Item as IntoIterator>::Item: Clone
+where
+    H: Iterator,
+    H::Item: IntoIterator,
+    <H::Item as IntoIterator>::IntoIter: Clone,
+    <H::Item as IntoIterator>::Item: Clone,
 {
-    MultiProduct(iters.map(|i| MultiProductIter::new(i.into_iter())).collect())
+    MultiProduct(
+        iters
+            .map(|i| MultiProductIter::new(i.into_iter()))
+            .collect(),
+    )
 }
 
 #[derive(Clone, Debug)]
 /// Holds the state of a single iterator within a MultiProduct.
 struct MultiProductIter<I>
-    where I: Iterator + Clone,
-          I::Item: Clone
+where
+    I: Iterator + Clone,
+    I::Item: Clone,
 {
     cur: Option<I::Item>,
     iter: I,
@@ -48,8 +55,9 @@ enum MultiProductIterState {
 }
 
 impl<I> MultiProduct<I>
-    where I: Iterator + Clone,
-          I::Item: Clone
+where
+    I: Iterator + Clone,
+    I::Item: Clone,
 {
     /// Iterates the rightmost iterator, then recursively iterates iterators
     /// to the left if necessary.
@@ -57,7 +65,7 @@ impl<I> MultiProduct<I>
     /// Returns true if the iteration succeeded, else false.
     fn iterate_last(
         multi_iters: &mut [MultiProductIter<I>],
-        mut state: MultiProductIterState
+        mut state: MultiProductIterState,
     ) -> bool {
         use self::MultiProductIterState::*;
 
@@ -65,10 +73,12 @@ impl<I> MultiProduct<I>
             let on_first_iter = match state {
                 StartOfIter => {
                     let on_first_iter = !last.in_progress();
-                    state = MidIter { on_first_iter: on_first_iter };
+                    state = MidIter {
+                        on_first_iter: on_first_iter,
+                    };
                     on_first_iter
-                },
-                MidIter { on_first_iter } => on_first_iter
+                }
+                MidIter { on_first_iter } => on_first_iter,
             };
 
             if !on_first_iter {
@@ -91,16 +101,17 @@ impl<I> MultiProduct<I>
             // At end of iteration (final iterator finishes), finish.
             match state {
                 StartOfIter => false,
-                MidIter { on_first_iter } => on_first_iter
+                MidIter { on_first_iter } => on_first_iter,
             }
         }
     }
 
     /// Returns the unwrapped value of the next iteration.
     fn curr_iterator(&self) -> Vec<I::Item> {
-        self.0.iter().map(|multi_iter| {
-            multi_iter.cur.clone().unwrap()
-        }).collect()
+        self.0
+            .iter()
+            .map(|multi_iter| multi_iter.cur.clone().unwrap())
+            .collect()
     }
 
     /// Returns true if iteration has started and has not yet finished; false
@@ -115,14 +126,15 @@ impl<I> MultiProduct<I>
 }
 
 impl<I> MultiProductIter<I>
-    where I: Iterator + Clone,
-          I::Item: Clone
+where
+    I: Iterator + Clone,
+    I::Item: Clone,
 {
     fn new(iter: I) -> Self {
         MultiProductIter {
             cur: None,
             iter: iter.clone(),
-            iter_orig: iter
+            iter_orig: iter,
         }
     }
 
@@ -144,16 +156,14 @@ impl<I> MultiProductIter<I>
 }
 
 impl<I> Iterator for MultiProduct<I>
-    where I: Iterator + Clone,
-          I::Item: Clone
+where
+    I: Iterator + Clone,
+    I::Item: Clone,
 {
     type Item = Vec<I::Item>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if MultiProduct::iterate_last(
-            &mut self.0,
-            MultiProductIterState::StartOfIter
-        ) {
+        if MultiProduct::iterate_last(&mut self.0, MultiProductIterState::StartOfIter) {
             Some(self.curr_iterator())
         } else {
             None
@@ -166,18 +176,24 @@ impl<I> Iterator for MultiProduct<I>
         }
 
         if !self.in_progress() {
-            return self.0.into_iter().fold(1, |acc, multi_iter| {
-                acc * multi_iter.iter.count()
-            });
+            return self
+                .0
+                .into_iter()
+                .fold(1, |acc, multi_iter| acc * multi_iter.iter.count());
         }
 
         self.0.into_iter().fold(
             0,
-            |acc, MultiProductIter { iter, iter_orig, cur: _ }| {
+            |acc,
+             MultiProductIter {
+                 iter,
+                 iter_orig,
+                 cur: _,
+             }| {
                 let total_count = iter_orig.count();
                 let cur_count = iter.count();
                 acc * total_count + cur_count
-            }
+            },
         )
     }
 
@@ -195,18 +211,25 @@ impl<I> Iterator for MultiProduct<I>
 
         self.0.iter().fold(
             (0, Some(0)),
-            |acc, &MultiProductIter { ref iter, ref iter_orig, cur: _ }| {
+            |acc,
+             &MultiProductIter {
+                 ref iter,
+                 ref iter_orig,
+                 cur: _,
+             }| {
                 let cur_size = iter.size_hint();
                 let total_size = iter_orig.size_hint();
                 size_hint::add(size_hint::mul(acc, total_size), cur_size)
-            }
+            },
         )
     }
 
     fn last(self) -> Option<Self::Item> {
         let iter_count = self.0.len();
 
-        let lasts: Self::Item = self.0.into_iter()
+        let lasts: Self::Item = self
+            .0
+            .into_iter()
             .map(|multi_iter| multi_iter.iter.last())
             .while_some()
             .collect();

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -14,15 +14,17 @@ pub struct Combinations<I: Iterator> {
 }
 
 impl<I> fmt::Debug for Combinations<I>
-    where I: Iterator + fmt::Debug,
-          I::Item: fmt::Debug,
+where
+    I: Iterator + fmt::Debug,
+    I::Item: fmt::Debug,
 {
     debug_fmt_fields!(Combinations, n, indices, pool, first);
 }
 
 /// Create a new `Combinations` from a clonable iterator.
 pub fn combinations<I>(iter: I, n: usize) -> Combinations<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     let mut indices: Vec<usize> = Vec::with_capacity(n);
     for i in 0..n {
@@ -45,8 +47,9 @@ pub fn combinations<I>(iter: I, n: usize) -> Combinations<I>
 }
 
 impl<I> Iterator for Combinations<I>
-    where I: Iterator,
-          I::Item: Clone
+where
+    I: Iterator,
+    I::Item: Clone,
 {
     type Item = Vec<I::Item>;
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/concat_impl.rs
+++ b/src/concat_impl.rs
@@ -10,13 +10,20 @@ use Itertools;
 ///
 /// ```rust
 /// use itertools::concat;
-/// 
+///
 /// let input = vec![vec![1], vec![2, 3], vec![4, 5, 6]];
 /// assert_eq!(concat(input), vec![1, 2, 3, 4, 5, 6]);
 /// ```
 pub fn concat<I>(iterable: I) -> I::Item
-    where I: IntoIterator,
-          I::Item: Extend<<<I as IntoIterator>::Item as IntoIterator>::Item> + IntoIterator + Default
+where
+    I: IntoIterator,
+    I::Item: Extend<<<I as IntoIterator>::Item as IntoIterator>::Item> + IntoIterator + Default,
 {
-    iterable.into_iter().fold1(|mut a, b| { a.extend(b); a }).unwrap_or_else(|| <_>::default())
+    iterable
+        .into_iter()
+        .fold1(|mut a, b| {
+            a.extend(b);
+            a
+        })
+        .unwrap_or_else(|| <_>::default())
 }

--- a/src/cons_tuples_impl.rs
+++ b/src/cons_tuples_impl.rs
@@ -1,4 +1,3 @@
-
 macro_rules! impl_cons_iter(
     ($_A:ident, $_B:ident, ) => (); // stop
 
@@ -44,13 +43,15 @@ impl_cons_iter!(A, B, C, D, E, F, G, H,);
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug)]
 pub struct ConsTuples<I, J>
-    where I: Iterator<Item=J>,
+where
+    I: Iterator<Item = J>,
 {
     iter: I,
 }
 
 impl<I, J> Clone for ConsTuples<I, J>
-    where I: Clone + Iterator<Item=J>,
+where
+    I: Clone + Iterator<Item = J>,
 {
     fn clone(&self) -> Self {
         ConsTuples {
@@ -62,7 +63,10 @@ impl<I, J> Clone for ConsTuples<I, J>
 /// Create an iterator that maps for example iterators of
 /// `((A, B), C)` to `(A, B, C)`.
 pub fn cons_tuples<I, J>(iterable: I) -> ConsTuples<I, J>
-    where I: Iterator<Item=J>
+where
+    I: Iterator<Item = J>,
 {
-    ConsTuples { iter: iterable.into_iter() }
+    ConsTuples {
+        iter: iterable.into_iter(),
+    }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -13,8 +13,9 @@ use structs::PutBack;
 /// `Diff` represents the way in which the elements yielded by the iterator `I` differ to some
 /// iterator `J`.
 pub enum Diff<I, J>
-    where I: Iterator,
-          J: Iterator
+where
+    I: Iterator,
+    J: Iterator,
 {
     /// The index of the first non-matching element along with both iterator's remaining elements
     /// starting with the first mis-match.
@@ -37,11 +38,11 @@ pub enum Diff<I, J>
 ///
 /// If `i` becomes exhausted before `j` becomes exhausted, the number of elements in `i` along with
 /// the remaining `j` elements will be returned as `Diff::Longer`.
-pub fn diff_with<I, J, F>(i: I, j: J, is_equal: F)
-    -> Option<Diff<I::IntoIter, J::IntoIter>>
-    where I: IntoIterator,
-          J: IntoIterator,
-          F: Fn(&I::Item, &J::Item) -> bool
+pub fn diff_with<I, J, F>(i: I, j: J, is_equal: F) -> Option<Diff<I::IntoIter, J::IntoIter>>
+where
+    I: IntoIterator,
+    J: IntoIterator,
+    F: Fn(&I::Item, &J::Item) -> bool,
 {
     let mut i = i.into_iter();
     let mut j = j.into_iter();
@@ -49,13 +50,16 @@ pub fn diff_with<I, J, F>(i: I, j: J, is_equal: F)
     while let Some(i_elem) = i.next() {
         match j.next() {
             None => return Some(Diff::Shorter(idx, put_back(i).with_value(i_elem))),
-            Some(j_elem) => if !is_equal(&i_elem, &j_elem) {
-                let remaining_i = put_back(i).with_value(i_elem);
-                let remaining_j = put_back(j).with_value(j_elem);
-                return Some(Diff::FirstMismatch(idx, remaining_i, remaining_j));
-            },
+            Some(j_elem) => {
+                if !is_equal(&i_elem, &j_elem) {
+                    let remaining_i = put_back(i).with_value(i_elem);
+                    let remaining_j = put_back(j).with_value(j_elem);
+                    return Some(Diff::FirstMismatch(idx, remaining_i, remaining_j));
+                }
+            }
         }
         idx += 1;
     }
-    j.next().map(|j_elem| Diff::Longer(idx, put_back(j).with_value(j_elem)))
+    j.next()
+        .map(|j_elem| Diff::Longer(idx, put_back(j).with_value(j_elem)))
 }

--- a/src/either_or_both.rs
+++ b/src/either_or_both.rs
@@ -26,7 +26,7 @@ impl<A, B> EitherOrBoth<A, B> {
     pub fn left(self) -> Option<A> {
         match self {
             Left(left) | Both(left, _) => Some(left),
-            _ => None
+            _ => None,
         }
     }
 
@@ -34,7 +34,7 @@ impl<A, B> EitherOrBoth<A, B> {
     pub fn right(self) -> Option<B> {
         match self {
             Right(right) | Both(_, right) => Some(right),
-            _ => None
+            _ => None,
         }
     }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use std::cell::RefCell;
+use std::fmt;
 
 /// Format all iterator elements lazily, separated by `sep`.
 ///
@@ -28,8 +28,9 @@ pub struct Format<'a, I> {
 }
 
 pub fn new_format<'a, I, F>(iter: I, separator: &'a str, f: F) -> FormatWith<'a, I, F>
-    where I: Iterator,
-          F: FnMut(I::Item, &mut FnMut(&fmt::Display) -> fmt::Result) -> fmt::Result
+where
+    I: Iterator,
+    F: FnMut(I::Item, &mut FnMut(&fmt::Display) -> fmt::Result) -> fmt::Result,
 {
     FormatWith {
         sep: separator,
@@ -38,7 +39,8 @@ pub fn new_format<'a, I, F>(iter: I, separator: &'a str, f: F) -> FormatWith<'a,
 }
 
 pub fn new_format_default<'a, I>(iter: I, separator: &'a str) -> Format<'a, I>
-    where I: Iterator,
+where
+    I: Iterator,
 {
     Format {
         sep: separator,
@@ -47,8 +49,9 @@ pub fn new_format_default<'a, I>(iter: I, separator: &'a str) -> Format<'a, I>
 }
 
 impl<'a, I, F> fmt::Display for FormatWith<'a, I, F>
-    where I: Iterator,
-          F: FnMut(I::Item, &mut FnMut(&fmt::Display) -> fmt::Result) -> fmt::Result
+where
+    I: Iterator,
+    F: FnMut(I::Item, &mut FnMut(&fmt::Display) -> fmt::Result) -> fmt::Result,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (mut iter, mut format) = match self.inner.borrow_mut().take() {
@@ -60,7 +63,6 @@ impl<'a, I, F> fmt::Display for FormatWith<'a, I, F>
             try!(format(fst, &mut |disp: &fmt::Display| disp.fmt(f)));
             for elt in iter {
                 if self.sep.len() > 0 {
-
                     try!(f.write_str(self.sep));
                 }
                 try!(format(elt, &mut |disp: &fmt::Display| disp.fmt(f)));
@@ -71,10 +73,12 @@ impl<'a, I, F> fmt::Display for FormatWith<'a, I, F>
 }
 
 impl<'a, I> Format<'a, I>
-    where I: Iterator,
+where
+    I: Iterator,
 {
     fn format<F>(&self, f: &mut fmt::Formatter, mut cb: F) -> fmt::Result
-        where F: FnMut(&I::Item, &mut fmt::Formatter) -> fmt::Result,
+    where
+        F: FnMut(&I::Item, &mut fmt::Formatter) -> fmt::Result,
     {
         let mut iter = match self.inner.borrow_mut().take() {
             Some(t) => t,
@@ -109,5 +113,5 @@ macro_rules! impl_format {
     }
 }
 
-impl_format!{Display Debug
-             UpperExp LowerExp UpperHex LowerHex Octal Binary Pointer}
+impl_format! {Display Debug
+UpperExp LowerExp UpperHex LowerHex Octal Binary Pointer}

--- a/src/free.rs
+++ b/src/free.rs
@@ -12,21 +12,17 @@ type VecIntoIter<T> = ::std::vec::IntoIter<T>;
 #[cfg(feature = "use_std")]
 use Itertools;
 
-pub use adaptors::{
-    interleave,
-    merge,
-    put_back,
-};
+pub use adaptors::{interleave, merge, put_back};
 #[cfg(feature = "use_std")]
-pub use put_back_n_impl::put_back_n;
+pub use kmerge_impl::kmerge;
+pub use merge_join::merge_join_by;
 #[cfg(feature = "use_std")]
 pub use multipeek_impl::multipeek;
 #[cfg(feature = "use_std")]
-pub use kmerge_impl::kmerge;
-pub use zip_eq_impl::zip_eq;
-pub use merge_join::merge_join_by;
+pub use put_back_n_impl::put_back_n;
 #[cfg(feature = "use_std")]
 pub use rciter_impl::rciter;
+pub use zip_eq_impl::zip_eq;
 
 /// Iterate `iterable` with a running index.
 ///
@@ -40,7 +36,8 @@ pub use rciter_impl::rciter;
 /// }
 /// ```
 pub fn enumerate<I>(iterable: I) -> iter::Enumerate<I::IntoIter>
-    where I: IntoIterator
+where
+    I: IntoIterator,
 {
     iterable.into_iter().enumerate()
 }
@@ -57,8 +54,9 @@ pub fn enumerate<I>(iterable: I) -> iter::Enumerate<I::IntoIter>
 /// }
 /// ```
 pub fn rev<I>(iterable: I) -> iter::Rev<I::IntoIter>
-    where I: IntoIterator,
-          I::IntoIter: DoubleEndedIterator
+where
+    I: IntoIterator,
+    I::IntoIter: DoubleEndedIterator,
 {
     iterable.into_iter().rev()
 }
@@ -76,8 +74,9 @@ pub fn rev<I>(iterable: I) -> iter::Rev<I::IntoIter>
 /// }
 /// ```
 pub fn zip<I, J>(i: I, j: J) -> Zip<I::IntoIter, J::IntoIter>
-    where I: IntoIterator,
-          J: IntoIterator
+where
+    I: IntoIterator,
+    J: IntoIterator,
 {
     i.into_iter().zip(j)
 }
@@ -93,9 +92,13 @@ pub fn zip<I, J>(i: I, j: J) -> Zip<I::IntoIter, J::IntoIter>
 ///     /* loop body */
 /// }
 /// ```
-pub fn chain<I, J>(i: I, j: J) -> iter::Chain<<I as IntoIterator>::IntoIter, <J as IntoIterator>::IntoIter>
-    where I: IntoIterator,
-          J: IntoIterator<Item = I::Item>
+pub fn chain<I, J>(
+    i: I,
+    j: J,
+) -> iter::Chain<<I as IntoIterator>::IntoIter, <J as IntoIterator>::IntoIter>
+where
+    I: IntoIterator,
+    J: IntoIterator<Item = I::Item>,
 {
     i.into_iter().chain(j)
 }
@@ -110,8 +113,9 @@ pub fn chain<I, J>(i: I, j: J) -> iter::Chain<<I as IntoIterator>::IntoIter, <J 
 /// assert_eq!(cloned(b"abc").next(), Some(b'a'));
 /// ```
 pub fn cloned<'a, I, T: 'a>(iterable: I) -> iter::Cloned<I::IntoIter>
-    where I: IntoIterator<Item=&'a T>,
-          T: Clone,
+where
+    I: IntoIterator<Item = &'a T>,
+    T: Clone,
 {
     iterable.into_iter().cloned()
 }
@@ -126,8 +130,9 @@ pub fn cloned<'a, I, T: 'a>(iterable: I) -> iter::Cloned<I::IntoIter>
 /// assert_eq!(fold(&[1., 2., 3.], 0., |a, &b| f32::max(a, b)), 3.);
 /// ```
 pub fn fold<I, B, F>(iterable: I, init: B, f: F) -> B
-    where I: IntoIterator,
-          F: FnMut(B, I::Item) -> B
+where
+    I: IntoIterator,
+    F: FnMut(B, I::Item) -> B,
 {
     iterable.into_iter().fold(init, f)
 }
@@ -142,8 +147,9 @@ pub fn fold<I, B, F>(iterable: I, init: B, f: F) -> B
 /// assert!(all(&[1, 2, 3], |elt| *elt > 0));
 /// ```
 pub fn all<I, F>(iterable: I, f: F) -> bool
-    where I: IntoIterator,
-          F: FnMut(I::Item) -> bool
+where
+    I: IntoIterator,
+    F: FnMut(I::Item) -> bool,
 {
     iterable.into_iter().all(f)
 }
@@ -158,8 +164,9 @@ pub fn all<I, F>(iterable: I, f: F) -> bool
 /// assert!(any(&[0, -1, 2], |elt| *elt > 0));
 /// ```
 pub fn any<I, F>(iterable: I, f: F) -> bool
-    where I: IntoIterator,
-          F: FnMut(I::Item) -> bool
+where
+    I: IntoIterator,
+    F: FnMut(I::Item) -> bool,
 {
     iterable.into_iter().any(f)
 }
@@ -174,8 +181,9 @@ pub fn any<I, F>(iterable: I, f: F) -> bool
 /// assert_eq!(max(0..10), Some(9));
 /// ```
 pub fn max<I>(iterable: I) -> Option<I::Item>
-    where I: IntoIterator,
-          I::Item: Ord
+where
+    I: IntoIterator,
+    I::Item: Ord,
 {
     iterable.into_iter().max()
 }
@@ -190,12 +198,12 @@ pub fn max<I>(iterable: I) -> Option<I::Item>
 /// assert_eq!(min(0..10), Some(0));
 /// ```
 pub fn min<I>(iterable: I) -> Option<I::Item>
-    where I: IntoIterator,
-          I::Item: Ord
+where
+    I: IntoIterator,
+    I::Item: Ord,
 {
     iterable.into_iter().min()
 }
-
 
 /// Combine all iterator elements into one String, seperated by `sep`.
 ///
@@ -208,8 +216,9 @@ pub fn min<I>(iterable: I) -> Option<I::Item>
 /// ```
 #[cfg(feature = "use_std")]
 pub fn join<I>(iterable: I, sep: &str) -> String
-    where I: IntoIterator,
-          I::Item: Display
+where
+    I: IntoIterator,
+    I::Item: Display,
 {
     iterable.into_iter().join(sep)
 }
@@ -228,9 +237,9 @@ pub fn join<I>(iterable: I, sep: &str) -> String
 /// ```
 #[cfg(feature = "use_std")]
 pub fn sorted<I>(iterable: I) -> VecIntoIter<I::Item>
-    where I: IntoIterator,
-          I::Item: Ord
+where
+    I: IntoIterator,
+    I::Item: Ord,
 {
     iterable.into_iter().sorted()
 }
-

--- a/src/group_map.rs
+++ b/src/group_map.rs
@@ -9,8 +9,9 @@ use std::iter::Iterator;
 /// See [`.into_group_map()`](../trait.Itertools.html#method.into_group_map)
 /// for more information.
 pub fn into_group_map<I, K, V>(iter: I) -> HashMap<K, Vec<V>>
-    where I: Iterator<Item=(K, V)>,
-          K: Hash + Eq,
+where
+    I: Iterator<Item = (K, V)>,
+    K: Hash + Eq,
 {
     let mut lookup = HashMap::new();
 

--- a/src/impl_macros.rs
+++ b/src/impl_macros.rs
@@ -1,4 +1,4 @@
-//! 
+//!
 //! Implementation's internal macros
 
 macro_rules! debug_fmt_fields {

--- a/src/intersperse.rs
+++ b/src/intersperse.rs
@@ -1,5 +1,5 @@
-use std::iter::Fuse;
 use super::size_hint;
+use std::iter::Fuse;
 
 #[derive(Clone)]
 /// An iterator adaptor to insert a particular value
@@ -13,7 +13,8 @@ use super::size_hint;
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug)]
 pub struct Intersperse<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     element: I::Item,
     iter: Fuse<I>,
@@ -22,7 +23,8 @@ pub struct Intersperse<I>
 
 /// Create a new Intersperse iterator
 pub fn intersperse<I>(iter: I, elt: I::Item) -> Intersperse<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     let mut iter = iter.fuse();
     Intersperse {
@@ -33,8 +35,9 @@ pub fn intersperse<I>(iter: I, elt: I::Item) -> Intersperse<I>
 }
 
 impl<I> Iterator for Intersperse<I>
-    where I: Iterator,
-          I::Item: Clone
+where
+    I: Iterator,
+    I::Item: Clone,
 {
     type Item = I::Item;
     #[inline]
@@ -58,22 +61,23 @@ impl<I> Iterator for Intersperse<I>
         size_hint::add_scalar(size_hint::add(sh, sh), has_peek)
     }
 
-    fn fold<B, F>(mut self, init: B, mut f: F) -> B where
-        Self: Sized, F: FnMut(B, Self::Item) -> B,
+    fn fold<B, F>(mut self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
     {
         let mut accum = init;
-        
+
         if let Some(x) = self.peek.take() {
             accum = f(accum, x);
         }
 
         let element = &self.element;
 
-        self.iter.fold(accum,
-            |accum, x| {
-                let accum = f(accum, element.clone());
-                let accum = f(accum, x);
-                accum
+        self.iter.fold(accum, |accum, x| {
+            let accum = f(accum, element.clone());
+            let accum = f(accum, x);
+            accum
         })
     }
 }

--- a/src/kmerge_impl.rs
+++ b/src/kmerge_impl.rs
@@ -1,9 +1,8 @@
-
 use size_hint;
 use Itertools;
 
-use std::mem::replace;
 use std::fmt;
+use std::mem::replace;
 
 macro_rules! clone_fields {
     ($name:ident, $base:expr, $($field:ident),+) => (
@@ -24,24 +23,21 @@ macro_rules! clone_fields {
 /// `KMerge` into a min-heap.
 #[derive(Debug)]
 struct HeadTail<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     head: I::Item,
     tail: I,
 }
 
 impl<I> HeadTail<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     /// Constructs a `HeadTail` from an `Iterator`. Returns `None` if the `Iterator` is empty.
     fn new(mut it: I) -> Option<HeadTail<I>> {
         let head = it.next();
-        head.map(|h| {
-            HeadTail {
-                head: h,
-                tail: it,
-            }
-        })
+        head.map(|h| HeadTail { head: h, tail: it })
     }
 
     /// Get the next element and update `head`, returning the old head in `Some`.
@@ -62,8 +58,9 @@ impl<I> HeadTail<I>
 }
 
 impl<I> Clone for HeadTail<I>
-    where I: Iterator + Clone,
-          I::Item: Clone
+where
+    I: Iterator + Clone,
+    I::Item: Clone,
 {
     fn clone(&self) -> Self {
         clone_fields!(HeadTail, self, head, tail)
@@ -72,7 +69,8 @@ impl<I> Clone for HeadTail<I>
 
 /// Make `data` a heap (min-heap w.r.t the sorting).
 fn heapify<T, S>(data: &mut [T], mut less_than: S)
-    where S: FnMut(&T, &T) -> bool
+where
+    S: FnMut(&T, &T) -> bool,
 {
     for i in (0..data.len() / 2).rev() {
         sift_down(data, i, &mut less_than);
@@ -81,7 +79,8 @@ fn heapify<T, S>(data: &mut [T], mut less_than: S)
 
 /// Sift down element at `index` (`heap` is a min-heap wrt the ordering)
 fn sift_down<T, S>(heap: &mut [T], index: usize, mut less_than: S)
-    where S: FnMut(&T, &T) -> bool
+where
+    S: FnMut(&T, &T) -> bool,
 {
     debug_assert!(index <= heap.len());
     let mut pos = index;
@@ -127,7 +126,7 @@ impl<T: PartialOrd> KMergePredicate<T> for KMergeByLt {
     }
 }
 
-impl<T, F: FnMut(&T, &T)->bool> KMergePredicate<T> for F {
+impl<T, F: FnMut(&T, &T) -> bool> KMergePredicate<T> for F {
     fn kmerge_pred(&mut self, a: &T, b: &T) -> bool {
         self(a, b)
     }
@@ -146,9 +145,10 @@ impl<T, F: FnMut(&T, &T)->bool> KMergePredicate<T> for F {
 /// }
 /// ```
 pub fn kmerge<I>(iterable: I) -> KMerge<<I::Item as IntoIterator>::IntoIter>
-    where I: IntoIterator,
-          I::Item: IntoIterator,
-          <<I as IntoIterator>::Item as IntoIterator>::Item: PartialOrd
+where
+    I: IntoIterator,
+    I::Item: IntoIterator,
+    <<I as IntoIterator>::Item as IntoIterator>::Item: PartialOrd,
 {
     kmerge_by(iterable, KMergeByLt)
 }
@@ -162,15 +162,17 @@ pub fn kmerge<I>(iterable: I) -> KMerge<<I::Item as IntoIterator>::IntoIter>
 /// information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct KMergeBy<I, F>
-    where I: Iterator,
+where
+    I: Iterator,
 {
     heap: Vec<HeadTail<I>>,
     less_than: F,
 }
 
 impl<I, F> fmt::Debug for KMergeBy<I, F>
-    where I: Iterator + fmt::Debug,
-          I::Item: fmt::Debug,
+where
+    I: Iterator + fmt::Debug,
+    I::Item: fmt::Debug,
 {
     debug_fmt_fields!(KMergeBy, heap);
 }
@@ -178,24 +180,31 @@ impl<I, F> fmt::Debug for KMergeBy<I, F>
 /// Create an iterator that merges elements of the contained iterators.
 ///
 /// Equivalent to `iterable.into_iter().kmerge_by(less_than)`.
-pub fn kmerge_by<I, F>(iterable: I, mut less_than: F)
-    -> KMergeBy<<I::Item as IntoIterator>::IntoIter, F>
-    where I: IntoIterator,
-          I::Item: IntoIterator,
-          F: KMergePredicate<<<I as IntoIterator>::Item as IntoIterator>::Item>,
+pub fn kmerge_by<I, F>(
+    iterable: I,
+    mut less_than: F,
+) -> KMergeBy<<I::Item as IntoIterator>::IntoIter, F>
+where
+    I: IntoIterator,
+    I::Item: IntoIterator,
+    F: KMergePredicate<<<I as IntoIterator>::Item as IntoIterator>::Item>,
 {
     let iter = iterable.into_iter();
     let (lower, _) = iter.size_hint();
     let mut heap: Vec<_> = Vec::with_capacity(lower);
     heap.extend(iter.filter_map(|it| HeadTail::new(it.into_iter())));
     heapify(&mut heap, |a, b| less_than.kmerge_pred(&a.head, &b.head));
-    KMergeBy { heap: heap, less_than: less_than }
+    KMergeBy {
+        heap: heap,
+        less_than: less_than,
+    }
 }
 
 impl<I, F> Clone for KMergeBy<I, F>
-    where I: Iterator + Clone,
-          I::Item: Clone,
-          F: Clone,
+where
+    I: Iterator + Clone,
+    I::Item: Clone,
+    F: Clone,
 {
     fn clone(&self) -> KMergeBy<I, F> {
         clone_fields!(KMergeBy, self, heap, less_than)
@@ -203,8 +212,9 @@ impl<I, F> Clone for KMergeBy<I, F>
 }
 
 impl<I, F> Iterator for KMergeBy<I, F>
-    where I: Iterator,
-          F: KMergePredicate<I::Item>
+where
+    I: Iterator,
+    F: KMergePredicate<I::Item>,
 {
     type Item = I::Item;
 
@@ -218,14 +228,17 @@ impl<I, F> Iterator for KMergeBy<I, F>
             self.heap.swap_remove(0).head
         };
         let less_than = &mut self.less_than;
-        sift_down(&mut self.heap, 0, |a, b| less_than.kmerge_pred(&a.head, &b.head));
+        sift_down(&mut self.heap, 0, |a, b| {
+            less_than.kmerge_pred(&a.head, &b.head)
+        });
         Some(result)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.heap.iter()
-                 .map(|i| i.size_hint())
-                 .fold1(size_hint::add)
-                 .unwrap_or((0, Some(0)))
+        self.heap
+            .iter()
+            .map(|i| i.size_hint())
+            .fold1(size_hint::add)
+            .unwrap_or((0, Some(0)))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![warn(missing_docs)]
-#![crate_name="itertools"]
+#![crate_name = "itertools"]
 #![cfg_attr(not(feature = "use_std"), no_std)]
 
 //! Extra iterator adaptors, functions and macros.
@@ -45,7 +45,7 @@
 //! This version of itertools requires Rust 1.24 or later.
 //!
 //! [`Iterator`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html
-#![doc(html_root_url="https://docs.rs/itertools/0.8/")]
+#![doc(html_root_url = "https://docs.rs/itertools/0.8/")]
 
 extern crate either;
 
@@ -54,15 +54,15 @@ extern crate core as std;
 
 pub use either::Either;
 
+use std::cmp::Ordering;
 #[cfg(feature = "use_std")]
 use std::collections::HashMap;
-use std::iter::{IntoIterator};
-use std::cmp::Ordering;
 use std::fmt;
 #[cfg(feature = "use_std")]
-use std::hash::Hash;
-#[cfg(feature = "use_std")]
 use std::fmt::Write;
+#[cfg(feature = "use_std")]
+use std::hash::Hash;
+use std::iter::IntoIterator;
 #[cfg(feature = "use_std")]
 type VecIntoIter<T> = ::std::vec::IntoIter<T>;
 #[cfg(feature = "use_std")]
@@ -77,29 +77,15 @@ pub use std::iter as __std_iter;
 
 /// The concrete iterator types.
 pub mod structs {
-    pub use adaptors::{
-        Dedup,
-        DedupBy,
-        Interleave,
-        InterleaveShortest,
-        Product,
-        PutBack,
-        Batching,
-        MapInto,
-        MapResults,
-        Merge,
-        MergeBy,
-        TakeWhileRef,
-        WhileSome,
-        Coalesce,
-        TupleCombinations,
-        Positions,
-        Update,
-    };
-    #[allow(deprecated)]
-    pub use adaptors::Step;
     #[cfg(feature = "use_std")]
     pub use adaptors::MultiProduct;
+    #[allow(deprecated)]
+    pub use adaptors::Step;
+    pub use adaptors::{
+        Batching, Coalesce, Dedup, DedupBy, Interleave, InterleaveShortest, MapInto, MapResults,
+        Merge, MergeBy, Positions, Product, PutBack, TakeWhileRef, TupleCombinations, Update,
+        WhileSome,
+    };
     #[cfg(feature = "use_std")]
     pub use combinations::Combinations;
     #[cfg(feature = "use_std")]
@@ -108,7 +94,7 @@ pub mod structs {
     pub use exactly_one_err::ExactlyOneError;
     pub use format::{Format, FormatWith};
     #[cfg(feature = "use_std")]
-    pub use groupbylazy::{IntoChunks, Chunk, Chunks, GroupBy, Group, Groups};
+    pub use groupbylazy::{Chunk, Chunks, Group, GroupBy, Groups, IntoChunks};
     pub use intersperse::Intersperse;
     #[cfg(feature = "use_std")]
     pub use kmerge_impl::{KMerge, KMergeBy};
@@ -124,7 +110,7 @@ pub mod structs {
     pub use rciter_impl::RcIter;
     pub use repeatn::RepeatN;
     #[allow(deprecated)]
-    pub use sources::{RepeatCall, Unfold, Iterate};
+    pub use sources::{Iterate, RepeatCall, Unfold};
     #[cfg(feature = "use_std")]
     pub use tee::Tee;
     pub use tuple_impl::{TupleBuffer, TupleWindows, Tuples};
@@ -135,20 +121,20 @@ pub mod structs {
     pub use zip_longest::ZipLongest;
     pub use ziptuple::Zip;
 }
-#[allow(deprecated)]
-pub use structs::*;
 pub use concat_impl::concat;
 pub use cons_tuples_impl::cons_tuples;
 pub use diff::diff_with;
 pub use diff::Diff;
 #[cfg(feature = "use_std")]
-pub use kmerge_impl::{kmerge_by};
+pub use kmerge_impl::kmerge_by;
 pub use minmax::MinMaxResult;
 pub use peeking_take_while::PeekingNext;
 pub use process_results_impl::process_results;
 pub use repeatn::repeat_n;
 #[allow(deprecated)]
-pub use sources::{repeat_call, unfold, iterate};
+pub use sources::{iterate, repeat_call, unfold};
+#[allow(deprecated)]
+pub use structs::*;
 pub use with_position::Position;
 pub use ziptuple::multizip;
 mod adaptors;
@@ -158,14 +144,14 @@ pub use either_or_both::EitherOrBoth;
 pub mod free;
 #[doc(inline)]
 pub use free::*;
-mod concat_impl;
-mod cons_tuples_impl;
 #[cfg(feature = "use_std")]
 mod combinations;
 #[cfg(feature = "use_std")]
 mod combinations_with_replacement;
-mod exactly_one_err;
+mod concat_impl;
+mod cons_tuples_impl;
 mod diff;
+mod exactly_one_err;
 mod format;
 #[cfg(feature = "use_std")]
 mod group_map;
@@ -337,7 +323,7 @@ macro_rules! izip {
 /// method in the list.
 ///
 /// [`Iterator`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html
-pub trait Itertools : Iterator {
+pub trait Itertools: Iterator {
     // adaptors
 
     /// Alternate elements from two iterators until both have run out.
@@ -353,8 +339,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![1, -1, 2, -2, 3, 4, 5, 6]);
     /// ```
     fn interleave<J>(self, other: J) -> Interleave<Self, J::IntoIter>
-        where J: IntoIterator<Item = Self::Item>,
-              Self: Sized
+    where
+        J: IntoIterator<Item = Self::Item>,
+        Self: Sized,
     {
         interleave(self, other)
     }
@@ -371,8 +358,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![1, -1, 2, -2, 3]);
     /// ```
     fn interleave_shortest<J>(self, other: J) -> InterleaveShortest<Self, J::IntoIter>
-        where J: IntoIterator<Item = Self::Item>,
-              Self: Sized
+    where
+        J: IntoIterator<Item = Self::Item>,
+        Self: Sized,
     {
         adaptors::interleave_shortest(self, other.into_iter())
     }
@@ -390,8 +378,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal((0..3).intersperse(8), vec![0, 8, 1, 8, 2]);
     /// ```
     fn intersperse(self, element: Self::Item) -> Intersperse<Self>
-        where Self: Sized,
-              Self::Item: Clone
+    where
+        Self: Sized,
+        Self::Item: Clone,
     {
         intersperse::intersperse(self, element)
     }
@@ -424,8 +413,9 @@ pub trait Itertools : Iterator {
     /// ```
     #[inline]
     fn zip_longest<J>(self, other: J) -> ZipLongest<Self, J::IntoIter>
-        where J: IntoIterator,
-              Self: Sized
+    where
+        J: IntoIterator,
+        Self: Sized,
     {
         zip_longest::zip_longest(self, other.into_iter())
     }
@@ -437,8 +427,9 @@ pub trait Itertools : Iterator {
     /// lengths.
     #[inline]
     fn zip_eq<J>(self, other: J) -> ZipEq<Self, J::IntoIter>
-        where J: IntoIterator,
-              Self: Sized
+    where
+        J: IntoIterator,
+        Self: Sized,
     {
         zip_eq(self, other)
     }
@@ -467,8 +458,9 @@ pub trait Itertools : Iterator {
     /// ```
     ///
     fn batching<B, F>(self, f: F) -> Batching<Self, F>
-        where F: FnMut(&mut Self) -> Option<B>,
-              Self: Sized
+    where
+        F: FnMut(&mut Self) -> Option<B>,
+        Self: Sized,
     {
         adaptors::batching(self, f)
     }
@@ -508,9 +500,10 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn group_by<K, F>(self, key: F) -> GroupBy<K, Self, F>
-        where Self: Sized,
-              F: FnMut(&Self::Item) -> K,
-              K: PartialEq,
+    where
+        Self: Sized,
+        F: FnMut(&Self::Item) -> K,
+        K: PartialEq,
     {
         groupbylazy::new(self, key)
     }
@@ -544,7 +537,8 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn chunks(self, size: usize) -> IntoChunks<Self>
-        where Self: Sized,
+    where
+        Self: Sized,
     {
         assert!(size != 0);
         groupbylazy::new_chunks(self, size)
@@ -582,9 +576,10 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![(1, 2, 3), (2, 3, 4)]);
     /// ```
     fn tuple_windows<T>(self) -> TupleWindows<Self, T>
-        where Self: Sized + Iterator<Item = T::Item>,
-              T: tuple_impl::TupleCollect,
-              T::Item: Clone
+    where
+        Self: Sized + Iterator<Item = T::Item>,
+        T: tuple_impl::TupleCollect,
+        T::Item: Clone,
     {
         tuple_impl::tuple_windows(self)
     }
@@ -621,8 +616,9 @@ pub trait Itertools : Iterator {
     ///
     /// See also [`Tuples::into_buffer`](structs/struct.Tuples.html#method.into_buffer).
     fn tuples<T>(self) -> Tuples<Self, T>
-        where Self: Sized + Iterator<Item = T::Item>,
-              T: tuple_impl::TupleCollect
+    where
+        Self: Sized + Iterator<Item = T::Item>,
+        T: tuple_impl::TupleCollect,
     {
         tuple_impl::tuples(self)
     }
@@ -646,8 +642,9 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn tee(self) -> (Tee<Self>, Tee<Self>)
-        where Self: Sized,
-              Self::Item: Clone
+    where
+        Self: Sized,
+        Self::Item: Clone,
     {
         tee::new(self)
     }
@@ -668,10 +665,11 @@ pub trait Itertools : Iterator {
     /// let it = (0..8).step(3);
     /// itertools::assert_equal(it, vec![0, 3, 6]);
     /// ```
-    #[deprecated(note="Use std .step_by() instead", since="0.8")]
+    #[deprecated(note = "Use std .step_by() instead", since = "0.8")]
     #[allow(deprecated)]
     fn step(self, n: usize) -> Step<Self>
-        where Self: Sized
+    where
+        Self: Sized,
     {
         adaptors::step(self, n)
     }
@@ -684,8 +682,9 @@ pub trait Itertools : Iterator {
     /// (1i32..42i32).map_into::<f64>().collect_vec();
     /// ```
     fn map_into<R>(self) -> MapInto<Self, R>
-        where Self: Sized,
-              Self::Item: Into<R>,
+    where
+        Self: Sized,
+        Self::Item: Into<R>,
     {
         adaptors::map_into(self)
     }
@@ -702,8 +701,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![Ok(42), Err(false), Ok(12)]);
     /// ```
     fn map_results<F, T, U, E>(self, f: F) -> MapResults<Self, F>
-        where Self: Iterator<Item = Result<T, E>> + Sized,
-              F: FnMut(T) -> U,
+    where
+        Self: Iterator<Item = Result<T, E>> + Sized,
+        F: FnMut(T) -> U,
     {
         adaptors::map_results(self, f)
     }
@@ -723,9 +723,10 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![0, 0, 3, 5, 6, 9, 10]);
     /// ```
     fn merge<J>(self, other: J) -> Merge<Self, J::IntoIter>
-        where Self: Sized,
-              Self::Item: PartialOrd,
-              J: IntoIterator<Item = Self::Item>
+    where
+        Self: Sized,
+        Self::Item: PartialOrd,
+        J: IntoIterator<Item = Self::Item>,
     {
         merge(self, other)
     }
@@ -747,9 +748,10 @@ pub trait Itertools : Iterator {
     /// ```
 
     fn merge_by<J, F>(self, other: J, is_first: F) -> MergeBy<Self, J::IntoIter, F>
-        where Self: Sized,
-              J: IntoIterator<Item = Self::Item>,
-              F: FnMut(&Self::Item, &Self::Item) -> bool
+    where
+        Self: Sized,
+        J: IntoIterator<Item = Self::Item>,
+        F: FnMut(&Self::Item, &Self::Item) -> bool,
     {
         adaptors::merge_by_new(self, other.into_iter(), is_first)
     }
@@ -787,13 +789,13 @@ pub trait Itertools : Iterator {
     /// ```
     #[inline]
     fn merge_join_by<J, F>(self, other: J, cmp_fn: F) -> MergeJoinBy<Self, J::IntoIter, F>
-        where J: IntoIterator,
-              F: FnMut(&Self::Item, &J::Item) -> std::cmp::Ordering,
-              Self: Sized
+    where
+        J: IntoIterator,
+        F: FnMut(&Self::Item, &J::Item) -> std::cmp::Ordering,
+        Self: Sized,
     {
         merge_join_by(self, other, cmp_fn)
     }
-
 
     /// Return an iterator adaptor that flattens an iterator of iterators by
     /// merging them in ascending order.
@@ -813,9 +815,10 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn kmerge(self) -> KMerge<<Self::Item as IntoIterator>::IntoIter>
-        where Self: Sized,
-              Self::Item: IntoIterator,
-              <Self::Item as IntoIterator>::Item: PartialOrd,
+    where
+        Self: Sized,
+        Self::Item: IntoIterator,
+        <Self::Item as IntoIterator>::Item: PartialOrd,
     {
         kmerge(self)
     }
@@ -841,12 +844,11 @@ pub trait Itertools : Iterator {
     /// assert_eq!(it.last(), Some(-7.));
     /// ```
     #[cfg(feature = "use_std")]
-    fn kmerge_by<F>(self, first: F)
-        -> KMergeBy<<Self::Item as IntoIterator>::IntoIter, F>
-        where Self: Sized,
-              Self::Item: IntoIterator,
-              F: FnMut(&<Self::Item as IntoIterator>::Item,
-                       &<Self::Item as IntoIterator>::Item) -> bool
+    fn kmerge_by<F>(self, first: F) -> KMergeBy<<Self::Item as IntoIterator>::IntoIter, F>
+    where
+        Self: Sized,
+        Self::Item: IntoIterator,
+        F: FnMut(&<Self::Item as IntoIterator>::Item, &<Self::Item as IntoIterator>::Item) -> bool,
     {
         kmerge_by(self, first)
     }
@@ -863,10 +865,11 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![(0, 'α'), (0, 'β'), (1, 'α'), (1, 'β')]);
     /// ```
     fn cartesian_product<J>(self, other: J) -> Product<Self, J::IntoIter>
-        where Self: Sized,
-              Self::Item: Clone,
-              J: IntoIterator,
-              J::IntoIter: Clone
+    where
+        Self: Sized,
+        Self::Item: Clone,
+        J: IntoIterator,
+        J::IntoIter: Clone,
     {
         adaptors::cartesian_product(self, other.into_iter())
     }
@@ -898,10 +901,11 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn multi_cartesian_product(self) -> MultiProduct<<Self::Item as IntoIterator>::IntoIter>
-        where Self: Iterator + Sized,
-              Self::Item: IntoIterator,
-              <Self::Item as IntoIterator>::IntoIter: Clone,
-              <Self::Item as IntoIterator>::Item: Clone
+    where
+        Self: Iterator + Sized,
+        Self::Item: IntoIterator,
+        <Self::Item as IntoIterator>::IntoIter: Clone,
+        <Self::Item as IntoIterator>::Item: Clone,
     {
         adaptors::multi_cartesian_product(self)
     }
@@ -935,9 +939,9 @@ pub trait Itertools : Iterator {
     ///         vec![-6., 4., -1.]);
     /// ```
     fn coalesce<F>(self, f: F) -> Coalesce<Self, F>
-        where Self: Sized,
-              F: FnMut(Self::Item, Self::Item)
-                       -> Result<Self::Item, (Self::Item, Self::Item)>
+    where
+        Self: Sized,
+        F: FnMut(Self::Item, Self::Item) -> Result<Self::Item, (Self::Item, Self::Item)>,
     {
         adaptors::coalesce(self, f)
     }
@@ -957,8 +961,9 @@ pub trait Itertools : Iterator {
     ///                         vec![1., 2., 3., 2.]);
     /// ```
     fn dedup(self) -> Dedup<Self>
-        where Self: Sized,
-              Self::Item: PartialEq,
+    where
+        Self: Sized,
+        Self::Item: PartialEq,
     {
         adaptors::dedup(self)
     }
@@ -979,8 +984,9 @@ pub trait Itertools : Iterator {
     ///                         vec![(0, 1.), (0, 2.), (0, 3.), (1, 2.)]);
     /// ```
     fn dedup_by<Cmp>(self, cmp: Cmp) -> DedupBy<Self, Cmp>
-        where Self: Sized,
-              Cmp: FnMut(&Self::Item, &Self::Item)->bool,
+    where
+        Self: Sized,
+        Cmp: FnMut(&Self::Item, &Self::Item) -> bool,
     {
         adaptors::dedup_by(self, cmp)
     }
@@ -1001,8 +1007,9 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn unique(self) -> Unique<Self>
-        where Self: Sized,
-              Self::Item: Clone + Eq + Hash
+    where
+        Self: Sized,
+        Self::Item: Clone + Eq + Hash,
     {
         unique_impl::unique(self)
     }
@@ -1023,9 +1030,10 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn unique_by<V, F>(self, f: F) -> UniqueBy<Self, V, F>
-        where Self: Sized,
-              V: Eq + Hash,
-              F: FnMut(&Self::Item) -> V
+    where
+        Self: Sized,
+        V: Eq + Hash,
+        F: FnMut(&Self::Item) -> V,
     {
         unique_impl::unique_by(self, f)
     }
@@ -1043,8 +1051,9 @@ pub trait Itertools : Iterator {
     /// See also [`.take_while_ref()`](#method.take_while_ref)
     /// which is a similar adaptor.
     fn peeking_take_while<F>(&mut self, accept: F) -> PeekingTakeWhile<Self, F>
-        where Self: Sized + PeekingNext,
-              F: FnMut(&Self::Item) -> bool,
+    where
+        Self: Sized + PeekingNext,
+        F: FnMut(&Self::Item) -> bool,
     {
         peeking_take_while::peeking_take_while(self, accept)
     }
@@ -1068,8 +1077,9 @@ pub trait Itertools : Iterator {
     ///
     /// ```
     fn take_while_ref<F>(&mut self, accept: F) -> TakeWhileRef<Self, F>
-        where Self: Clone,
-              F: FnMut(&Self::Item) -> bool
+    where
+        Self: Clone,
+        F: FnMut(&Self::Item) -> bool,
     {
         adaptors::take_while_ref(self, accept)
     }
@@ -1089,7 +1099,8 @@ pub trait Itertools : Iterator {
     ///
     /// ```
     fn while_some<A>(self) -> WhileSome<Self>
-        where Self: Sized + Iterator<Item = Option<A>>
+    where
+        Self: Sized + Iterator<Item = Option<A>>,
     {
         adaptors::while_some(self)
     }
@@ -1128,9 +1139,10 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![(1, 2, 3), (1, 2, 4), (1, 3, 4), (2, 3, 4)]);
     /// ```
     fn tuple_combinations<T>(self) -> TupleCombinations<Self, T>
-        where Self: Sized + Clone,
-              Self::Item: Clone,
-              T: adaptors::HasCombination<Self>,
+    where
+        Self: Sized + Clone,
+        Self::Item: Clone,
+        T: adaptors::HasCombination<Self>,
     {
         adaptors::tuple_combinations(self)
     }
@@ -1167,8 +1179,9 @@ pub trait Itertools : Iterator {
     ///
     #[cfg(feature = "use_std")]
     fn combinations(self, n: usize) -> Combinations<Self>
-        where Self: Sized,
-              Self::Item: Clone
+    where
+        Self: Sized,
+        Self::Item: Clone,
     {
         combinations::combinations(self, n)
     }
@@ -1219,8 +1232,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![18, 16, 14, 12, 10, 4, 3, 2, 1, 0]);
     /// ```
     fn pad_using<F>(self, min: usize, f: F) -> PadUsing<Self, F>
-        where Self: Sized,
-              F: FnMut(usize) -> Self::Item
+    where
+        Self: Sized,
+        F: FnMut(usize) -> Self::Item,
     {
         pad_tail::pad_using(self, min, f)
     }
@@ -1245,7 +1259,8 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![Position::Only(0)]);
     /// ```
     fn with_position(self) -> WithPosition<Self>
-        where Self: Sized,
+    where
+        Self: Sized,
     {
         with_position::with_position(self)
     }
@@ -1264,8 +1279,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(data.iter().positions(|v| v % 2 == 1).rev(), vec![7, 6, 3, 2, 0]);
     /// ```
     fn positions<P>(self, predicate: P) -> Positions<Self, P>
-        where Self: Sized,
-              P: FnMut(Self::Item) -> bool,
+    where
+        Self: Sized,
+        P: FnMut(Self::Item) -> bool,
     {
         adaptors::positions(self, predicate)
     }
@@ -1281,8 +1297,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![vec![1, 0], vec![3, 2, 1, 0]]);
     /// ```
     fn update<F>(self, updater: F) -> Update<Self, F>
-        where Self: Sized,
-              F: FnMut(&mut Self::Item),
+    where
+        Self: Sized,
+        F: FnMut(&mut Self::Item),
     {
         adaptors::update(self, updater)
     }
@@ -1302,8 +1319,9 @@ pub trait Itertools : Iterator {
     /// assert_eq!(Some((1, 2)), iter.next_tuple());
     /// ```
     fn next_tuple<T>(&mut self) -> Option<T>
-        where Self: Sized + Iterator<Item = T::Item>,
-              T: tuple_impl::TupleCollect
+    where
+        Self: Sized + Iterator<Item = T::Item>,
+        T: tuple_impl::TupleCollect,
     {
         T::collect_from_iter_no_buf(self)
     }
@@ -1327,18 +1345,18 @@ pub trait Itertools : Iterator {
     /// }
     /// ```
     fn collect_tuple<T>(mut self) -> Option<T>
-        where Self: Sized + Iterator<Item = T::Item>,
-              T: tuple_impl::TupleCollect
+    where
+        Self: Sized + Iterator<Item = T::Item>,
+        T: tuple_impl::TupleCollect,
     {
         match self.next_tuple() {
             elt @ Some(_) => match self.next() {
                 Some(_) => None,
                 None => elt,
             },
-            _ => None
+            _ => None,
         }
     }
-
 
     /// Find the position and value of the first element satisfying a predicate.
     ///
@@ -1351,7 +1369,8 @@ pub trait Itertools : Iterator {
     /// assert_eq!(text.chars().find_position(|ch| ch.is_lowercase()), Some((1, 'α')));
     /// ```
     fn find_position<P>(&mut self, mut pred: P) -> Option<(usize, Self::Item)>
-        where P: FnMut(&Self::Item) -> bool
+    where
+        P: FnMut(&Self::Item) -> bool,
     {
         let mut index = 0usize;
         for elt in self {
@@ -1380,8 +1399,9 @@ pub trait Itertools : Iterator {
     /// assert!(data.into_iter().all_equal());
     /// ```
     fn all_equal(&mut self) -> bool
-        where Self: Sized,
-              Self::Item: PartialEq,
+    where
+        Self: Sized,
+        Self::Item: PartialEq,
     {
         match self.next() {
             None => true,
@@ -1405,7 +1425,8 @@ pub trait Itertools : Iterator {
     /// *Fusing notes: if the iterator is exhausted by dropping,
     /// the result of calling `.next()` again depends on the iterator implementation.*
     fn dropping(mut self, n: usize) -> Self
-        where Self: Sized
+    where
+        Self: Sized,
     {
         if n > 0 {
             self.nth(n - 1);
@@ -1429,8 +1450,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(init, vec![0, 3, 6]);
     /// ```
     fn dropping_back(mut self, n: usize) -> Self
-        where Self: Sized,
-              Self: DoubleEndedIterator
+    where
+        Self: Sized,
+        Self: DoubleEndedIterator,
     {
         if n > 0 {
             (&mut self).rev().nth(n - 1);
@@ -1455,10 +1477,11 @@ pub trait Itertools : Iterator {
     ///
     /// itertools::assert_equal(rx.iter(), vec![1, 3, 5, 7, 9]);
     /// ```
-    #[deprecated(note="Use .for_each() instead", since="0.8")]
+    #[deprecated(note = "Use .for_each() instead", since = "0.8")]
     fn foreach<F>(self, f: F)
-        where F: FnMut(Self::Item),
-              Self: Sized,
+    where
+        F: FnMut(Self::Item),
+        Self: Sized,
     {
         self.for_each(f)
     }
@@ -1477,8 +1500,10 @@ pub trait Itertools : Iterator {
     ///            vec![1, 2, 3, 4, 5, 6]);
     /// ```
     fn concat(self) -> Self::Item
-        where Self: Sized,
-              Self::Item: Extend<<<Self as Iterator>::Item as IntoIterator>::Item> + IntoIterator + Default
+    where
+        Self: Sized,
+        Self::Item:
+            Extend<<<Self as Iterator>::Item as IntoIterator>::Item> + IntoIterator + Default,
     {
         concat(self)
     }
@@ -1487,7 +1512,8 @@ pub trait Itertools : Iterator {
     /// for convenience.
     #[cfg(feature = "use_std")]
     fn collect_vec(self) -> Vec<Self::Item>
-        where Self: Sized
+    where
+        Self: Sized,
     {
         self.collect()
     }
@@ -1509,8 +1535,9 @@ pub trait Itertools : Iterator {
     /// ```
     #[inline]
     fn set_from<'a, A: 'a, J>(&mut self, from: J) -> usize
-        where Self: Iterator<Item = &'a mut A>,
-              J: IntoIterator<Item = A>
+    where
+        Self: Iterator<Item = &'a mut A>,
+        J: IntoIterator<Item = A>,
     {
         let mut count = 0;
         for elt in from {
@@ -1535,7 +1562,8 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn join(&mut self, sep: &str) -> String
-        where Self::Item: std::fmt::Display
+    where
+        Self::Item: std::fmt::Display,
     {
         match self.next() {
             None => String::new(),
@@ -1569,7 +1597,8 @@ pub trait Itertools : Iterator {
     ///            "1.10, 2.72, -3.00");
     /// ```
     fn format(self, sep: &str) -> Format<Self>
-        where Self: Sized,
+    where
+        Self: Sized,
     {
         format::new_format_default(self, sep)
     }
@@ -1607,8 +1636,9 @@ pub trait Itertools : Iterator {
     ///
     /// ```
     fn format_with<F>(self, sep: &str, format: F) -> FormatWith<Self, F>
-        where Self: Sized,
-              F: FnMut(Self::Item, &mut FnMut(&fmt::Display) -> fmt::Result) -> fmt::Result,
+    where
+        Self: Sized,
+        F: FnMut(Self::Item, &mut FnMut(&fmt::Display) -> fmt::Result) -> fmt::Result,
     {
         format::new_format(self, sep, format)
     }
@@ -1656,8 +1686,9 @@ pub trait Itertools : Iterator {
     /// );
     /// ```
     fn fold_results<A, E, B, F>(&mut self, mut start: B, mut f: F) -> Result<B, E>
-        where Self: Iterator<Item = Result<A, E>>,
-              F: FnMut(B, A) -> B
+    where
+        Self: Iterator<Item = Result<A, E>>,
+        F: FnMut(B, A) -> B,
     {
         for elt in self {
             match elt {
@@ -1688,8 +1719,9 @@ pub trait Itertools : Iterator {
     /// assert_eq!(more_values.next().unwrap(), Some(0));
     /// ```
     fn fold_options<A, B, F>(&mut self, mut start: B, mut f: F) -> Option<B>
-        where Self: Iterator<Item = Option<A>>,
-              F: FnMut(B, A) -> B
+    where
+        Self: Iterator<Item = Option<A>>,
+        F: FnMut(B, A) -> B,
     {
         for elt in self {
             match elt {
@@ -1713,8 +1745,9 @@ pub trait Itertools : Iterator {
     /// assert_eq!((0..0).fold1(|x, y| x * y), None);
     /// ```
     fn fold1<F>(mut self, f: F) -> Option<Self::Item>
-        where F: FnMut(Self::Item, Self::Item) -> Self::Item,
-              Self: Sized,
+    where
+        F: FnMut(Self::Item, Self::Item) -> Self::Item,
+        Self: Sized,
     {
         self.next().map(move |x| self.fold(x, f))
     }
@@ -1768,44 +1801,48 @@ pub trait Itertools : Iterator {
     ///     (0..10).fold1(|x, y| x - y));
     /// ```
     fn tree_fold1<F>(mut self, mut f: F) -> Option<Self::Item>
-        where F: FnMut(Self::Item, Self::Item) -> Self::Item,
-              Self: Sized,
+    where
+        F: FnMut(Self::Item, Self::Item) -> Self::Item,
+        Self: Sized,
     {
         type State<T> = Result<T, Option<T>>;
 
         fn inner0<T, II, FF>(it: &mut II, f: &mut FF) -> State<T>
-            where
-                II: Iterator<Item = T>,
-                FF: FnMut(T, T) -> T
+        where
+            II: Iterator<Item = T>,
+            FF: FnMut(T, T) -> T,
         {
             // This function could be replaced with `it.next().ok_or(None)`,
             // but half the useful tree_fold1 work is combining adjacent items,
             // so put that in a form that LLVM is more likely to optimize well.
 
-            let a =
-                if let Some(v) = it.next() { v }
-                else { return Err(None) };
-            let b =
-                if let Some(v) = it.next() { v }
-                else { return Err(Some(a)) };
+            let a = if let Some(v) = it.next() {
+                v
+            } else {
+                return Err(None);
+            };
+            let b = if let Some(v) = it.next() {
+                v
+            } else {
+                return Err(Some(a));
+            };
             Ok(f(a, b))
         }
 
         fn inner<T, II, FF>(stop: usize, it: &mut II, f: &mut FF) -> State<T>
-            where
-                II: Iterator<Item = T>,
-                FF: FnMut(T, T) -> T
+        where
+            II: Iterator<Item = T>,
+            FF: FnMut(T, T) -> T,
         {
             let mut x = try!(inner0(it, f));
             for height in 0..stop {
                 // Try to get another tree the same size with which to combine it,
                 // creating a new tree that's twice as big for next time around.
-                let next =
-                    if height == 0 {
-                        inner0(it, f)
-                    } else {
-                        inner(height, it, f)
-                    };
+                let next = if height == 0 {
+                    inner0(it, f)
+                } else {
+                    inner(height, it, f)
+                };
                 match next {
                     Ok(y) => x = f(x, y),
 
@@ -1865,10 +1902,11 @@ pub trait Itertools : Iterator {
     /// The big difference between the computations of `result2` and `result3` is that while
     /// `fold()` called the provided closure for every item of the callee iterator,
     /// `fold_while()` actually stopped iterating as soon as it encountered `Fold::Done(_)`.
-    #[deprecated(note="Use .try_fold() instead", since="0.8")]
+    #[deprecated(note = "Use .try_fold() instead", since = "0.8")]
     fn fold_while<B, F>(&mut self, init: B, mut f: F) -> FoldWhile<B>
-        where Self: Sized,
-              F: FnMut(B, Self::Item) -> FoldWhile<B>
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> FoldWhile<B>,
     {
         let mut acc = init;
         while let Some(item) = self.next() {
@@ -1899,8 +1937,9 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn sorted(self) -> VecIntoIter<Self::Item>
-        where Self: Sized,
-              Self::Item: Ord
+    where
+        Self: Sized,
+        Self::Item: Ord,
     {
         // Use .sort() directly since it is not quite identical with
         // .sort_by(Ord::cmp)
@@ -1934,8 +1973,9 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn sorted_by<F>(self, cmp: F) -> VecIntoIter<Self::Item>
-        where Self: Sized,
-              F: FnMut(&Self::Item, &Self::Item) -> Ordering,
+    where
+        Self: Sized,
+        F: FnMut(&Self::Item, &Self::Item) -> Ordering,
     {
         let mut v = Vec::from_iter(self);
         v.sort_by(cmp);
@@ -1967,9 +2007,10 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn sorted_by_key<K, F>(self, f: F) -> VecIntoIter<Self::Item>
-        where Self: Sized,
-              K: Ord,
-              F: FnMut(&Self::Item) -> K,
+    where
+        Self: Sized,
+        K: Ord,
+        F: FnMut(&Self::Item) -> K,
     {
         let mut v = Vec::from_iter(self);
         v.sort_by_key(f);
@@ -1998,10 +2039,11 @@ pub trait Itertools : Iterator {
     /// assert_eq!(failures, [false, true]);
     /// ```
     fn partition_map<A, B, F, L, R>(self, mut predicate: F) -> (A, B)
-        where Self: Sized,
-              F: FnMut(Self::Item) -> Either<L, R>,
-              A: Default + Extend<L>,
-              B: Default + Extend<R>,
+    where
+        Self: Sized,
+        F: FnMut(Self::Item) -> Either<L, R>,
+        A: Default + Extend<L>,
+        B: Default + Extend<R>,
     {
         let mut left = A::default();
         let mut right = B::default();
@@ -2030,8 +2072,9 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn into_group_map<K, V>(self) -> HashMap<K, Vec<V>>
-        where Self: Iterator<Item=(K, V)> + Sized,
-              K: Hash + Eq,
+    where
+        Self: Iterator<Item = (K, V)> + Sized,
+        K: Hash + Eq,
     {
         group_map::into_group_map(self)
     }
@@ -2072,7 +2115,9 @@ pub trait Itertools : Iterator {
     /// The elements can be floats but no particular result is guaranteed
     /// if an element is NaN.
     fn minmax(self) -> MinMaxResult<Self::Item>
-        where Self: Sized, Self::Item: PartialOrd
+    where
+        Self: Sized,
+        Self::Item: PartialOrd,
     {
         minmax::minmax_impl(self, |_| (), |x, y, _, _| x < y)
     }
@@ -2089,7 +2134,10 @@ pub trait Itertools : Iterator {
     /// The keys can be floats but no particular result is guaranteed
     /// if a key is NaN.
     fn minmax_by_key<K, F>(self, key: F) -> MinMaxResult<Self::Item>
-        where Self: Sized, K: PartialOrd, F: FnMut(&Self::Item) -> K
+    where
+        Self: Sized,
+        K: PartialOrd,
+        F: FnMut(&Self::Item) -> K,
     {
         minmax::minmax_impl(self, key, |_, _, xk, yk| xk < yk)
     }
@@ -2103,13 +2151,11 @@ pub trait Itertools : Iterator {
     /// the last maximal element wins.  This matches the behavior of the standard
     /// `Iterator::min()` and `Iterator::max()` methods.
     fn minmax_by<F>(self, mut compare: F) -> MinMaxResult<Self::Item>
-        where Self: Sized, F: FnMut(&Self::Item, &Self::Item) -> Ordering
+    where
+        Self: Sized,
+        F: FnMut(&Self::Item, &Self::Item) -> Ordering,
     {
-        minmax::minmax_impl(
-            self,
-            |_| (),
-            |x, y, _, _| Ordering::Less == compare(x, y)
-        )
+        minmax::minmax_impl(self, |_| (), |x, y, _, _| Ordering::Less == compare(x, y))
     }
 
     /// If the iterator yields exactly one element, that element will be returned, otherwise
@@ -2134,22 +2180,16 @@ pub trait Itertools : Iterator {
         Self: Sized,
     {
         match self.next() {
-            Some(first) => {
-                match self.next() {
-                    Some(second) => {
-                        Err(ExactlyOneError::new((Some(first), Some(second)), self))
-                    }
-                    None => {
-                        Ok(first)
-                    }
-                }
-            }
+            Some(first) => match self.next() {
+                Some(second) => Err(ExactlyOneError::new((Some(first), Some(second)), self)),
+                None => Ok(first),
+            },
             None => Err(ExactlyOneError::new((None, None), self)),
         }
     }
 }
 
-impl<T: ?Sized> Itertools for T where T: Iterator { }
+impl<T: ?Sized> Itertools for T where T: Iterator {}
 
 /// Return `true` if both iterables produce equal sequences
 /// (elements pairwise equal and sequences of the same length),
@@ -2163,19 +2203,24 @@ impl<T: ?Sized> Itertools for T where T: Iterator { }
 /// assert!(!itertools::equal(&[0, 0], &[0, 0, 0]));
 /// ```
 pub fn equal<I, J>(a: I, b: J) -> bool
-    where I: IntoIterator,
-          J: IntoIterator,
-          I::Item: PartialEq<J::Item>
+where
+    I: IntoIterator,
+    J: IntoIterator,
+    I::Item: PartialEq<J::Item>,
 {
     let mut ia = a.into_iter();
     let mut ib = b.into_iter();
     loop {
         match ia.next() {
             Some(x) => match ib.next() {
-                Some(y) => if x != y { return false; },
+                Some(y) => {
+                    if x != y {
+                        return false;
+                    }
+                }
                 None => return false,
             },
-            None => return ib.next().is_none()
+            None => return ib.next().is_none(),
         }
     }
 }
@@ -2191,10 +2236,11 @@ pub fn equal<I, J>(a: I, b: J) -> bool
 /// // ^PANIC: panicked at 'Failed assertion Some("eed") == Some("ess") for iteration 1',
 /// ```
 pub fn assert_equal<I, J>(a: I, b: J)
-    where I: IntoIterator,
-          J: IntoIterator,
-          I::Item: fmt::Debug + PartialEq<J::Item>,
-          J::Item: fmt::Debug,
+where
+    I: IntoIterator,
+    J: IntoIterator,
+    I::Item: fmt::Debug + PartialEq<J::Item>,
+    J::Item: fmt::Debug,
 {
     let mut ia = a.into_iter();
     let mut ib = b.into_iter();
@@ -2207,8 +2253,13 @@ pub fn assert_equal<I, J>(a: I, b: J)
                     (&Some(ref a), &Some(ref b)) => a == b,
                     _ => false,
                 };
-                assert!(equal, "Failed assertion {a:?} == {b:?} for iteration {i}",
-                        i=i, a=a, b=b);
+                assert!(
+                    equal,
+                    "Failed assertion {a:?} == {b:?} for iteration {i}",
+                    i = i,
+                    a = a,
+                    b = b
+                );
                 i += 1;
             }
         }
@@ -2233,9 +2284,10 @@ pub fn assert_equal<I, J>(a: I, b: J)
 /// assert_eq!(split_index, 3);
 /// ```
 pub fn partition<'a, A: 'a, I, F>(iter: I, mut pred: F) -> usize
-    where I: IntoIterator<Item = &'a mut A>,
-          I::IntoIter: DoubleEndedIterator,
-          F: FnMut(&A) -> bool
+where
+    I: IntoIterator<Item = &'a mut A>,
+    I::IntoIter: DoubleEndedIterator,
+    F: FnMut(&A) -> bool,
 {
     let mut split_index = 0;
     let mut iter = iter.into_iter();
@@ -2243,10 +2295,12 @@ pub fn partition<'a, A: 'a, I, F>(iter: I, mut pred: F) -> usize
         if !pred(front) {
             loop {
                 match iter.next_back() {
-                    Some(back) => if pred(back) {
-                        std::mem::swap(front, back);
-                        break;
-                    },
+                    Some(back) => {
+                        if pred(back) {
+                            std::mem::swap(front, back);
+                            break;
+                        }
+                    }
                     None => break 'main,
                 }
             }

--- a/src/merge_join.rs
+++ b/src/merge_join.rs
@@ -1,23 +1,27 @@
 use std::cmp::Ordering;
-use std::iter::Fuse;
 use std::fmt;
+use std::iter::Fuse;
 
-use super::adaptors::{PutBack, put_back};
+use super::adaptors::{put_back, PutBack};
 use either_or_both::EitherOrBoth;
 
 /// Return an iterator adaptor that merge-joins items from the two base iterators in ascending order.
 ///
 /// See [`.merge_join_by()`](trait.Itertools.html#method.merge_join_by) for more information.
-pub fn merge_join_by<I, J, F>(left: I, right: J, cmp_fn: F)
-    -> MergeJoinBy<I::IntoIter, J::IntoIter, F>
-    where I: IntoIterator,
-          J: IntoIterator,
-          F: FnMut(&I::Item, &J::Item) -> Ordering
+pub fn merge_join_by<I, J, F>(
+    left: I,
+    right: J,
+    cmp_fn: F,
+) -> MergeJoinBy<I::IntoIter, J::IntoIter, F>
+where
+    I: IntoIterator,
+    J: IntoIterator,
+    F: FnMut(&I::Item, &J::Item) -> Ordering,
 {
     MergeJoinBy {
         left: put_back(left.into_iter().fuse()),
         right: put_back(right.into_iter().fuse()),
-        cmp_fn: cmp_fn
+        cmp_fn: cmp_fn,
     }
 }
 
@@ -28,46 +32,43 @@ pub fn merge_join_by<I, J, F>(left: I, right: J, cmp_fn: F)
 pub struct MergeJoinBy<I: Iterator, J: Iterator, F> {
     left: PutBack<Fuse<I>>,
     right: PutBack<Fuse<J>>,
-    cmp_fn: F
+    cmp_fn: F,
 }
 
 impl<I, J, F> fmt::Debug for MergeJoinBy<I, J, F>
-    where I: Iterator + fmt::Debug,
-          I::Item: fmt::Debug,
-          J: Iterator + fmt::Debug,
-          J::Item: fmt::Debug,
+where
+    I: Iterator + fmt::Debug,
+    I::Item: fmt::Debug,
+    J: Iterator + fmt::Debug,
+    J::Item: fmt::Debug,
 {
     debug_fmt_fields!(MergeJoinBy, left, right);
 }
 
 impl<I, J, F> Iterator for MergeJoinBy<I, J, F>
-    where I: Iterator,
-          J: Iterator,
-          F: FnMut(&I::Item, &J::Item) -> Ordering
+where
+    I: Iterator,
+    J: Iterator,
+    F: FnMut(&I::Item, &J::Item) -> Ordering,
 {
     type Item = EitherOrBoth<I::Item, J::Item>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match (self.left.next(), self.right.next()) {
             (None, None) => None,
-            (Some(left), None) =>
-                Some(EitherOrBoth::Left(left)),
-            (None, Some(right)) =>
-                Some(EitherOrBoth::Right(right)),
-            (Some(left), Some(right)) => {
-                match (self.cmp_fn)(&left, &right) {
-                    Ordering::Equal =>
-                        Some(EitherOrBoth::Both(left, right)),
-                    Ordering::Less => {
-                        self.right.put_back(right);
-                        Some(EitherOrBoth::Left(left))
-                    },
-                    Ordering::Greater => {
-                        self.left.put_back(left);
-                        Some(EitherOrBoth::Right(right))
-                    }
+            (Some(left), None) => Some(EitherOrBoth::Left(left)),
+            (None, Some(right)) => Some(EitherOrBoth::Right(right)),
+            (Some(left), Some(right)) => match (self.cmp_fn)(&left, &right) {
+                Ordering::Equal => Some(EitherOrBoth::Both(left, right)),
+                Ordering::Less => {
+                    self.right.put_back(right);
+                    Some(EitherOrBoth::Left(left))
                 }
-            }
+                Ordering::Greater => {
+                    self.left.put_back(left);
+                    Some(EitherOrBoth::Right(right))
+                }
+            },
         }
     }
 

--- a/src/minmax.rs
+++ b/src/minmax.rs
@@ -1,4 +1,3 @@
-
 /// `MinMaxResult` is an enum returned by `minmax`. See `Itertools::minmax()` for
 /// more detail.
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -11,7 +10,7 @@ pub enum MinMaxResult<T> {
 
     /// More than one element in the iterator, the first element is not larger
     /// than the second
-    MinMax(T, T)
+    MinMax(T, T),
 }
 
 impl<T: Clone> MinMaxResult<T> {
@@ -35,34 +34,36 @@ impl<T: Clone> MinMaxResult<T> {
     /// let r = MinMax(1, 2);
     /// assert_eq!(r.into_option(), Some((1, 2)));
     /// ```
-    pub fn into_option(self) -> Option<(T,T)> {
+    pub fn into_option(self) -> Option<(T, T)> {
         match self {
             MinMaxResult::NoElements => None,
             MinMaxResult::OneElement(x) => Some((x.clone(), x)),
-            MinMaxResult::MinMax(x, y) => Some((x, y))
+            MinMaxResult::MinMax(x, y) => Some((x, y)),
         }
     }
 }
 
 /// Implementation guts for `minmax` and `minmax_by_key`.
-pub fn minmax_impl<I, K, F, L>(mut it: I, mut key_for: F,
-                               mut lt: L) -> MinMaxResult<I::Item>
-    where I: Iterator,
-          F: FnMut(&I::Item) -> K,
-          L: FnMut(&I::Item, &I::Item, &K, &K) -> bool,
+pub fn minmax_impl<I, K, F, L>(mut it: I, mut key_for: F, mut lt: L) -> MinMaxResult<I::Item>
+where
+    I: Iterator,
+    F: FnMut(&I::Item) -> K,
+    L: FnMut(&I::Item, &I::Item, &K, &K) -> bool,
 {
     let (mut min, mut max, mut min_key, mut max_key) = match it.next() {
         None => return MinMaxResult::NoElements,
-        Some(x) => {
-            match it.next() {
-                None => return MinMaxResult::OneElement(x),
-                Some(y) => {
-                    let xk = key_for(&x);
-                    let yk = key_for(&y);
-                    if !lt(&y, &x, &yk, &xk) {(x, y, xk, yk)} else {(y, x, yk, xk)}
+        Some(x) => match it.next() {
+            None => return MinMaxResult::OneElement(x),
+            Some(y) => {
+                let xk = key_for(&x);
+                let yk = key_for(&y);
+                if !lt(&y, &x, &yk, &xk) {
+                    (x, y, xk, yk)
+                } else {
+                    (y, x, yk, xk)
                 }
             }
-        }
+        },
     };
 
     loop {
@@ -73,7 +74,7 @@ pub fn minmax_impl<I, K, F, L>(mut it: I, mut key_for: F,
         // for 2 elements.
         let first = match it.next() {
             None => break,
-            Some(x) => x
+            Some(x) => x,
         };
         let second = match it.next() {
             None => {
@@ -85,7 +86,7 @@ pub fn minmax_impl<I, K, F, L>(mut it: I, mut key_for: F,
                 }
                 break;
             }
-            Some(x) => x
+            Some(x) => x,
         };
         let first_key = key_for(&first);
         let second_key = key_for(&second);

--- a/src/multipeek_impl.rs
+++ b/src/multipeek_impl.rs
@@ -1,14 +1,13 @@
-
-
-use std::iter::Fuse;
-use std::collections::VecDeque;
 use size_hint;
+use std::collections::VecDeque;
+use std::iter::Fuse;
 use PeekingNext;
 
 /// See [`multipeek()`](../fn.multipeek.html) for more information.
 #[derive(Clone, Debug)]
 pub struct MultiPeek<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     iter: Fuse<I>,
     buf: VecDeque<I::Item>,
@@ -18,7 +17,8 @@ pub struct MultiPeek<I>
 /// An iterator adaptor that allows the user to peek at multiple `.next()`
 /// values without advancing the base iterator.
 pub fn multipeek<I>(iterable: I) -> MultiPeek<I::IntoIter>
-    where I: IntoIterator
+where
+    I: IntoIterator,
 {
     MultiPeek {
         iter: iterable.into_iter().fuse(),
@@ -28,7 +28,8 @@ pub fn multipeek<I>(iterable: I) -> MultiPeek<I::IntoIter>
 }
 
 impl<I> MultiPeek<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     /// Reset the peeking “cursor”
     pub fn reset_peek(&mut self) {
@@ -59,18 +60,24 @@ impl<I: Iterator> MultiPeek<I> {
 }
 
 impl<I> PeekingNext for MultiPeek<I>
-    where I: Iterator,
+where
+    I: Iterator,
 {
     fn peeking_next<F>(&mut self, accept: F) -> Option<Self::Item>
-        where F: FnOnce(&Self::Item) -> bool
+    where
+        F: FnOnce(&Self::Item) -> bool,
     {
         if self.buf.is_empty() {
             if let Some(r) = self.peek() {
-                if !accept(r) { return None }
+                if !accept(r) {
+                    return None;
+                }
             }
         } else {
             if let Some(r) = self.buf.get(0) {
-                if !accept(r) { return None }
+                if !accept(r) {
+                    return None;
+                }
             }
         }
         self.next()
@@ -78,7 +85,8 @@ impl<I> PeekingNext for MultiPeek<I>
 }
 
 impl<I> Iterator for MultiPeek<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     type Item = I::Item;
 
@@ -97,8 +105,4 @@ impl<I> Iterator for MultiPeek<I>
 }
 
 // Same size
-impl<I> ExactSizeIterator for MultiPeek<I>
-    where I: ExactSizeIterator
-{}
-
-
+impl<I> ExactSizeIterator for MultiPeek<I> where I: ExactSizeIterator {}

--- a/src/pad_tail.rs
+++ b/src/pad_tail.rs
@@ -1,5 +1,5 @@
-use std::iter::Fuse;
 use size_hint;
+use std::iter::Fuse;
 
 /// An iterator adaptor that pads a sequence to a minimum length by filling
 /// missing elements using a closure.
@@ -18,8 +18,9 @@ pub struct PadUsing<I, F> {
 
 /// Create a new **PadUsing** iterator.
 pub fn pad_using<I, F>(iter: I, min: usize, filler: F) -> PadUsing<I, F>
-    where I: Iterator,
-          F: FnMut(usize) -> I::Item
+where
+    I: Iterator,
+    F: FnMut(usize) -> I::Item,
 {
     PadUsing {
         iter: iter.fuse(),
@@ -30,8 +31,9 @@ pub fn pad_using<I, F>(iter: I, min: usize, filler: F) -> PadUsing<I, F>
 }
 
 impl<I, F> Iterator for PadUsing<I, F>
-    where I: Iterator,
-          F: FnMut(usize) -> I::Item
+where
+    I: Iterator,
+    F: FnMut(usize) -> I::Item,
 {
     type Item = I::Item;
 
@@ -46,7 +48,7 @@ impl<I, F> Iterator for PadUsing<I, F>
                 } else {
                     None
                 }
-            },
+            }
             e => {
                 self.pos += 1;
                 e
@@ -61,8 +63,9 @@ impl<I, F> Iterator for PadUsing<I, F>
 }
 
 impl<I, F> DoubleEndedIterator for PadUsing<I, F>
-    where I: DoubleEndedIterator + ExactSizeIterator,
-          F: FnMut(usize) -> I::Item
+where
+    I: DoubleEndedIterator + ExactSizeIterator,
+    F: FnMut(usize) -> I::Item,
 {
     fn next_back(&mut self) -> Option<I::Item> {
         if self.min == 0 {
@@ -78,6 +81,8 @@ impl<I, F> DoubleEndedIterator for PadUsing<I, F>
 }
 
 impl<I, F> ExactSizeIterator for PadUsing<I, F>
-    where I: ExactSizeIterator,
-          F: FnMut(usize) -> I::Item
-{}
+where
+    I: ExactSizeIterator,
+    F: FnMut(usize) -> I::Item,
+{
+}

--- a/src/peeking_take_while.rs
+++ b/src/peeking_take_while.rs
@@ -1,4 +1,3 @@
-
 use std::iter::Peekable;
 use PutBack;
 #[cfg(feature = "use_std")]
@@ -12,19 +11,22 @@ use PutBackN;
 /// This is implemented by peeking adaptors like peekable and put back,
 /// but also by a few iterators that can be peeked natively, like the slice’s
 /// by reference iterator (`std::slice::Iter`).
-pub trait PeekingNext : Iterator {
+pub trait PeekingNext: Iterator {
     /// Pass a reference to the next iterator element to the closure `accept`;
     /// if `accept` returns true, return it as the next element,
     /// else None.
     fn peeking_next<F>(&mut self, accept: F) -> Option<Self::Item>
-        where F: FnOnce(&Self::Item) -> bool;
+    where
+        F: FnOnce(&Self::Item) -> bool;
 }
 
 impl<I> PeekingNext for Peekable<I>
-    where I: Iterator,
+where
+    I: Iterator,
 {
     fn peeking_next<F>(&mut self, accept: F) -> Option<Self::Item>
-        where F: FnOnce(&Self::Item) -> bool
+    where
+        F: FnOnce(&Self::Item) -> bool,
     {
         if let Some(r) = self.peek() {
             if !accept(r) {
@@ -36,10 +38,12 @@ impl<I> PeekingNext for Peekable<I>
 }
 
 impl<I> PeekingNext for PutBack<I>
-    where I: Iterator,
+where
+    I: Iterator,
 {
     fn peeking_next<F>(&mut self, accept: F) -> Option<Self::Item>
-        where F: FnOnce(&Self::Item) -> bool
+    where
+        F: FnOnce(&Self::Item) -> bool,
     {
         if let Some(r) = self.next() {
             if !accept(&r) {
@@ -55,10 +59,12 @@ impl<I> PeekingNext for PutBack<I>
 
 #[cfg(feature = "use_std")]
 impl<I> PeekingNext for PutBackN<I>
-    where I: Iterator,
+where
+    I: Iterator,
 {
     fn peeking_next<F>(&mut self, accept: F) -> Option<Self::Item>
-        where F: FnOnce(&Self::Item) -> bool
+    where
+        F: FnOnce(&Self::Item) -> bool,
     {
         if let Some(r) = self.next() {
             if !accept(&r) {
@@ -78,7 +84,8 @@ impl<I> PeekingNext for PutBackN<I>
 /// for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct PeekingTakeWhile<'a, I: 'a, F>
-    where I: Iterator,
+where
+    I: Iterator,
 {
     iter: &'a mut I,
     f: F,
@@ -86,18 +93,16 @@ pub struct PeekingTakeWhile<'a, I: 'a, F>
 
 /// Create a PeekingTakeWhile
 pub fn peeking_take_while<I, F>(iter: &mut I, f: F) -> PeekingTakeWhile<I, F>
-    where I: Iterator,
+where
+    I: Iterator,
 {
-    PeekingTakeWhile {
-        iter: iter,
-        f: f,
-    }
+    PeekingTakeWhile { iter: iter, f: f }
 }
 
 impl<'a, I, F> Iterator for PeekingTakeWhile<'a, I, F>
-    where I: PeekingNext,
-          F: FnMut(&I::Item) -> bool,
-
+where
+    I: PeekingNext,
+    F: FnMut(&I::Item) -> bool,
 {
     type Item = I::Item;
     fn next(&mut self) -> Option<Self::Item> {
@@ -146,4 +151,4 @@ peeking_next_by_clone! { ['a, T] ::std::collections::vec_deque::Iter<'a, T> }
 
 // cloning a Rev has no extra overhead; peekable and put backs are never DEI.
 peeking_next_by_clone! { [I: Clone + PeekingNext + DoubleEndedIterator]
-                         ::std::iter::Rev<I> }
+::std::iter::Rev<I> }

--- a/src/process_results_impl.rs
+++ b/src/process_results_impl.rs
@@ -1,4 +1,3 @@
-
 /// An iterator that produces only the `T` values as long as the
 /// inner iterator produces `Ok(T)`.
 ///
@@ -12,7 +11,8 @@ pub struct ProcessResults<'a, I, E: 'a> {
 }
 
 impl<'a, I, T, E> Iterator for ProcessResults<'a, I, E>
-    where I: Iterator<Item = Result<T, E>>
+where
+    I: Iterator<Item = Result<T, E>>,
 {
     type Item = T;
 
@@ -69,13 +69,17 @@ impl<'a, I, T, E> Iterator for ProcessResults<'a, I, E>
 /// assert!(second_max.is_err());
 /// ```
 pub fn process_results<I, F, T, E, R>(iterable: I, processor: F) -> Result<R, E>
-    where I: IntoIterator<Item = Result<T, E>>,
-          F: FnOnce(ProcessResults<I::IntoIter, E>) -> R
+where
+    I: IntoIterator<Item = Result<T, E>>,
+    F: FnOnce(ProcessResults<I::IntoIter, E>) -> R,
 {
     let iter = iterable.into_iter();
     let mut error = Ok(());
 
-    let result = processor(ProcessResults { error: &mut error, iter: iter });
+    let result = processor(ProcessResults {
+        error: &mut error,
+        iter: iter,
+    });
 
     error.map(|_| result)
 }

--- a/src/put_back_n_impl.rs
+++ b/src/put_back_n_impl.rs
@@ -15,7 +15,8 @@ pub struct PutBackN<I: Iterator> {
 ///
 /// Iterator element type is `I::Item`.
 pub fn put_back_n<I>(iterable: I) -> PutBackN<I::IntoIter>
-    where I: IntoIterator
+where
+    I: IntoIterator,
 {
     PutBackN {
         top: Vec::new(),
@@ -60,4 +61,3 @@ impl<I: Iterator> Iterator for PutBackN<I> {
         size_hint::add_scalar(self.iter.size_hint(), self.top.len())
     }
 }
-

--- a/src/rciter_impl.rs
+++ b/src/rciter_impl.rs
@@ -1,7 +1,6 @@
-
+use std::cell::RefCell;
 use std::iter::IntoIterator;
 use std::rc::Rc;
-use std::cell::RefCell;
 
 /// A wrapper for `Rc<RefCell<I>>`, that implements the `Iterator` trait.
 #[derive(Debug)]
@@ -45,20 +44,26 @@ pub struct RcIter<I> {
 /// `.next()`, i.e. if it somehow participates in an “iterator knot”
 /// where it is an adaptor of itself.
 pub fn rciter<I>(iterable: I) -> RcIter<I::IntoIter>
-    where I: IntoIterator
+where
+    I: IntoIterator,
 {
-    RcIter { rciter: Rc::new(RefCell::new(iterable.into_iter())) }
+    RcIter {
+        rciter: Rc::new(RefCell::new(iterable.into_iter())),
+    }
 }
 
 impl<I> Clone for RcIter<I> {
     #[inline]
     fn clone(&self) -> RcIter<I> {
-        RcIter { rciter: self.rciter.clone() }
+        RcIter {
+            rciter: self.rciter.clone(),
+        }
     }
 }
 
 impl<A, I> Iterator for RcIter<I>
-    where I: Iterator<Item = A>
+where
+    I: Iterator<Item = A>,
 {
     type Item = A;
     #[inline]
@@ -77,7 +82,8 @@ impl<A, I> Iterator for RcIter<I>
 }
 
 impl<I> DoubleEndedIterator for RcIter<I>
-    where I: DoubleEndedIterator
+where
+    I: DoubleEndedIterator,
 {
     #[inline]
     fn next_back(&mut self) -> Option<I::Item> {
@@ -87,7 +93,8 @@ impl<I> DoubleEndedIterator for RcIter<I>
 
 /// Return an iterator from `&RcIter<I>` (by simply cloning it).
 impl<'a, I> IntoIterator for &'a RcIter<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     type Item = I::Item;
     type IntoIter = RcIter<I>;

--- a/src/repeatn.rs
+++ b/src/repeatn.rs
@@ -1,4 +1,3 @@
-
 /// An iterator that produces *n* repetitions of an element.
 ///
 /// See [`repeat_n()`](../fn.repeat_n.html) for more information.
@@ -11,17 +10,22 @@ pub struct RepeatN<A> {
 
 /// Create an iterator that produces `n` repetitions of `element`.
 pub fn repeat_n<A>(element: A, n: usize) -> RepeatN<A>
-    where A: Clone,
+where
+    A: Clone,
 {
     if n == 0 {
-        RepeatN { elt: None, n: n, }
+        RepeatN { elt: None, n: n }
     } else {
-        RepeatN { elt: Some(element), n: n, }
+        RepeatN {
+            elt: Some(element),
+            n: n,
+        }
     }
 }
 
 impl<A> Iterator for RepeatN<A>
-    where A: Clone
+where
+    A: Clone,
 {
     type Item = A;
 
@@ -41,7 +45,8 @@ impl<A> Iterator for RepeatN<A>
 }
 
 impl<A> DoubleEndedIterator for RepeatN<A>
-    where A: Clone
+where
+    A: Clone,
 {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
@@ -49,6 +54,4 @@ impl<A> DoubleEndedIterator for RepeatN<A>
     }
 }
 
-impl<A> ExactSizeIterator for RepeatN<A>
-    where A: Clone
-{}
+impl<A> ExactSizeIterator for RepeatN<A> where A: Clone {}

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -1,8 +1,8 @@
 //! Arithmetic on **Iterator** *.size_hint()* values.
 //!
 
-use std::usize;
 use std::cmp;
+use std::usize;
 
 /// **SizeHint** is the return type of **Iterator::size_hint()**.
 pub type SizeHint = (usize, Option<usize>);
@@ -37,7 +37,6 @@ pub fn sub_scalar(sh: SizeHint, x: usize) -> SizeHint {
     hi = hi.map(|elt| elt.saturating_sub(x));
     (low, hi)
 }
-
 
 /// Multiply **SizeHint** correctly
 ///

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -6,14 +6,13 @@ use std::fmt;
 use std::mem;
 
 /// See [`repeat_call`](../fn.repeat_call.html) for more information.
-#[deprecated(note="Use std repeat_with() instead", since="0.8")]
+#[deprecated(note = "Use std repeat_with() instead", since = "0.8")]
 pub struct RepeatCall<F> {
     f: F,
 }
 
-impl<F> fmt::Debug for RepeatCall<F>
-{
-    debug_fmt_fields!(RepeatCall, );
+impl<F> fmt::Debug for RepeatCall<F> {
+    debug_fmt_fields!(RepeatCall,);
 }
 
 /// An iterator source that produces elements indefinitely by calling
@@ -38,15 +37,17 @@ impl<F> fmt::Debug for RepeatCall<F>
 ///     vec![1, 1, 1, 1, 1]
 /// );
 /// ```
-#[deprecated(note="Use std repeat_with() instead", since="0.8")]
+#[deprecated(note = "Use std repeat_with() instead", since = "0.8")]
 pub fn repeat_call<F, A>(function: F) -> RepeatCall<F>
-    where F: FnMut() -> A
+where
+    F: FnMut() -> A,
 {
     RepeatCall { f: function }
 }
 
 impl<A, F> Iterator for RepeatCall<F>
-    where F: FnMut() -> A
+where
+    F: FnMut() -> A,
 {
     type Item = A;
 
@@ -98,7 +99,8 @@ impl<A, F> Iterator for RepeatCall<F>
 /// assert_eq!(fibonacci.last(), Some(2_971_215_073))
 /// ```
 pub fn unfold<A, St, F>(initial_state: St, f: F) -> Unfold<St, F>
-    where F: FnMut(&mut St) -> Option<A>
+where
+    F: FnMut(&mut St) -> Option<A>,
 {
     Unfold {
         f: f,
@@ -107,7 +109,8 @@ pub fn unfold<A, St, F>(initial_state: St, f: F) -> Unfold<St, F>
 }
 
 impl<St, F> fmt::Debug for Unfold<St, F>
-    where St: fmt::Debug,
+where
+    St: fmt::Debug,
 {
     debug_fmt_fields!(Unfold, state);
 }
@@ -122,7 +125,8 @@ pub struct Unfold<St, F> {
 }
 
 impl<A, St, F> Iterator for Unfold<St, F>
-    where F: FnMut(&mut St) -> Option<A>
+where
+    F: FnMut(&mut St) -> Option<A>,
 {
     type Item = A;
 
@@ -151,13 +155,15 @@ pub struct Iterate<St, F> {
 }
 
 impl<St, F> fmt::Debug for Iterate<St, F>
-    where St: fmt::Debug,
+where
+    St: fmt::Debug,
 {
     debug_fmt_fields!(Iterate, state);
 }
 
 impl<St, F> Iterator for Iterate<St, F>
-    where F: FnMut(&St) -> St
+where
+    F: FnMut(&St) -> St,
 {
     type Item = St;
 
@@ -181,7 +187,8 @@ impl<St, F> Iterator for Iterate<St, F>
 /// itertools::assert_equal(iterate(1, |&i| i * 3).take(5), vec![1, 3, 9, 27, 81]);
 /// ```
 pub fn iterate<St, F>(initial_value: St, f: F) -> Iterate<St, F>
-    where F: FnMut(&St) -> St
+where
+    F: FnMut(&St) -> St,
 {
     Iterate {
         state: initial_value,

--- a/src/tee.rs
+++ b/src/tee.rs
@@ -19,24 +19,37 @@ struct TeeBuffer<A, I> {
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug)]
 pub struct Tee<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     rcbuffer: Rc<RefCell<TeeBuffer<I::Item, I>>>,
     id: bool,
 }
 
 pub fn new<I>(iter: I) -> (Tee<I>, Tee<I>)
-    where I: Iterator
+where
+    I: Iterator,
 {
-    let buffer = TeeBuffer{backlog: VecDeque::new(), iter: iter, owner: false};
-    let t1 = Tee{rcbuffer: Rc::new(RefCell::new(buffer)), id: true};
-    let t2 = Tee{rcbuffer: t1.rcbuffer.clone(), id: false};
+    let buffer = TeeBuffer {
+        backlog: VecDeque::new(),
+        iter: iter,
+        owner: false,
+    };
+    let t1 = Tee {
+        rcbuffer: Rc::new(RefCell::new(buffer)),
+        id: true,
+    };
+    let t2 = Tee {
+        rcbuffer: t1.rcbuffer.clone(),
+        id: false,
+    };
     (t1, t2)
 }
 
 impl<I> Iterator for Tee<I>
-    where I: Iterator,
-          I::Item: Clone
+where
+    I: Iterator,
+    I::Item: Clone,
 {
     type Item = I::Item;
     fn next(&mut self) -> Option<I::Item> {
@@ -73,6 +86,8 @@ impl<I> Iterator for Tee<I>
 }
 
 impl<I> ExactSizeIterator for Tee<I>
-    where I: ExactSizeIterator,
-          I::Item: Clone
-{}
+where
+    I: ExactSizeIterator,
+    I::Item: Clone,
+{
+}

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -8,25 +8,25 @@ use std::iter::Fuse;
 /// [`Tuples::into_buffer()`](struct.Tuples.html#method.into_buffer).
 #[derive(Debug)]
 pub struct TupleBuffer<T>
-    where T: TupleCollect
+where
+    T: TupleCollect,
 {
     cur: usize,
     buf: T::Buffer,
 }
 
 impl<T> TupleBuffer<T>
-    where T: TupleCollect
+where
+    T: TupleCollect,
 {
     fn new(buf: T::Buffer) -> Self {
-        TupleBuffer {
-            cur: 0,
-            buf: buf,
-        }
+        TupleBuffer { cur: 0, buf: buf }
     }
 }
 
 impl<T> Iterator for TupleBuffer<T>
-    where T: TupleCollect
+where
+    T: TupleCollect,
 {
     type Item = T::Item;
 
@@ -45,26 +45,25 @@ impl<T> Iterator for TupleBuffer<T>
         let len = if buffer.len() == 0 {
             0
         } else {
-            buffer.iter()
-                  .position(|x| x.is_none())
-                  .unwrap_or(buffer.len())
+            buffer
+                .iter()
+                .position(|x| x.is_none())
+                .unwrap_or(buffer.len())
         };
         (len, Some(len))
     }
 }
 
-impl<T> ExactSizeIterator for TupleBuffer<T>
-    where T: TupleCollect
-{
-}
+impl<T> ExactSizeIterator for TupleBuffer<T> where T: TupleCollect {}
 
 /// An iterator that groups the items in tuples of a specific size.
 ///
 /// See [`.tuples()`](../trait.Itertools.html#method.tuples) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Tuples<I, T>
-    where I: Iterator<Item = T::Item>,
-          T: TupleCollect
+where
+    I: Iterator<Item = T::Item>,
+    T: TupleCollect,
 {
     iter: Fuse<I>,
     buf: T::Buffer,
@@ -72,8 +71,9 @@ pub struct Tuples<I, T>
 
 /// Create a new tuples iterator.
 pub fn tuples<I, T>(iter: I) -> Tuples<I, T>
-    where I: Iterator<Item = T::Item>,
-          T: TupleCollect
+where
+    I: Iterator<Item = T::Item>,
+    T: TupleCollect,
 {
     Tuples {
         iter: iter.fuse(),
@@ -82,8 +82,9 @@ pub fn tuples<I, T>(iter: I) -> Tuples<I, T>
 }
 
 impl<I, T> Iterator for Tuples<I, T>
-    where I: Iterator<Item = T::Item>,
-          T: TupleCollect
+where
+    I: Iterator<Item = T::Item>,
+    T: TupleCollect,
 {
     type Item = T;
 
@@ -93,8 +94,9 @@ impl<I, T> Iterator for Tuples<I, T>
 }
 
 impl<I, T> Tuples<I, T>
-    where I: Iterator<Item = T::Item>,
-          T: TupleCollect
+where
+    I: Iterator<Item = T::Item>,
+    T: TupleCollect,
 {
     /// Return a buffer with the produced items that was not enough to be grouped in a tuple.
     ///
@@ -111,7 +113,6 @@ impl<I, T> Tuples<I, T>
     }
 }
 
-
 /// An iterator over all contiguous windows that produces tuples of a specific size.
 ///
 /// See [`.tuple_windows()`](../trait.Itertools.html#method.tuple_windows) for more
@@ -119,8 +120,9 @@ impl<I, T> Tuples<I, T>
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug)]
 pub struct TupleWindows<I, T>
-    where I: Iterator<Item = T::Item>,
-          T: TupleCollect
+where
+    I: Iterator<Item = T::Item>,
+    T: TupleCollect,
 {
     iter: I,
     last: Option<T>,
@@ -128,9 +130,10 @@ pub struct TupleWindows<I, T>
 
 /// Create a new tuple windows iterator.
 pub fn tuple_windows<I, T>(mut iter: I) -> TupleWindows<I, T>
-    where I: Iterator<Item = T::Item>,
-          T: TupleCollect,
-          T::Item: Clone
+where
+    I: Iterator<Item = T::Item>,
+    T: TupleCollect,
+    T::Item: Clone,
 {
     use std::iter::once;
 
@@ -151,15 +154,16 @@ pub fn tuple_windows<I, T>(mut iter: I) -> TupleWindows<I, T>
 }
 
 impl<I, T> Iterator for TupleWindows<I, T>
-    where I: Iterator<Item = T::Item>,
-          T: TupleCollect + Clone,
-          T::Item: Clone
+where
+    I: Iterator<Item = T::Item>,
+    T: TupleCollect + Clone,
+    T::Item: Clone,
 {
     type Item = T;
 
     fn next(&mut self) -> Option<T> {
         if T::num_items() == 1 {
-            return T::collect_from_iter_no_buf(&mut self.iter)
+            return T::collect_from_iter_no_buf(&mut self.iter);
         }
         if let Some(ref mut last) = self.last {
             if let Some(new) = self.iter.next() {
@@ -176,10 +180,12 @@ pub trait TupleCollect: Sized {
     type Buffer: Default + AsRef<[Option<Self::Item>]> + AsMut<[Option<Self::Item>]>;
 
     fn collect_from_iter<I>(iter: I, buf: &mut Self::Buffer) -> Option<Self>
-        where I: IntoIterator<Item = Self::Item>;
+    where
+        I: IntoIterator<Item = Self::Item>;
 
     fn collect_from_iter_no_buf<I>(iter: I) -> Option<Self>
-        where I: IntoIterator<Item = Self::Item>;
+    where
+        I: IntoIterator<Item = Self::Item>;
 
     fn num_items() -> usize;
 

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -1,8 +1,7 @@
-
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::collections::hash_map::{Entry};
-use std::hash::Hash;
 use std::fmt;
+use std::hash::Hash;
 
 /// An iterator adapter to filter out duplicate elements.
 ///
@@ -17,17 +16,19 @@ pub struct UniqueBy<I: Iterator, V, F> {
 }
 
 impl<I, V, F> fmt::Debug for UniqueBy<I, V, F>
-    where I: Iterator + fmt::Debug,
-          V: fmt::Debug + Hash + Eq,
+where
+    I: Iterator + fmt::Debug,
+    V: fmt::Debug + Hash + Eq,
 {
     debug_fmt_fields!(UniqueBy, iter, used);
 }
 
 /// Create a new `UniqueBy` iterator.
 pub fn unique_by<I, V, F>(iter: I, f: F) -> UniqueBy<I, V, F>
-    where V: Eq + Hash,
-          F: FnMut(&I::Item) -> V,
-          I: Iterator,
+where
+    V: Eq + Hash,
+    F: FnMut(&I::Item) -> V,
+    I: Iterator,
 {
     UniqueBy {
         iter: iter,
@@ -38,8 +39,9 @@ pub fn unique_by<I, V, F>(iter: I, f: F) -> UniqueBy<I, V, F>
 
 // count the number of new unique keys in iterable (`used` is the set already seen)
 fn count_new_keys<I, K>(mut used: HashMap<K, ()>, iterable: I) -> usize
-    where I: IntoIterator<Item=K>,
-          K: Hash + Eq,
+where
+    I: IntoIterator<Item = K>,
+    K: Hash + Eq,
 {
     let iter = iterable.into_iter();
     let current_used = used.len();
@@ -48,9 +50,10 @@ fn count_new_keys<I, K>(mut used: HashMap<K, ()>, iterable: I) -> usize
 }
 
 impl<I, V, F> Iterator for UniqueBy<I, V, F>
-    where I: Iterator,
-          V: Eq + Hash,
-          F: FnMut(&I::Item) -> V
+where
+    I: Iterator,
+    V: Eq + Hash,
+    F: FnMut(&I::Item) -> V,
 {
     type Item = I::Item;
 
@@ -77,8 +80,9 @@ impl<I, V, F> Iterator for UniqueBy<I, V, F>
 }
 
 impl<I> Iterator for Unique<I>
-    where I: Iterator,
-          I::Item: Eq + Hash + Clone
+where
+    I: Iterator,
+    I::Item: Eq + Hash + Clone,
 {
     type Item = I::Item;
 
@@ -114,21 +118,23 @@ pub struct Unique<I: Iterator> {
 }
 
 impl<I> fmt::Debug for Unique<I>
-    where I: Iterator + fmt::Debug,
-          I::Item: Hash + Eq + fmt::Debug,
+where
+    I: Iterator + fmt::Debug,
+    I::Item: Hash + Eq + fmt::Debug,
 {
     debug_fmt_fields!(Unique, iter);
 }
 
 pub fn unique<I>(iter: I) -> Unique<I>
-    where I: Iterator,
-          I::Item: Eq + Hash,
+where
+    I: Iterator,
+    I::Item: Eq + Hash,
 {
     Unique {
         iter: UniqueBy {
             iter: iter,
             used: HashMap::new(),
             f: (),
-        }
+        },
     }
 }

--- a/src/with_position.rs
+++ b/src/with_position.rs
@@ -1,4 +1,4 @@
-use std::iter::{Fuse,Peekable};
+use std::iter::{Fuse, Peekable};
 
 /// An iterator adaptor that wraps each element in an [`Position`](../enum.Position.html).
 ///
@@ -7,7 +7,8 @@ use std::iter::{Fuse,Peekable};
 /// See [`.with_position()`](../trait.Itertools.html#method.with_position) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct WithPosition<I>
-    where I: Iterator,
+where
+    I: Iterator,
 {
     handled_first: bool,
     peekable: Peekable<Fuse<I>>,
@@ -15,7 +16,8 @@ pub struct WithPosition<I>
 
 /// Create a new `WithPosition` iterator.
 pub fn with_position<I>(iter: I) -> WithPosition<I>
-    where I: Iterator,
+where
+    I: Iterator,
 {
     WithPosition {
         handled_first: false,
@@ -43,10 +45,7 @@ impl<T> Position<T> {
     /// Return the inner value.
     pub fn into_inner(self) -> T {
         match self {
-            Position::First(x) |
-            Position::Middle(x) |
-            Position::Last(x) |
-            Position::Only(x) => x,
+            Position::First(x) | Position::Middle(x) | Position::Last(x) | Position::Only(x) => x,
         }
     }
 }
@@ -85,6 +84,4 @@ impl<I: Iterator> Iterator for WithPosition<I> {
     }
 }
 
-impl<I> ExactSizeIterator for WithPosition<I>
-    where I: ExactSizeIterator,
-{ }
+impl<I> ExactSizeIterator for WithPosition<I> where I: ExactSizeIterator {}

--- a/src/zip_eq_impl.rs
+++ b/src/zip_eq_impl.rs
@@ -25,8 +25,9 @@ pub struct ZipEq<I, J> {
 /// }
 /// ```
 pub fn zip_eq<I, J>(i: I, j: J) -> ZipEq<I::IntoIter, J::IntoIter>
-    where I: IntoIterator,
-          J: IntoIterator
+where
+    I: IntoIterator,
+    J: IntoIterator,
 {
     ZipEq {
         a: i.into_iter(),
@@ -35,8 +36,9 @@ pub fn zip_eq<I, J>(i: I, j: J) -> ZipEq<I::IntoIter, J::IntoIter>
 }
 
 impl<I, J> Iterator for ZipEq<I, J>
-    where I: Iterator,
-          J: Iterator
+where
+    I: Iterator,
+    J: Iterator,
 {
     type Item = (I::Item, J::Item);
 
@@ -44,8 +46,9 @@ impl<I, J> Iterator for ZipEq<I, J>
         match (self.a.next(), self.b.next()) {
             (None, None) => None,
             (Some(a), Some(b)) => Some((a, b)),
-            (None, Some(_)) | (Some(_), None) =>
-            panic!("itertools: .zip_eq() reached end of one iterator before the other")
+            (None, Some(_)) | (Some(_), None) => {
+                panic!("itertools: .zip_eq() reached end of one iterator before the other")
+            }
         }
     }
 
@@ -55,6 +58,8 @@ impl<I, J> Iterator for ZipEq<I, J>
 }
 
 impl<I, J> ExactSizeIterator for ZipEq<I, J>
-    where I: ExactSizeIterator,
-          J: ExactSizeIterator
-{}
+where
+    I: ExactSizeIterator,
+    J: ExactSizeIterator,
+{
+}

--- a/src/zip_longest.rs
+++ b/src/zip_longest.rs
@@ -1,5 +1,5 @@
-use std::cmp::Ordering::{Equal, Greater, Less};
 use super::size_hint;
+use std::cmp::Ordering::{Equal, Greater, Less};
 use std::iter::Fuse;
 
 use either_or_both::EitherOrBoth;
@@ -20,9 +20,10 @@ pub struct ZipLongest<T, U> {
 }
 
 /// Create a new `ZipLongest` iterator.
-pub fn zip_longest<T, U>(a: T, b: U) -> ZipLongest<T, U> 
-    where T: Iterator,
-          U: Iterator
+pub fn zip_longest<T, U>(a: T, b: U) -> ZipLongest<T, U>
+where
+    T: Iterator,
+    U: Iterator,
 {
     ZipLongest {
         a: a.fuse(),
@@ -31,8 +32,9 @@ pub fn zip_longest<T, U>(a: T, b: U) -> ZipLongest<T, U>
 }
 
 impl<T, U> Iterator for ZipLongest<T, U>
-    where T: Iterator,
-          U: Iterator
+where
+    T: Iterator,
+    U: Iterator,
 {
     type Item = EitherOrBoth<T::Item, U::Item>;
 
@@ -53,8 +55,9 @@ impl<T, U> Iterator for ZipLongest<T, U>
 }
 
 impl<T, U> DoubleEndedIterator for ZipLongest<T, U>
-    where T: DoubleEndedIterator + ExactSizeIterator,
-          U: DoubleEndedIterator + ExactSizeIterator
+where
+    T: DoubleEndedIterator + ExactSizeIterator,
+    U: DoubleEndedIterator + ExactSizeIterator,
 {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
@@ -73,6 +76,8 @@ impl<T, U> DoubleEndedIterator for ZipLongest<T, U>
 }
 
 impl<T, U> ExactSizeIterator for ZipLongest<T, U>
-    where T: ExactSizeIterator,
-          U: ExactSizeIterator
-{}
+where
+    T: ExactSizeIterator,
+    U: ExactSizeIterator,
+{
+}

--- a/src/ziptuple.rs
+++ b/src/ziptuple.rs
@@ -39,8 +39,9 @@ pub struct Zip<T> {
 /// assert_eq!(results, [0 + 3, 10 + 7, 29, 36]);
 /// ```
 pub fn multizip<T, U>(t: U) -> Zip<T>
-    where Zip<T>: From<U>,
-          Zip<T>: Iterator,
+where
+    Zip<T>: From<U>,
+    Zip<T>: Iterator,
 {
     Zip::from(t)
 }

--- a/tests/merge_join.rs
+++ b/tests/merge_join.rs
@@ -1,110 +1,103 @@
 extern crate itertools;
 
-use itertools::EitherOrBoth;
 use itertools::free::merge_join_by;
+use itertools::EitherOrBoth;
 
 #[test]
 fn empty() {
     let left: Vec<u32> = vec![];
     let right: Vec<u32> = vec![];
     let expected_result: Vec<EitherOrBoth<u32, u32>> = vec![];
-    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r))
-        .collect::<Vec<_>>();
+    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r)).collect::<Vec<_>>();
     assert_eq!(expected_result, actual_result);
 }
 
 #[test]
 fn left_only() {
-    let left: Vec<u32> = vec![1,2,3];
+    let left: Vec<u32> = vec![1, 2, 3];
     let right: Vec<u32> = vec![];
     let expected_result: Vec<EitherOrBoth<u32, u32>> = vec![
         EitherOrBoth::Left(1),
         EitherOrBoth::Left(2),
-        EitherOrBoth::Left(3)
+        EitherOrBoth::Left(3),
     ];
-    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r))
-        .collect::<Vec<_>>();
+    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r)).collect::<Vec<_>>();
     assert_eq!(expected_result, actual_result);
 }
 
 #[test]
 fn right_only() {
     let left: Vec<u32> = vec![];
-    let right: Vec<u32> = vec![1,2,3];
+    let right: Vec<u32> = vec![1, 2, 3];
     let expected_result: Vec<EitherOrBoth<u32, u32>> = vec![
         EitherOrBoth::Right(1),
         EitherOrBoth::Right(2),
-        EitherOrBoth::Right(3)
+        EitherOrBoth::Right(3),
     ];
-    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r))
-        .collect::<Vec<_>>();
+    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r)).collect::<Vec<_>>();
     assert_eq!(expected_result, actual_result);
 }
 
 #[test]
 fn first_left_then_right() {
-    let left: Vec<u32> = vec![1,2,3];
-    let right: Vec<u32> = vec![4,5,6];
+    let left: Vec<u32> = vec![1, 2, 3];
+    let right: Vec<u32> = vec![4, 5, 6];
     let expected_result: Vec<EitherOrBoth<u32, u32>> = vec![
         EitherOrBoth::Left(1),
         EitherOrBoth::Left(2),
         EitherOrBoth::Left(3),
         EitherOrBoth::Right(4),
         EitherOrBoth::Right(5),
-        EitherOrBoth::Right(6)
+        EitherOrBoth::Right(6),
     ];
-    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r))
-        .collect::<Vec<_>>();
+    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r)).collect::<Vec<_>>();
     assert_eq!(expected_result, actual_result);
 }
 
 #[test]
 fn first_right_then_left() {
-    let left: Vec<u32> = vec![4,5,6];
-    let right: Vec<u32> = vec![1,2,3];
+    let left: Vec<u32> = vec![4, 5, 6];
+    let right: Vec<u32> = vec![1, 2, 3];
     let expected_result: Vec<EitherOrBoth<u32, u32>> = vec![
         EitherOrBoth::Right(1),
         EitherOrBoth::Right(2),
         EitherOrBoth::Right(3),
         EitherOrBoth::Left(4),
         EitherOrBoth::Left(5),
-        EitherOrBoth::Left(6)
+        EitherOrBoth::Left(6),
     ];
-    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r))
-        .collect::<Vec<_>>();
+    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r)).collect::<Vec<_>>();
     assert_eq!(expected_result, actual_result);
 }
 
 #[test]
 fn interspersed_left_and_right() {
-    let left: Vec<u32> = vec![1,3,5];
-    let right: Vec<u32> = vec![2,4,6];
+    let left: Vec<u32> = vec![1, 3, 5];
+    let right: Vec<u32> = vec![2, 4, 6];
     let expected_result: Vec<EitherOrBoth<u32, u32>> = vec![
         EitherOrBoth::Left(1),
         EitherOrBoth::Right(2),
         EitherOrBoth::Left(3),
         EitherOrBoth::Right(4),
         EitherOrBoth::Left(5),
-        EitherOrBoth::Right(6)
+        EitherOrBoth::Right(6),
     ];
-    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r))
-        .collect::<Vec<_>>();
+    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r)).collect::<Vec<_>>();
     assert_eq!(expected_result, actual_result);
 }
 
 #[test]
 fn overlapping_left_and_right() {
-    let left: Vec<u32> = vec![1,3,4,6];
-    let right: Vec<u32> = vec![2,3,4,5];
+    let left: Vec<u32> = vec![1, 3, 4, 6];
+    let right: Vec<u32> = vec![2, 3, 4, 5];
     let expected_result: Vec<EitherOrBoth<u32, u32>> = vec![
         EitherOrBoth::Left(1),
         EitherOrBoth::Right(2),
         EitherOrBoth::Both(3, 3),
         EitherOrBoth::Both(4, 4),
         EitherOrBoth::Right(5),
-        EitherOrBoth::Left(6)
+        EitherOrBoth::Left(6),
     ];
-    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r))
-        .collect::<Vec<_>>();
+    let actual_result = merge_join_by(left, right, |l, r| l.cmp(r)).collect::<Vec<_>>();
     assert_eq!(expected_result, actual_result);
 }

--- a/tests/peeking_take_while.rs
+++ b/tests/peeking_take_while.rs
@@ -1,4 +1,3 @@
-
 extern crate itertools;
 
 use itertools::Itertools;

--- a/tests/test_core.rs
+++ b/tests/test_core.rs
@@ -5,14 +5,15 @@
 //! except according to those terms.
 #![no_std]
 
-#[macro_use] extern crate itertools as it;
+#[macro_use]
+extern crate itertools as it;
 
 use core::iter;
 
-use it::Itertools;
+use it::free::put_back;
 use it::interleave;
 use it::multizip;
-use it::free::put_back;
+use it::Itertools;
 
 #[test]
 fn product2() {
@@ -31,12 +32,11 @@ fn product_temporary() {
     for (_x, _y, _z) in iproduct!(
         [0, 1, 2].iter().cloned(),
         [0, 1, 2].iter().cloned(),
-        [0, 1, 2].iter().cloned())
-    {
+        [0, 1, 2].iter().cloned()
+    ) {
         // ok
     }
 }
-
 
 #[test]
 fn izip_macro() {
@@ -58,7 +58,7 @@ fn izip_macro() {
 #[test]
 fn izip2() {
     let _zip1: iter::Zip<_, _> = izip!(1.., 2..);
-    let _zip2: iter::Zip<_, _> = izip!(1.., 2.., );
+    let _zip2: iter::Zip<_, _> = izip!(1.., 2..,);
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn write_to() {
 
 #[test]
 fn test_interleave() {
-    let xs: [u8; 0]  = [];
+    let xs: [u8; 0] = [];
     let ys = [7u8, 9, 8, 10];
     let zs = [2u8, 77];
     let it = interleave(xs.iter(), ys.iter());
@@ -138,15 +138,13 @@ fn batching() {
     let ys = [(0, 1), (2, 1)];
 
     // An iterator that gathers elements up in pairs
-    let pit = xs.iter().cloned().batching(|it| {
-               match it.next() {
-                   None => None,
-                   Some(x) => match it.next() {
-                       None => None,
-                       Some(y) => Some((x, y)),
-                   }
-               }
-           });
+    let pit = xs.iter().cloned().batching(|it| match it.next() {
+        None => None,
+        Some(x) => match it.next() {
+            None => None,
+            Some(y) => Some((x, y)),
+        },
+    });
     it::assert_equal(pit, ys.iter().cloned());
 }
 
@@ -174,7 +172,6 @@ fn merge() {
     it::assert_equal((0..10).step(2).merge((1..10).step(2)), 0..10);
 }
 
-
 #[test]
 fn repeatn() {
     let s = "α";
@@ -194,29 +191,33 @@ fn count_clones() {
     use core::cell::Cell;
     #[derive(PartialEq, Debug)]
     struct Foo {
-        n: Cell<usize>
+        n: Cell<usize>,
     }
 
-    impl Clone for Foo
-    {
-        fn clone(&self) -> Self
-        {
+    impl Clone for Foo {
+        fn clone(&self) -> Self {
             let n = self.n.get();
             self.n.set(n + 1);
-            Foo { n: Cell::new(n + 1) }
+            Foo {
+                n: Cell::new(n + 1),
+            }
         }
     }
 
-
     for n in 0..10 {
-        let f = Foo{n: Cell::new(0)};
+        let f = Foo { n: Cell::new(0) };
         let it = it::repeat_n(f, n);
         // drain it
         let last = it.last();
         if n == 0 {
             assert_eq!(last, None);
         } else {
-            assert_eq!(last, Some(Foo{n: Cell::new(n - 1)}));
+            assert_eq!(
+                last,
+                Some(Foo {
+                    n: Cell::new(n - 1)
+                })
+            );
         }
     }
 }
@@ -248,7 +249,19 @@ fn tree_fold1() {
 #[test]
 fn exactly_one() {
     assert_eq!((0..10).filter(|&x| x == 2).exactly_one().unwrap(), 2);
-    assert!((0..10).filter(|&x| x > 1 && x < 4).exactly_one().unwrap_err().eq(2..4));
-    assert!((0..10).filter(|&x| x > 1 && x < 5).exactly_one().unwrap_err().eq(2..5));
-    assert!((0..10).filter(|&_| false).exactly_one().unwrap_err().eq(0..0));
+    assert!((0..10)
+        .filter(|&x| x > 1 && x < 4)
+        .exactly_one()
+        .unwrap_err()
+        .eq(2..4));
+    assert!((0..10)
+        .filter(|&x| x > 1 && x < 5)
+        .exactly_one()
+        .unwrap_err()
+        .eq(2..5));
+    assert!((0..10)
+        .filter(|&_| false)
+        .exactly_one()
+        .unwrap_err()
+        .eq(0..0));
 }

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -1,14 +1,14 @@
-
-#[macro_use] extern crate itertools as it;
+#[macro_use]
+extern crate itertools as it;
 extern crate permutohedron;
 
-use it::Itertools;
-use it::multizip;
-use it::multipeek;
-use it::free::rciter;
-use it::free::put_back_n;
-use it::FoldWhile;
 use it::cloned;
+use it::free::put_back_n;
+use it::free::rciter;
+use it::multipeek;
+use it::multizip;
+use it::FoldWhile;
+use it::Itertools;
 
 #[test]
 fn product3() {
@@ -22,9 +22,7 @@ fn product3() {
             }
         }
     }
-    for (_, _, _, _) in iproduct!(0..3, 0..2, 0..2, 0..3) {
-        /* test compiles */
-    }
+    for (_, _, _, _) in iproduct!(0..3, 0..2, 0..2, 0..3) { /* test compiles */ }
 }
 
 #[test]
@@ -51,7 +49,6 @@ fn interleave_shortest() {
     let it = v0.into_iter().interleave_shortest(i1);
     assert_eq!(it.size_hint(), (6, Some(6)));
 }
-
 
 #[test]
 fn unique_by() {
@@ -100,17 +97,37 @@ fn dedup() {
 
 #[test]
 fn dedup_by() {
-    let xs = [(0, 0), (0, 1), (1, 1), (2, 1), (0, 2), (3, 1), (0, 3), (1, 3)];
+    let xs = [
+        (0, 0),
+        (0, 1),
+        (1, 1),
+        (2, 1),
+        (0, 2),
+        (3, 1),
+        (0, 3),
+        (1, 3),
+    ];
     let ys = [(0, 0), (0, 1), (0, 2), (3, 1), (0, 3)];
-    it::assert_equal(ys.iter(), xs.iter().dedup_by(|x, y| x.1==y.1));
+    it::assert_equal(ys.iter(), xs.iter().dedup_by(|x, y| x.1 == y.1));
     let xs = [(0, 1), (0, 2), (0, 3), (0, 4), (0, 5)];
     let ys = [(0, 1)];
-    it::assert_equal(ys.iter(), xs.iter().dedup_by(|x, y| x.0==y.0));
+    it::assert_equal(ys.iter(), xs.iter().dedup_by(|x, y| x.0 == y.0));
 
-    let xs = [(0, 0), (0, 1), (1, 1), (2, 1), (0, 2), (3, 1), (0, 3), (1, 3)];
+    let xs = [
+        (0, 0),
+        (0, 1),
+        (1, 1),
+        (2, 1),
+        (0, 2),
+        (3, 1),
+        (0, 3),
+        (1, 3),
+    ];
     let ys = [(0, 0), (0, 1), (0, 2), (3, 1), (0, 3)];
     let mut xs_d = Vec::new();
-    xs.iter().dedup_by(|x, y| x.1==y.1).fold((), |(), &elt| xs_d.push(elt));
+    xs.iter()
+        .dedup_by(|x, y| x.1 == y.1)
+        .fold((), |(), &elt| xs_d.push(elt));
     assert_eq!(&xs_d, &ys);
 }
 
@@ -138,7 +155,7 @@ fn test_put_back_n() {
 
 #[test]
 fn tee() {
-    let xs  = [0, 1, 2, 3];
+    let xs = [0, 1, 2, 3];
     let (mut t1, mut t2) = xs.iter().cloned().tee();
     assert_eq!(t1.next(), Some(0));
     assert_eq!(t2.next(), Some(0));
@@ -161,7 +178,6 @@ fn tee() {
     let (t1, t2) = xs.iter().cloned().tee();
     it::assert_equal(t1.zip(t2), xs.iter().cloned().zip(xs.iter().cloned()));
 }
-
 
 #[test]
 fn test_rciter() {
@@ -186,19 +202,21 @@ fn test_rciter() {
 #[allow(deprecated)]
 #[test]
 fn trait_pointers() {
-    struct ByRef<'r, I: ?Sized>(&'r mut I) where I: 'r;
+    struct ByRef<'r, I: ?Sized>(&'r mut I)
+    where
+        I: 'r;
 
-    impl<'r, X, I: ?Sized> Iterator for ByRef<'r, I> where
-        I: 'r + Iterator<Item=X>
+    impl<'r, X, I: ?Sized> Iterator for ByRef<'r, I>
+    where
+        I: 'r + Iterator<Item = X>,
     {
         type Item = X;
-        fn next(&mut self) -> Option<X>
-        {
+        fn next(&mut self) -> Option<X> {
             self.0.next()
         }
     }
 
-    let mut it = Box::new(0..10) as Box<Iterator<Item=i32>>;
+    let mut it = Box::new(0..10) as Box<Iterator<Item = i32>>;
     assert_eq!(it.next(), Some(0));
 
     {
@@ -218,9 +236,16 @@ fn trait_pointers() {
 
 #[test]
 fn merge_by() {
-    let odd : Vec<(u32, &str)> = vec![(1, "hello"), (3, "world"), (5, "!")];
+    let odd: Vec<(u32, &str)> = vec![(1, "hello"), (3, "world"), (5, "!")];
     let even = vec![(2, "foo"), (4, "bar"), (6, "baz")];
-    let expected = vec![(1, "hello"), (2, "foo"), (3, "world"), (4, "bar"), (5, "!"), (6, "baz")];
+    let expected = vec![
+        (1, "hello"),
+        (2, "foo"),
+        (3, "world"),
+        (4, "bar"),
+        (5, "!"),
+        (6, "baz"),
+    ];
     let results = odd.iter().merge_by(even.iter(), |a, b| a.0 <= b.0);
     it::assert_equal(results, expected.iter());
 }
@@ -234,7 +259,7 @@ fn merge_by_btree() {
     let mut bt2 = BTreeMap::new();
     bt2.insert("foo", 2);
     bt2.insert("bar", 4);
-    let results = bt1.into_iter().merge_by(bt2.into_iter(), |a, b| a.0 <= b.0 );
+    let results = bt1.into_iter().merge_by(bt2.into_iter(), |a, b| a.0 <= b.0);
     let expected = vec![("bar", 4), ("foo", 2), ("hello", 1), ("world", 3)];
     it::assert_equal(results, expected.into_iter());
 }
@@ -276,19 +301,17 @@ fn kmerge_empty_size_hint() {
 #[test]
 fn join() {
     let many = [1, 2, 3];
-    let one  = [1];
+    let one = [1];
     let none: Vec<i32> = vec![];
 
     assert_eq!(many.iter().join(", "), "1, 2, 3");
-    assert_eq!( one.iter().join(", "), "1");
+    assert_eq!(one.iter().join(", "), "1");
     assert_eq!(none.iter().join(", "), "");
 }
 
 #[test]
 fn sorted_by() {
-    let sc = [3, 4, 1, 2].iter().cloned().sorted_by(|&a, &b| {
-        a.cmp(&b)
-    });
+    let sc = [3, 4, 1, 2].iter().cloned().sorted_by(|&a, &b| a.cmp(&b));
     it::assert_equal(sc, vec![1, 2, 3, 4]);
 
     let v = (0..5).sorted_by(|&a, &b| a.cmp(&b).reverse());
@@ -306,7 +329,7 @@ fn sorted_by_key() {
 
 #[test]
 fn test_multipeek() {
-    let nums = vec![1u8,2,3,4,5];
+    let nums = vec![1u8, 2, 3, 4, 5];
 
     let mp = multipeek(nums.iter().map(|&x| x));
     assert_eq!(nums, mp.collect::<Vec<_>>());
@@ -328,7 +351,6 @@ fn test_multipeek() {
     assert_eq!(mp.next(), Some(5));
     assert_eq!(mp.next(), None);
     assert_eq!(mp.peek(), None);
-
 }
 
 #[test]
@@ -348,7 +370,7 @@ fn test_multipeek_reset() {
 #[test]
 fn test_multipeek_peeking_next() {
     use it::PeekingNext;
-    let nums = vec![1u8,2,3,4,5,6,7];
+    let nums = vec![1u8, 2, 3, 4, 5, 6, 7];
 
     let mut mp = multipeek(nums.iter().map(|&x| x));
     assert_eq!(mp.peeking_next(|&x| x != 0), Some(1));
@@ -410,11 +432,11 @@ fn group_by() {
 
         for &idx in &indices[..] {
             let (key, text) = match idx {
-                 0 => ('A', "Aaa".chars()),
-                 1 => ('B', "Bbb".chars()),
-                 2 => ('C', "ccCc".chars()),
-                 3 => ('D', "DDDD".chars()),
-                 _ => unreachable!(),
+                0 => ('A', "Aaa".chars()),
+                1 => ('B', "Bbb".chars()),
+                2 => ('C', "ccCc".chars()),
+                3 => ('D', "DDDD".chars()),
+                _ => unreachable!(),
             };
             assert_eq!(key, subs[idx].0);
             it::assert_equal(&mut subs[idx].1, text);
@@ -439,9 +461,11 @@ fn group_by() {
     {
         let mut ntimes = 0;
         let text = "AABCCC";
-        for (_, sub) in &text.chars().group_by(|&x| { ntimes += 1; x}) {
-            for _ in sub {
-            }
+        for (_, sub) in &text.chars().group_by(|&x| {
+            ntimes += 1;
+            x
+        }) {
+            for _ in sub {}
         }
         assert_eq!(ntimes, text.len());
     }
@@ -449,8 +473,10 @@ fn group_by() {
     {
         let mut ntimes = 0;
         let text = "AABCCC";
-        for _ in &text.chars().group_by(|&x| { ntimes += 1; x}) {
-        }
+        for _ in &text.chars().group_by(|&x| {
+            ntimes += 1;
+            x
+        }) {}
         assert_eq!(ntimes, text.len());
     }
 
@@ -490,8 +516,7 @@ fn group_by_lazy_2() {
         if i < 2 {
             groups.push(group);
         } else if i < 4 {
-            for _ in group {
-            }
+            for _ in group {}
         } else {
             groups.push(group);
         }
@@ -503,7 +528,11 @@ fn group_by_lazy_2() {
     // use groups as chunks
     let data = vec![0, 0, 0, 1, 1, 0, 0, 2, 2, 3, 3];
     let mut i = 0;
-    let grouper = data.iter().group_by(move |_| { let k = i / 3; i += 1; k });
+    let grouper = data.iter().group_by(move |_| {
+        let k = i / 3;
+        i += 1;
+        k
+    });
     for (i, group) in &grouper {
         match i {
             0 => it::assert_equal(group, &[0, 0, 0]),
@@ -554,8 +583,8 @@ fn concat_empty() {
 
 #[test]
 fn concat_non_empty() {
-    let data = vec![vec![1,2,3], vec![4,5,6], vec![7,8,9]];
-    assert_eq!(data.into_iter().concat(), vec![1,2,3,4,5,6,7,8,9])
+    let data = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
+    assert_eq!(data.into_iter().concat(), vec![1, 2, 3, 4, 5, 6, 7, 8, 9])
 }
 
 #[test]
@@ -563,19 +592,20 @@ fn combinations() {
     assert!((1..3).combinations(5).next().is_none());
 
     let it = (1..3).combinations(2);
-    it::assert_equal(it, vec![
-        vec![1, 2],
-        ]);
+    it::assert_equal(it, vec![vec![1, 2]]);
 
     let it = (1..5).combinations(2);
-    it::assert_equal(it, vec![
-        vec![1, 2],
-        vec![1, 3],
-        vec![1, 4],
-        vec![2, 3],
-        vec![2, 4],
-        vec![3, 4],
-        ]);
+    it::assert_equal(
+        it,
+        vec![
+            vec![1, 2],
+            vec![1, 3],
+            vec![1, 4],
+            vec![2, 3],
+            vec![2, 4],
+            vec![3, 4],
+        ],
+    );
 
     it::assert_equal((0..0).tuple_combinations::<(_, _)>(), <Vec<_>>::new());
     it::assert_equal((0..1).tuple_combinations::<(_, _)>(), <Vec<_>>::new());
@@ -600,7 +630,6 @@ fn combinations_of_too_short() {
         assert!((0..i - 1).combinations(i).next().is_none());
     }
 }
-
 
 #[test]
 fn combinations_zero() {
@@ -649,8 +678,9 @@ fn diff_mismatch() {
     let diff = it::diff_with(a.iter(), b_map, |a, b| *a == b);
 
     assert!(match diff {
-        Some(it::Diff::FirstMismatch(1, _, from_diff)) =>
-            from_diff.collect::<Vec<_>>() == vec![5, 3, 4],
+        Some(it::Diff::FirstMismatch(1, _, from_diff)) => {
+            from_diff.collect::<Vec<_>>() == vec![5, 3, 4]
+        }
         _ => false,
     });
 }
@@ -663,8 +693,7 @@ fn diff_longer() {
     let diff = it::diff_with(a.iter(), b_map, |a, b| *a == b);
 
     assert!(match diff {
-        Some(it::Diff::Longer(_, remaining)) =>
-            remaining.collect::<Vec<_>>() == vec![5, 6],
+        Some(it::Diff::Longer(_, remaining)) => remaining.collect::<Vec<_>>() == vec![5, 6],
         _ => false,
     });
 }
@@ -684,8 +713,8 @@ fn diff_shorter() {
 
 #[test]
 fn minmax() {
-    use std::cmp::Ordering;
     use it::MinMaxResult;
+    use std::cmp::Ordering;
 
     // A peculiar type: Equality compares both tuple items, but ordering only the
     // first item.  This is so we can check the stability property easily.
@@ -704,7 +733,10 @@ fn minmax() {
         }
     }
 
-    assert_eq!(None::<Option<u32>>.iter().minmax(), MinMaxResult::NoElements);
+    assert_eq!(
+        None::<Option<u32>>.iter().minmax(),
+        MinMaxResult::NoElements
+    );
 
     assert_eq!(Some(1u32).iter().minmax(), MinMaxResult::OneElement(&1));
 
@@ -717,7 +749,11 @@ fn minmax() {
     assert_eq!(min, &Val(2, 0));
     assert_eq!(max, &Val(0, 2));
 
-    let (min, max) = data.iter().minmax_by(|x, y| x.1.cmp(&y.1)).into_option().unwrap();
+    let (min, max) = data
+        .iter()
+        .minmax_by(|x, y| x.1.cmp(&y.1))
+        .into_option()
+        .unwrap();
     assert_eq!(min, &Val(2, 0));
     assert_eq!(max, &Val(0, 2));
 }
@@ -740,8 +776,9 @@ fn format() {
 
 #[test]
 fn while_some() {
-    let ns = (1..10).map(|x| if x % 5 != 0 { Some(x) } else { None })
-                    .while_some();
+    let ns = (1..10)
+        .map(|x| if x % 5 != 0 { Some(x) } else { None })
+        .while_some();
     it::assert_equal(ns, vec![1, 2, 3, 4]);
 }
 
@@ -750,15 +787,18 @@ fn while_some() {
 fn fold_while() {
     let mut iterations = 0;
     let vec = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    let sum = vec.into_iter().fold_while(0, |acc, item| {
-        iterations += 1;
-        let new_sum = acc.clone() + item;
-        if new_sum <= 20 {
-            FoldWhile::Continue(new_sum)
-        } else {
-            FoldWhile::Done(acc)
-        }
-    }).into_inner();
+    let sum = vec
+        .into_iter()
+        .fold_while(0, |acc, item| {
+            iterations += 1;
+            let new_sum = acc.clone() + item;
+            if new_sum <= 20 {
+                FoldWhile::Continue(new_sum)
+            } else {
+                FoldWhile::Done(acc)
+            }
+        })
+        .into_inner();
     assert_eq!(iterations, 6);
     assert_eq!(sum, 15);
 }

--- a/tests/zip.rs
+++ b/tests/zip.rs
@@ -1,18 +1,19 @@
 extern crate itertools;
 
-use itertools::Itertools;
-use itertools::EitherOrBoth::{Both, Left, Right};
 use itertools::free::zip_eq;
+use itertools::EitherOrBoth::{Both, Left, Right};
+use itertools::Itertools;
 
 #[test]
 fn zip_longest_fused() {
     let a = [Some(1), None, Some(3), Some(4)];
     let b = [1, 2, 3];
 
-    let unfused = a.iter().batching(|it| *it.next().unwrap())
+    let unfused = a
+        .iter()
+        .batching(|it| *it.next().unwrap())
         .zip_longest(b.iter().cloned());
-    itertools::assert_equal(unfused,
-                       vec![Both(1, 1), Right(2), Right(3)]);
+    itertools::assert_equal(unfused, vec![Both(1, 1), Right(2), Right(3)]);
 }
 
 #[test]
@@ -42,11 +43,9 @@ fn test_double_ended_zip_longest() {
     assert_eq!(it.next(), None);
 }
 
-
 #[should_panic]
 #[test]
-fn zip_eq_panic1()
-{
+fn zip_eq_panic1() {
     let a = [1, 2];
     let b = [1, 2, 3];
 
@@ -55,11 +54,9 @@ fn zip_eq_panic1()
 
 #[should_panic]
 #[test]
-fn zip_eq_panic2()
-{
+fn zip_eq_panic2() {
     let a: [i32; 0] = [];
     let b = [1, 2, 3];
 
     zip_eq(&a, &b).count();
 }
-


### PR DESCRIPTION
This PR adds support for `rustfmt`. The CI script installs the binary on the stable release only and checks if the code is formatted correctly.

Closes #368.