### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -688,7 +688,7 @@ fn multi_cartesian_product_iterator(b: &mut test::Bencher)
 
     b.iter(|| {
         let mut sum = 0;
-        for x in xs.into_iter().multi_cartesian_product() {
+        for x in xs.iter().multi_cartesian_product() {
             sum += x[0];
             sum += x[1];
             sum += x[2];
@@ -704,7 +704,7 @@ fn multi_cartesian_product_fold(b: &mut test::Bencher)
 
     b.iter(|| {
         let mut sum = 0;
-        xs.into_iter().multi_cartesian_product().fold((), |(), x| {
+        xs.iter().multi_cartesian_product().fold((), |(), x| {
             sum += x[0];
             sum += x[1];
             sum += x[2];


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future change. See https://github.com/rust-lang/rust/pull/65819 for more information.