### PR TITLE
Implement peeking_fold_while

### DIFF
--- a/src/peeking_fold_while.rs
+++ b/src/peeking_fold_while.rs
@@ -1,0 +1,70 @@
+use std::iter::Peekable;
+use PutBack;
+#[cfg(feature = "use_std")]
+use PutBackN;
+
+/// A trait for folding an iterator by peeking at its elements before
+/// consuming them.
+pub trait PeekingFoldWhile : Iterator {
+    /// An iterator method that applies a function to each element
+    /// as long as it returns successfully, producing a single value.
+    ///
+    /// See [`.peeking_fold_while()`](../trait.Itertools.html#method.peeking_fold_while) for
+    /// more information.
+    fn peeking_fold_while<T, E, F>(&mut self, init: T, f: F) -> Result<T, E>
+        where F: FnMut(T, &Self::Item) -> Result<T, E>;
+}
+
+impl<I> PeekingFoldWhile for Peekable<I>
+    where I:Iterator
+{
+    fn peeking_fold_while<T, E, F>(&mut self, init: T, mut f: F) -> Result<T, E>
+        where F: FnMut(T, &I::Item) -> Result<T, E>,
+    {
+        let mut acc = init;
+        while let Some(x) = self.peek() {
+            let result = f(acc, x);
+            if result.is_ok() {
+                self.next();
+            }
+            acc = result?;
+        }
+        Ok(acc)
+    }
+}
+
+impl<I> PeekingFoldWhile for PutBack<I>
+    where I: Iterator
+{
+    fn peeking_fold_while<T, E, F>(&mut self, init: T, mut f: F) -> Result<T, E>
+        where F: FnMut(T, &I::Item) -> Result<T, E>,
+    {
+        let mut acc = init;
+        while let Some(x) = self.next() {
+            let result = f(acc, &x);
+            if result.is_err() {
+                self.put_back(x);
+            }
+            acc = result?;
+        }
+        Ok(acc)
+    }
+}
+
+impl<I> PeekingFoldWhile for PutBackN<I>
+    where I: Iterator
+{
+    fn peeking_fold_while<T, E, F>(&mut self, init: T, mut f: F) -> Result<T, E>
+        where F: FnMut(T, &I::Item) -> Result<T, E>,
+    {
+        let mut acc = init;
+        while let Some(x) = self.next() {
+            let result = f(acc, &x);
+            if result.is_err() {
+                self.put_back(x);
+            }
+            acc = result?;
+        }
+        Ok(acc)
+    }
+}

--- a/tests/peeking_fold_while.rs
+++ b/tests/peeking_fold_while.rs
@@ -1,0 +1,58 @@
+extern crate itertools;
+
+use itertools::Itertools;
+use itertools::{put_back, put_back_n};
+
+#[test]
+fn peeking_fold_while_peekable_consumes_all() {
+    let a = [10, 20, 30];
+    let mut it = a.iter().peekable();
+    let sum = it.peeking_fold_while(0i8, |acc, &&x| acc.checked_add(x).ok_or(acc));
+    assert_eq!(sum, Ok(60));
+    assert_eq!(it.next(), None);
+}
+
+#[test]
+fn peeking_fold_while_peekable_consumes_some() {
+    let a = [10, 20, 30, 100, 40, 50];
+    let mut it = a.iter().peekable();
+    let sum = it.peeking_fold_while(0i8, |acc, &&x| acc.checked_add(x).ok_or(acc));
+    assert_eq!(sum, Err(60));
+    assert_eq!(it.next(), Some(&100));
+}
+
+#[test]
+fn peeking_fold_while_put_back_consumes_all() {
+    let a = [10, 20, 30];
+    let mut it = put_back(a.iter());
+    let sum = it.peeking_fold_while(0i8, |acc, &&x| acc.checked_add(x).ok_or(acc));
+    assert_eq!(sum, Ok(60));
+    assert_eq!(it.next(), None);
+}
+
+#[test]
+fn peeking_fold_while_put_back_consumes_some() {
+    let a = [10, 20, 30, 100, 40, 50];
+    let mut it = put_back(a.iter());
+    let sum = it.peeking_fold_while(0i8, |acc, &&x| acc.checked_add(x).ok_or(acc));
+    assert_eq!(sum, Err(60));
+    assert_eq!(it.next(), Some(&100));
+}
+
+#[test]
+fn peeking_fold_while_put_back_n_consumes_all() {
+    let a = [10, 20, 30];
+    let mut it = put_back_n(a.iter());
+    let sum = it.peeking_fold_while(0i8, |acc, &&x| acc.checked_add(x).ok_or(acc));
+    assert_eq!(sum, Ok(60));
+    assert_eq!(it.next(), None);
+}
+
+#[test]
+fn peeking_fold_while_put_back_n_consumes_some() {
+    let a = [10, 20, 30, 100, 40, 50];
+    let mut it = put_back(a.iter());
+    let sum = it.peeking_fold_while(0i8, |acc, &&x| acc.checked_add(x).ok_or(acc));
+    assert_eq!(sum, Err(60));
+    assert_eq!(it.next(), Some(&100));
+}


### PR DESCRIPTION

## Issue
`try_fold` is capable of folding an iterator until a short-circuiting condition is met. For instance, the [short-circuiting example in the docs](https://doc.rust-lang.org/std/iter/trait.Iterator.html#examples-28) sums up integers until an integer overflow is encountered. However, `try_fold` ends up consuming the element that caused the short-circuit (in this case, the element 100). 

```rust
let a = [10, 20, 30, 100, 40, 50];
let mut it = a.iter();
let sum = it.try_fold(0i8, |acc, &x| acc.checked_add(x).ok_or(acc));
assert_eq!(sum, Err(60));
assert_eq!(it.next(), Some(&40));
```

## Solution
I've implemented a `PeekingFoldWhile` trait for `Peekable`s and `PutBack`s with a method `peeking_fold_while` that does not consume the short-circuiting element. Using it on the above example leads to the following behavior:

```rust
use itertools::Itertools;

let mut it = a.iter().peekable();
let sum = it.peeking_fold_while(0i8, |acc, &&x| acc.checked_add(x).ok_or(acc));
assert_eq!(sum, Err(60));
assert_eq!(it.next(), Some(&100));
```

This is my first attempt at contributing so feedback is welcome 😄 