### PR TITLE
Disable automatic formatting for nightly users

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,3 @@
+# Temporarily disable rustfmt completely to avoid conflicts of newly formatted
+# code with old PRs.
+ignore = ["/"]


### PR DESCRIPTION
Unfortunately, neither `ignore` or `disable_all_formatting` is stable, and `#![rustfmt::skip]` in `lib.rs` doesn't work because inner tool attributes are also unstable. Luckily, using unstable features in `.rustfmt.toml` only gives a warning on stable and works on Nightly, so this should improve the workflow for some users.

See also #368