### PR TITLE
don't require ParitalEq to the Item of DedupBy

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -763,7 +763,6 @@ impl<I, Pred> fmt::Debug for DedupBy<I, Pred>
 
 impl<I, Pred> Iterator for DedupBy<I, Pred>
     where I: Iterator,
-          I::Item: PartialEq,
           Pred: DedupPredicate<I::Item>,
 {
     type Item = I::Item;


### PR DESCRIPTION
`PartialEq` is't needed because `dedup_pred` take its place.