### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,35 @@ sudo: false
 matrix:
   include:
     - rust: 1.32.0
+      script:
+        - |
+            cargo build --verbose --no-default-features &&
+            cargo build --verbose --features "$FEATURES" &&
+            cargo test --verbose --features "$FEATURES"
     - rust: stable
+      script:
+        - |
+            cargo build --verbose --no-default-features &&
+            cargo build --verbose --features "$FEATURES" &&
+            cargo test --verbose --features "$FEATURES" &&
+            cargo bench --verbose --features "$FEATURES"
     - rust: beta
+      script:
+        - |
+            cargo build --verbose --no-default-features &&
+            cargo build --verbose --features "$FEATURES" &&
+            cargo test --verbose --features "$FEATURES" &&
+            cargo bench --verbose --features "$FEATURES"
     - rust: nightly
+      script:
+        - |
+            cargo build --verbose --no-default-features &&
+            cargo build --verbose --features "$FEATURES" &&
+            cargo test --verbose --features "$FEATURES" &&
+            cargo bench --verbose --features "$FEATURES"
 branches:
   only:
     - master
     # bors branches
     - staging
     - trying
-script:
-  - |
-      cargo build --verbose --no-default-features &&
-      cargo build --verbose --features "$FEATURES" &&
-      cargo test --verbose --features "$FEATURES" &&
-      cargo bench --verbose --features "$FEATURES"


### PR DESCRIPTION
Fix #405

Don't run `cargo bench` on the minimum-rust-version job.