### PR TITLE
Combination for zero sized array

### DIFF
--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -50,6 +50,11 @@ impl<I> Iterator for Combinations<I>
 {
     type Item = Vec<I::Item>;
     fn next(&mut self) -> Option<Self::Item> {
+        if self.first && self.k == 0 {
+            self.first = false;
+            return Some(Vec::new());
+        }
+        
         let mut pool_len = self.pool.len();
         if self.pool.is_done() {
             if pool_len == 0 || self.k > pool_len {

--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -66,7 +66,7 @@ where
         // If this is the first iteration, return early
         if self.first {
             self.first = false;
-            // In empty edge cases (k == 0), return an empty vector.
+            // Handle corner cases of ((N,0)), ((0,N)), and ((0,0))
             return match (self.pool.is_done(), self.k == 0) {
                 (_, true) => Some(Vec::new()), // ((0/N, 0)) = 1
                 (true, false) => None,         // ((0, N)) = 0

--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -67,11 +67,10 @@ where
         if self.first {
             self.first = false;
             // In empty edge cases (k == 0), return an empty vector.
-            return if self.k == 0 || self.pool.is_done() {
-                Some(Vec::new())
-            // Otherwise, yield the initial state
-            } else {
-                Some(self.current())
+            return match (self.pool.is_done(), self.k == 0) {
+                (_, true) => Some(Vec::new()), // ((0/N, 0)) = 1
+                (true, false) => None,         // ((0, N)) = 0
+                _ => Some(self.current())      // Otherwise, yield the initial state
             };
         }
 

--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -65,12 +65,12 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         // If this is the first iteration, return early
         if self.first {
-            // In empty edge cases, stop iterating immediately
+            self.first = false;
+            // In empty edge cases (k == 0), return an empty vector.
             return if self.k == 0 || self.pool.is_done() {
-                None
+                Some(Vec::new())
             // Otherwise, yield the initial state
             } else {
-                self.first = false;
                 Some(self.current())
             };
         }

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -637,7 +637,7 @@ fn combinations_with_replacement() {
     // Empty pool
     it::assert_equal(
         (0..0).combinations_with_replacement(2),
-        vec![vec![]],
+        <Vec<Vec<_>>>::new(),
     );
 }
 

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -599,6 +599,7 @@ fn combinations_of_too_short() {
 #[test]
 fn combinations_zero() {
     it::assert_equal((1..3).combinations(0), vec![vec![]]);
+    it::assert_equal((0..0).combinations(0), vec![vec![]]);
 }
 
 #[test]
@@ -620,6 +621,11 @@ fn combinations_with_replacement() {
     // Zero size
     it::assert_equal(
         (0..3).combinations_with_replacement(0),
+        <Vec<Vec<_>>>::new(),
+    );
+    // Zero size on empty pool
+    it::assert_equal(
+        (0..0).combinations_with_replacement(0),
         <Vec<Vec<_>>>::new(),
     );
     // Empty pool

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -627,17 +627,17 @@ fn combinations_with_replacement() {
     // Zero size
     it::assert_equal(
         (0..3).combinations_with_replacement(0),
-        <Vec<Vec<_>>>::new(),
+        vec![vec![]],
     );
     // Zero size on empty pool
     it::assert_equal(
         (0..0).combinations_with_replacement(0),
-        <Vec<Vec<_>>>::new(),
+        vec![vec![]],
     );
     // Empty pool
     it::assert_equal(
         (0..0).combinations_with_replacement(2),
-        <Vec<Vec<_>>>::new(),
+        vec![vec![]],
     );
 }
 

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -603,6 +603,12 @@ fn combinations_zero() {
 }
 
 #[test]
+fn permutations_zero() {
+    it::assert_equal((1..3).permutations(0), vec![vec![]]);
+    it::assert_equal((0..0).permutations(0), vec![vec![]]);
+}
+
+#[test]
 fn combinations_with_replacement() {
     // Pool smaller than n
     it::assert_equal((0..1).combinations_with_replacement(2), vec![vec![0, 0]]);


### PR DESCRIPTION
Fixes #361

1. Add corner case handling for `combinations`
1. Add test cases for `combinations`, `combinations_with_replacement`, and `permutations`.

Zero-sized array is property handled in other combinatorics operators.
