### PR TITLE
Use `?` instead of deprecated `try!`

### DIFF
--- a/examples/iris.rs
+++ b/examples/iris.rs
@@ -44,7 +44,7 @@ impl FromStr for Iris {
 
         // using Iterator::by_ref()
         for (index, part) in parts.by_ref().take(4).enumerate() {
-            iris.data[index] = try!(part.parse::<f32>());
+            iris.data[index] = part.parse::<f32>()?;
         }
         if let Some(name) = parts.next() {
             iris.name = name.into();

--- a/src/format.rs
+++ b/src/format.rs
@@ -58,13 +58,13 @@ impl<'a, I, F> fmt::Display for FormatWith<'a, I, F>
         };
 
         if let Some(fst) = iter.next() {
-            try!(format(fst, &mut |disp: &fmt::Display| disp.fmt(f)));
+            format(fst, &mut |disp: &fmt::Display| disp.fmt(f))?;
             for elt in iter {
                 if self.sep.len() > 0 {
 
-                    try!(f.write_str(self.sep));
+                    f.write_str(self.sep)?;
                 }
-                try!(format(elt, &mut |disp: &fmt::Display| disp.fmt(f)));
+                format(elt, &mut |disp: &fmt::Display| disp.fmt(f))?;
             }
         }
         Ok(())
@@ -83,12 +83,12 @@ impl<'a, I> Format<'a, I>
         };
 
         if let Some(fst) = iter.next() {
-            try!(cb(&fst, f));
+            cb(&fst, f)?;
             for elt in iter {
                 if self.sep.len() > 0 {
-                    try!(f.write_str(self.sep));
+                    f.write_str(self.sep)?;
                 }
-                try!(cb(&elt, f));
+                cb(&elt, f)?;
             }
         }
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1845,7 +1845,7 @@ pub trait Itertools : Iterator {
                 II: Iterator<Item = T>,
                 FF: FnMut(T, T) -> T
         {
-            let mut x = try!(inner0(it, f));
+            let mut x = inner0(it, f)?;
             for height in 0..stop {
                 // Try to get another tree the same size with which to combine it,
                 // creating a new tree that's twice as big for next time around.


### PR DESCRIPTION
I suggest using `?` instead of the deprecated `try!` macro.

Rust 1.40 warned: use of deprecated item 'try': use the `?` operator instead. Rust 1.13 introduced `?`, we require Rust 1.24 as minimal version.