### PR TITLE
Simplify `Clone` implementations

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -14,16 +14,6 @@ use std::iter::{Fuse, Peekable, FromIterator};
 use std::marker::PhantomData;
 use size_hint;
 
-macro_rules! clone_fields {
-    ($name:ident, $base:expr, $($field:ident),+) => (
-        $name {
-            $(
-                $field : $base . $field .clone()
-            ),*
-        }
-    );
-}
-
 /// An iterator adaptor that alternates elements from two iterators until both
 /// run out.
 ///
@@ -555,9 +545,7 @@ impl<I, J, F> Clone for MergeBy<I, J, F>
           Peekable<J>: Clone,
           F: Clone
 {
-    fn clone(&self) -> Self {
-        clone_fields!(MergeBy, self, a, b, fused, cmp)
-    }
+    clone_fields!(a, b, fused, cmp);
 }
 
 impl<I, J, F> Iterator for MergeBy<I, J, F>
@@ -650,9 +638,7 @@ impl<I: Clone, F: Clone> Clone for Coalesce<I, F>
     where I: Iterator,
           I::Item: Clone
 {
-    fn clone(&self) -> Self {
-        clone_fields!(Coalesce, self, iter, f)
-    }
+    clone_fields!(iter, f);
 }
 
 impl<I, F> fmt::Debug for Coalesce<I, F>
@@ -729,9 +715,7 @@ impl<I: Clone, Pred: Clone> Clone for DedupBy<I, Pred>
     where I: Iterator,
           I::Item: Clone,
 {
-    fn clone(&self) -> Self {
-        clone_fields!(DedupBy, self, iter, dedup_pred)
-    }
+    clone_fields!(iter, dedup_pred);
 }
 
 /// Create a new `DedupBy`.

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -17,14 +17,7 @@ impl<I> Clone for Combinations<I>
     where I: Clone + Iterator,
           I::Item: Clone,
 {
-    fn clone(&self) -> Self {
-        Combinations {
-            k: self.k,
-            indices: self.indices.clone(),
-            pool: self.pool.clone(),
-            first: self.first,
-        }
-    }
+    clone_fields!(k, indices, pool, first);
 }
 
 impl<I> fmt::Debug for Combinations<I>

--- a/src/cons_tuples_impl.rs
+++ b/src/cons_tuples_impl.rs
@@ -52,11 +52,7 @@ pub struct ConsTuples<I, J>
 impl<I, J> Clone for ConsTuples<I, J>
     where I: Clone + Iterator<Item=J>,
 {
-    fn clone(&self) -> Self {
-        ConsTuples {
-            iter: self.iter.clone(),
-        }
-    }
+    clone_fields!(iter);
 }
 
 /// Create an iterator that maps for example iterators of

--- a/src/impl_macros.rs
+++ b/src/impl_macros.rs
@@ -12,3 +12,13 @@ macro_rules! debug_fmt_fields {
         }
     }
 }
+
+macro_rules! clone_fields {
+    ($($field:ident),*) => {
+        fn clone(&self) -> Self {
+            Self {
+                $($field: self.$field.clone(),)*
+            }
+        }
+    }
+}

--- a/src/kmerge_impl.rs
+++ b/src/kmerge_impl.rs
@@ -5,16 +5,6 @@ use Itertools;
 use std::mem::replace;
 use std::fmt;
 
-macro_rules! clone_fields {
-    ($name:ident, $base:expr, $($field:ident),+) => (
-        $name {
-            $(
-                $field : $base . $field .clone()
-            ),*
-        }
-    );
-}
-
 /// Head element and Tail iterator pair
 ///
 /// `PartialEq`, `Eq`, `PartialOrd` and `Ord` are implemented by comparing sequences based on
@@ -65,9 +55,7 @@ impl<I> Clone for HeadTail<I>
     where I: Iterator + Clone,
           I::Item: Clone
 {
-    fn clone(&self) -> Self {
-        clone_fields!(HeadTail, self, head, tail)
-    }
+    clone_fields!(head, tail);
 }
 
 /// Make `data` a heap (min-heap w.r.t the sorting).
@@ -197,9 +185,7 @@ impl<I, F> Clone for KMergeBy<I, F>
           I::Item: Clone,
           F: Clone,
 {
-    fn clone(&self) -> KMergeBy<I, F> {
-        clone_fields!(KMergeBy, self, heap, less_than)
-    }
+    clone_fields!(heap, less_than);
 }
 
 impl<I, F> Iterator for KMergeBy<I, F>

--- a/src/merge_join.rs
+++ b/src/merge_join.rs
@@ -38,13 +38,7 @@ impl<I, J, F> Clone for MergeJoinBy<I, J, F>
           J::Item: Clone,
           F: Clone,
 {
-    fn clone(&self) -> Self {
-        MergeJoinBy {
-            left: self.left.clone(),
-            right: self.right.clone(),
-            cmp_fn: self.cmp_fn.clone(),
-        }
-    }
+    clone_fields!(left, right, cmp_fn);
 }
 
 impl<I, J, F> fmt::Debug for MergeJoinBy<I, J, F>

--- a/src/permutations.rs
+++ b/src/permutations.rs
@@ -18,12 +18,7 @@ impl<I> Clone for Permutations<I>
     where I: Clone + Iterator,
           I::Item: Clone,
 {
-    fn clone(&self) -> Self {
-        Permutations {
-            vals: self.vals.clone(),
-            state: self.state.clone(),
-        }
-    }
+    clone_fields!(vals, state);
 }
 
 #[derive(Clone, Debug)]

--- a/src/rciter_impl.rs
+++ b/src/rciter_impl.rs
@@ -52,9 +52,7 @@ pub fn rciter<I>(iterable: I) -> RcIter<I::IntoIter>
 
 impl<I> Clone for RcIter<I> {
     #[inline]
-    fn clone(&self) -> RcIter<I> {
-        RcIter { rciter: self.rciter.clone() }
-    }
+    clone_fields!(rciter);
 }
 
 impl<A, I> Iterator for RcIter<I>

--- a/src/with_position.rs
+++ b/src/with_position.rs
@@ -17,12 +17,7 @@ impl<I> Clone for WithPosition<I>
     where I: Clone + Iterator,
           I::Item: Clone,
 {
-    fn clone(&self) -> Self {
-        WithPosition {
-            handled_first: self.handled_first,
-            peekable: self.peekable.clone(),
-        }
-    }
+    clone_fields!(handled_first, peekable);
 }
 
 /// Create a new `WithPosition` iterator.


### PR DESCRIPTION
Use a macro `clone_fields`, similar to `debug_fmt_fields`.

I replaced existing implementations of `clone_fields` and simplified the macro's parameters.