### PR TITLE
Add Itertools::intersperse_with

### DIFF
--- a/src/intersperse.rs
+++ b/src/intersperse.rs
@@ -62,7 +62,7 @@ impl<I> Iterator for Intersperse<I>
         Self: Sized, F: FnMut(B, Self::Item) -> B,
     {
         let mut accum = init;
-        
+
         if let Some(x) = self.peek.take() {
             accum = f(accum, x);
         }
@@ -72,6 +72,84 @@ impl<I> Iterator for Intersperse<I>
         self.iter.fold(accum,
             |accum, x| {
                 let accum = f(accum, element.clone());
+                let accum = f(accum, x);
+                accum
+        })
+    }
+}
+
+/// An iterator adaptor to insert a particular value created by a function
+/// between each element of the adapted iterator.
+///
+/// Iterator element type is `I::Item`
+///
+/// This iterator is *fused*.
+///
+/// See [`.intersperse_with()`](../trait.Itertools.html#method.intersperse_with) for more information.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[derive(Debug)]
+pub struct IntersperseWith<I, ElemF>
+    where I: Iterator,
+    ElemF: FnMut() -> I::Item,
+{
+    element: ElemF,
+    iter: Fuse<I>,
+    peek: Option<I::Item>,
+}
+
+/// Create a new IntersperseWith iterator
+pub fn intersperse_with<I, ElemF>(iter: I, elt: ElemF) -> IntersperseWith<I, ElemF>
+    where I: Iterator,
+    ElemF: FnMut() -> I::Item
+{
+    let mut iter = iter.fuse();
+    IntersperseWith {
+        peek: iter.next(),
+        iter: iter,
+        element: elt,
+    }
+}
+
+impl<I, ElemF> Iterator for IntersperseWith<I, ElemF>
+    where I: Iterator,
+          ElemF: FnMut() -> I::Item
+{
+    type Item = I::Item;
+    #[inline]
+    fn next(&mut self) -> Option<I::Item> {
+        if self.peek.is_some() {
+            self.peek.take()
+        } else {
+            self.peek = self.iter.next();
+            if self.peek.is_some() {
+                Some((self.element)())
+            } else {
+                None
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // 2 * SH + { 1 or 0 }
+        let has_peek = self.peek.is_some() as usize;
+        let sh = self.iter.size_hint();
+        size_hint::add_scalar(size_hint::add(sh, sh), has_peek)
+    }
+
+    fn fold<B, F>(mut self, init: B, mut f: F) -> B where
+        Self: Sized, F: FnMut(B, Self::Item) -> B,
+    {
+        let mut accum = init;
+
+        if let Some(x) = self.peek.take() {
+            accum = f(accum, x);
+        }
+
+        let element = &mut self.element;
+
+        self.iter.fold(accum,
+            |accum, x| {
+                let accum = f(accum, (element)());
                 let accum = f(accum, x);
                 accum
         })

--- a/src/intersperse.rs
+++ b/src/intersperse.rs
@@ -1,7 +1,6 @@
 use std::iter::Fuse;
 use super::size_hint;
 
-#[derive(Clone)]
 /// An iterator adaptor to insert a particular value
 /// between each element of the adapted iterator.
 ///
@@ -11,7 +10,7 @@ use super::size_hint;
 ///
 /// See [`.intersperse()`](../trait.Itertools.html#method.intersperse) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Intersperse<I>
     where I: Iterator
 {
@@ -87,7 +86,7 @@ impl<I> Iterator for Intersperse<I>
 ///
 /// See [`.intersperse_with()`](../trait.Itertools.html#method.intersperse_with) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct IntersperseWith<I, ElemF>
     where I: Iterator,
     ElemF: FnMut() -> I::Item,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,6 +402,7 @@ pub trait Itertools : Iterator {
     ///
     /// let mut i = 10;
     /// itertools::assert_equal((0..3).intersperse_with(|| { i -= 1; i }), vec![0, 9, 1, 8, 2]);
+    /// assert_eq!(i, 8);
     /// ```
     fn intersperse_with<F>(self, element: F) -> IntersperseWith<Self, F>
         where Self: Sized,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub mod structs {
     pub use crate::format::{Format, FormatWith};
     #[cfg(feature = "use_std")]
     pub use crate::groupbylazy::{IntoChunks, Chunk, Chunks, GroupBy, Group, Groups};
-    pub use crate::intersperse::Intersperse;
+    pub use crate::intersperse::{Intersperse, IntersperseWith};
     #[cfg(feature = "use_std")]
     pub use crate::kmerge_impl::{KMerge, KMergeBy};
     pub use crate::merge_join::MergeJoinBy;
@@ -388,6 +388,26 @@ pub trait Itertools : Iterator {
               Self::Item: Clone
     {
         intersperse::intersperse(self, element)
+    }
+
+    /// An iterator adaptor to insert a particular value created by a function
+    /// between each element of the adapted iterator.
+    ///
+    /// Iterator element type is `Self::Item`.
+    ///
+    /// This iterator is *fused*.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let mut i = 10;
+    /// itertools::assert_equal((0..3).intersperse_with(|| { i -= 1; i }), vec![0, 9, 1, 8, 2]);
+    /// ```
+    fn intersperse_with<F>(self, element: F) -> IntersperseWith<Self, F>
+        where Self: Sized,
+        F: FnMut() -> Self::Item
+    {
+        intersperse::intersperse_with(self, element)
     }
 
     /// Create an iterator which iterates over both this and the specified


### PR DESCRIPTION
Pretty self-explanatory. Useful for non-clonable elements or otherwise stateful interspersing.
`intersperse()` could be implemented via `intersperse_with()`, allowing the change to be more minimal. I haven't done it currently, but if you don't see any downsides I'd amend this change to do `self.intersperse_with(|| element)` for `intersperse()` instead.