### PR TITLE
Add Itertools::filter_{,map_}results

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -1192,6 +1192,72 @@ impl<I, F, T, E> Iterator for FilterResults<I, F>
     }
 }
 
+/// An iterator adapter to filter and apply a transformation on values within a nested `Result`.
+///
+/// See [`.filter_map_results()`](../trait.Itertools.html#method.filter_map_results) for more information.
+#[derive(Clone)]
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct FilterMapResults<I, F> {
+    iter: I,
+    f: F
+}
+
+/// Create a new `FilterResults` iterator.
+pub fn filter_map_results<I, F, T, U, E>(iter: I, f: F) -> FilterMapResults<I, F>
+    where I: Iterator<Item = Result<T, E>>,
+          F: FnMut(T) -> Option<U>,
+{
+    FilterMapResults {
+        iter,
+        f,
+    }
+}
+
+impl<I, F, T, U, E> Iterator for FilterMapResults<I, F>
+    where I: Iterator<Item = Result<T, E>>,
+          F: FnMut(T) -> Option<U>,
+{
+    type Item = Result<U, E>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.iter.next() {
+                Some(Ok(v)) => {
+                    if let Some(v) = (self.f)(v) {
+                        return Some(Ok(v));
+                    }
+                },
+                Some(Err(e)) => return Some(Err(e)),
+                None => return None,
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, self.iter.size_hint().1)
+    }
+
+    fn fold<Acc, Fold>(self, init: Acc, mut fold_f: Fold) -> Acc
+        where Fold: FnMut(Acc, Self::Item) -> Acc,
+    {
+        let mut f = self.f;
+        self.iter.fold(init, move |acc, v| {
+            if let Some(v) = v.map(&mut f).transpose() {
+                fold_f(acc, v)
+            } else {
+                acc
+            }
+        })
+    }
+
+    fn collect<C>(self) -> C
+        where C: FromIterator<Self::Item>
+    {
+        let mut f = self.f;
+        self.iter.filter_map(move |v| v.map(&mut f).transpose()).collect()
+    }
+}
+
 /// An iterator adapter to get the positions of each element that matches a predicate.
 ///
 /// See [`.positions()`](../trait.Itertools.html#method.positions) for more information.

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -1074,28 +1074,31 @@ where
     I::Item: Into<R>,
 {}
 
-/// An iterator adapter to apply a transformation within a nested `Result`.
+#[deprecated(note="Use MapOk instead", since="0.10")]
+pub type MapResults<I, F> = MapOk<I, F>;
+
+/// An iterator adapter to apply a transformation within a nested `Result::Ok`.
 ///
-/// See [`.map_results()`](../trait.Itertools.html#method.map_results) for more information.
+/// See [`.map_ok()`](../trait.Itertools.html#method.map_ok) for more information.
 #[derive(Clone)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-pub struct MapResults<I, F> {
+pub struct MapOk<I, F> {
     iter: I,
     f: F
 }
 
-/// Create a new `MapResults` iterator.
-pub fn map_results<I, F, T, U, E>(iter: I, f: F) -> MapResults<I, F>
+/// Create a new `MapOk` iterator.
+pub fn map_ok<I, F, T, U, E>(iter: I, f: F) -> MapOk<I, F>
     where I: Iterator<Item = Result<T, E>>,
           F: FnMut(T) -> U,
 {
-    MapResults {
+    MapOk {
         iter,
         f,
     }
 }
 
-impl<I, F, T, U, E> Iterator for MapResults<I, F>
+impl<I, F, T, U, E> Iterator for MapOk<I, F>
     where I: Iterator<Item = Result<T, E>>,
           F: FnMut(T) -> U,
 {
@@ -1124,28 +1127,28 @@ impl<I, F, T, U, E> Iterator for MapResults<I, F>
     }
 }
 
-/// An iterator adapter to filter values within a nested `Result`.
+/// An iterator adapter to filter values within a nested `Result::Ok`.
 ///
-/// See [`.filter_results()`](../trait.Itertools.html#method.filter_results) for more information.
+/// See [`.filter_ok()`](../trait.Itertools.html#method.filter_ok) for more information.
 #[derive(Clone)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-pub struct FilterResults<I, F> {
+pub struct FilterOk<I, F> {
     iter: I,
     f: F
 }
 
-/// Create a new `FilterResults` iterator.
-pub fn filter_results<I, F, T, E>(iter: I, f: F) -> FilterResults<I, F>
+/// Create a new `FilterOk` iterator.
+pub fn filter_ok<I, F, T, E>(iter: I, f: F) -> FilterOk<I, F>
     where I: Iterator<Item = Result<T, E>>,
           F: FnMut(&T) -> bool,
 {
-    FilterResults {
+    FilterOk {
         iter,
         f,
     }
 }
 
-impl<I, F, T, E> Iterator for FilterResults<I, F>
+impl<I, F, T, E> Iterator for FilterOk<I, F>
     where I: Iterator<Item = Result<T, E>>,
           F: FnMut(&T) -> bool,
 {
@@ -1188,12 +1191,11 @@ impl<I, F, T, E> Iterator for FilterResults<I, F>
     }
 }
 
-/// An iterator adapter to filter and apply a transformation on values within a nested `Result`.
+/// An iterator adapter to filter and apply a transformation on values within a nested `Result::Ok`.
 ///
-/// See [`.filter_map_results()`](../trait.Itertools.html#method.filter_map_results) for more information.
-#[derive(Clone)]
+/// See [`.filter_map_ok()`](../trait.Itertools.html#method.filter_map_ok) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-pub struct FilterMapResults<I, F> {
+pub struct FilterMapOk<I, F> {
     iter: I,
     f: F
 }
@@ -1206,18 +1208,18 @@ fn transpose_result<T, E>(result: Result<Option<T>, E>) -> Option<Result<T, E>> 
     }
 }
 
-/// Create a new `FilterResults` iterator.
-pub fn filter_map_results<I, F, T, U, E>(iter: I, f: F) -> FilterMapResults<I, F>
+/// Create a new `FilterOk` iterator.
+pub fn filter_map_ok<I, F, T, U, E>(iter: I, f: F) -> FilterMapOk<I, F>
     where I: Iterator<Item = Result<T, E>>,
           F: FnMut(T) -> Option<U>,
 {
-    FilterMapResults {
+    FilterMapOk {
         iter,
         f,
     }
 }
 
-impl<I, F, T, U, E> Iterator for FilterMapResults<I, F>
+impl<I, F, T, U, E> Iterator for FilterMapOk<I, F>
     where I: Iterator<Item = Result<T, E>>,
           F: FnMut(T) -> Option<U>,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ pub mod structs {
         DedupBy,
         Interleave,
         InterleaveShortest,
+        FilterResults,
         Product,
         PutBack,
         Batching,
@@ -735,6 +736,24 @@ pub trait Itertools : Iterator {
               F: FnMut(T) -> U,
     {
         adaptors::map_results(self, f)
+    }
+
+    /// Return an iterator adaptor that filters every `Result::Ok`
+    /// value with the provided closure. `Result::Err` values are
+    /// unchanged.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let input = vec![Ok(22), Err(false), Ok(11)];
+    /// let it = input.into_iter().filter_results(|&i| i > 20);
+    /// itertools::assert_equal(it, vec![Ok(22), Err(false)]);
+    /// ```
+    fn filter_results<F, T, E>(self, f: F) -> FilterResults<Self, F>
+        where Self: Iterator<Item = Result<T, E>> + Sized,
+              F: FnMut(&T) -> bool,
+    {
+        adaptors::filter_results(self, f)
     }
 
     /// Return an iterator adaptor that merges the two base iterators in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ pub mod structs {
         DedupBy,
         Interleave,
         InterleaveShortest,
+        FilterMapResults,
         FilterResults,
         Product,
         PutBack,
@@ -754,6 +755,24 @@ pub trait Itertools : Iterator {
               F: FnMut(&T) -> bool,
     {
         adaptors::filter_results(self, f)
+    }
+
+    /// Return an iterator adaptor that filters and transforms every
+    /// `Result::Ok` value with the provided closure. `Result::Err`
+    /// values are unchanged.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let input = vec![Ok(22), Err(false), Ok(11)];
+    /// let it = input.into_iter().filter_map_results(|i| if i > 20 { Some(i * 2) } else { None });
+    /// itertools::assert_equal(it, vec![Ok(44), Err(false)]);
+    /// ```
+    fn filter_map_results<F, T, U, E>(self, f: F) -> FilterMapResults<Self, F>
+        where Self: Iterator<Item = Result<T, E>> + Sized,
+              F: FnMut(T) -> Option<U>,
+    {
+        adaptors::filter_map_results(self, f)
     }
 
     /// Return an iterator adaptor that merges the two base iterators in


### PR DESCRIPTION
I found myself wanting `filter_map_results()` and just implemented `filter_results()` in the same stretch. I hope you find it useful!

I wasn't sure if #236 applies to these new iterators; I just implemented them.