### PR TITLE
Extension trait for a range column-row iterator

### DIFF
--- a/src/column_row.rs
+++ b/src/column_row.rs
@@ -1,0 +1,46 @@
+use std::ops::Range;
+
+pub struct ColumnRowIter<T: Copy + core::cmp::PartialOrd + core::ops::AddAssign + From<u8>> {
+    range_row: Range<T>,
+    row_pos: T,
+    range_column: Range<T>,
+    col_pos: T,
+}
+
+impl<T> Iterator for ColumnRowIter<T>
+where
+    T: core::marker::Copy + core::cmp::PartialOrd + core::ops::AddAssign + From<u8>,
+{
+    type Item = (T, T);
+
+    fn next(&mut self) -> Option<(T, T)> {
+        while self.range_column.contains(&self.col_pos) {
+            if self.range_row.contains(&self.row_pos) {
+                let row_pos = self.row_pos;
+                self.row_pos += 1.into();
+                return Some((self.col_pos, row_pos));
+            }
+            self.col_pos += 1.into();
+            self.row_pos = self.range_row.start;
+        }
+        None
+    }
+}
+
+pub trait RangeExt<T: Copy + core::cmp::PartialOrd + core::ops::AddAssign + From<u8>> {
+    fn rows(self, r: Range<T>) -> ColumnRowIter<T>;
+}
+
+impl<T: Copy> RangeExt<T> for Range<T>
+where
+    T: core::marker::Copy + core::cmp::PartialOrd + core::ops::AddAssign + From<u8>,
+{
+    fn rows(self, rows: Range<T>) -> ColumnRowIter<T> {
+        ColumnRowIter {
+            range_column: self.clone(),
+            col_pos: self.start,
+            range_row: rows.clone(),
+            row_pos: rows.start,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,7 @@ mod with_position;
 mod zip_eq_impl;
 mod zip_longest;
 mod ziptuple;
+pub mod column_row;
 
 #[macro_export]
 /// Create an iterator over the “cartesian product” of iterators.


### PR DESCRIPTION
Extension trait for a range, which accepts another range to make an iterator that would give x,y tuple 'visiting' every possibility. I wrote it for some pixel based stuff currently because I couldnt find it anywhere else. 

```
use itertools::column_row::RangeExt;
fn main() {
    for (x, y) in (0..3).rows(0..5) {
        println!("x:{:?} y:{:?}", x, y);
    }
}
```
produces
```
x:0 y:0
x:0 y:1
x:0 y:2
x:0 y:3
x:0 y:4
x:1 y:0
x:1 y:1
x:1 y:2
x:1 y:3
x:1 y:4
x:2 y:0
x:2 y:1
x:2 y:2
x:2 y:3
x:2 y:4
```
Currently doesnt support RangeTo which is a shame. But from looking at the code base I know my implementation doesnt fit here at all currently. Im happy to bikeshed literally everything about this pr, but wanted to come with something working. Let me know if it has a home here.

Thanks