### PR TITLE
Temporary fix for CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ either = { version = "1.0", default-features = false }
 
 [dev-dependencies]
 rand = "0.7"
-criterion = "0.3"
+criterion = "=0.3.0" # TODO update criterion version once it becomes compatible with our minimum required Rust verision or bump minimum required rust version
 
 [dev-dependencies.quickcheck]
 version = "0.9"


### PR DESCRIPTION
Referring to https://github.com/rust-itertools/itertools/issues/405: As far as I understood, `dev-dependencies` are for examples, tests, and benches.

I tried to fix CI by fixing `criterion 0.3.0` for the time being so that it does not get in the way of other things in the queue.

From looking at https://github.com/bheisler/criterion.rs, it seems as if they bumped required rust version to 1.33, which I would not do for itertoos.

As noted in the patch, I hope that we can relax the version requirement one day.