### PR TITLE
Use field init shorthand

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -370,7 +370,7 @@ impl<I, F> fmt::Debug for Batching<I, F> where I: fmt::Debug {
 
 /// Create a new Batching iterator.
 pub fn batching<I, F>(iter: I, f: F) -> Batching<I, F> {
-    Batching { f: f, iter: iter }
+    Batching { f, iter }
 }
 
 impl<B, F, I> Iterator for Batching<I, F>
@@ -534,7 +534,7 @@ pub fn merge_by_new<I, J, F>(a: I, b: J, cmp: F) -> MergeBy<I::IntoIter, J::Into
         a: a.into_iter().peekable(),
         b: b.into_iter().peekable(),
         fused: None,
-        cmp: cmp,
+        cmp,
     }
 }
 
@@ -655,9 +655,9 @@ pub fn coalesce<I, F>(mut iter: I, f: F) -> Coalesce<I, F>
     Coalesce {
         iter: CoalesceCore {
             last: iter.next(),
-            iter: iter,
+            iter,
         },
-        f: f,
+        f,
     }
 }
 
@@ -725,7 +725,7 @@ pub fn dedup_by<I, Pred>(mut iter: I, dedup_pred: Pred) -> DedupBy<I, Pred>
     DedupBy {
         iter: CoalesceCore {
             last: iter.next(),
-            iter: iter,
+            iter,
         },
         dedup_pred,
     }
@@ -801,7 +801,7 @@ impl<'a, I, F> fmt::Debug for TakeWhileRef<'a, I, F>
 pub fn take_while_ref<I, F>(iter: &mut I, f: F) -> TakeWhileRef<I, F>
     where I: Iterator + Clone
 {
-    TakeWhileRef { iter: iter, f: f }
+    TakeWhileRef { iter, f }
 }
 
 impl<'a, I, F> Iterator for TakeWhileRef<'a, I, F>
@@ -843,7 +843,7 @@ pub struct WhileSome<I> {
 
 /// Create a new `WhileSome<I>`.
 pub fn while_some<I>(iter: I) -> WhileSome<I> {
-    WhileSome { iter: iter }
+    WhileSome { iter }
 }
 
 impl<I, A> Iterator for WhileSome<I>
@@ -915,7 +915,7 @@ pub struct Tuple1Combination<I> {
 
 impl<I> From<I> for Tuple1Combination<I> {
     fn from(iter: I) -> Self {
-        Tuple1Combination { iter: iter }
+        Tuple1Combination { iter }
     }
 }
 
@@ -1007,7 +1007,7 @@ pub struct MapInto<I, R> {
 /// Create a new [`MapInto`](struct.MapInto.html) iterator.
 pub fn map_into<I, R>(iter: I) -> MapInto<I, R> {
     MapInto {
-        iter: iter,
+        iter,
         _res: PhantomData,
     }
 }
@@ -1068,8 +1068,8 @@ pub fn map_results<I, F, T, U, E>(iter: I, f: F) -> MapResults<I, F>
           F: FnMut(T) -> U,
 {
     MapResults {
-        iter: iter,
-        f: f,
+        iter,
+        f,
     }
 }
 
@@ -1119,8 +1119,8 @@ pub fn positions<I, F>(iter: I, f: F) -> Positions<I, F>
           F: FnMut(I::Item) -> bool,
 {
     Positions {
-        iter: iter,
-        f: f,
+        iter,
+        f,
         count: 0
     }
 }
@@ -1177,7 +1177,7 @@ where
     I: Iterator,
     F: FnMut(&mut I::Item),
 {
-    Update { iter: iter, f: f }
+    Update { iter, f }
 }
 
 impl<I, F> Iterator for Update<I, F>

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -65,7 +65,7 @@ impl<I> MultiProduct<I>
             let on_first_iter = match state {
                 StartOfIter => {
                     let on_first_iter = !last.in_progress();
-                    state = MidIter { on_first_iter: on_first_iter };
+                    state = MidIter { on_first_iter };
                     on_first_iter
                 },
                 MidIter { on_first_iter } => on_first_iter

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -40,7 +40,7 @@ pub fn combinations<I>(iter: I, k: usize) -> Combinations<I>
 
     Combinations {
         indices: (0..k).collect(),
-        pool: pool,
+        pool,
         first: true,
     }
 }

--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -51,7 +51,7 @@ where
         k,
         indices,
         max_index: 0,
-        pool: pool,
+        pool,
         first: true,
     }
 }

--- a/src/groupbylazy.rs
+++ b/src/groupbylazy.rs
@@ -30,7 +30,7 @@ impl ChunkIndex {
     #[inline(always)]
     fn new(size: usize) -> Self {
         ChunkIndex {
-            size: size,
+            size,
             index: 0,
             key: 0,
         }
@@ -380,7 +380,7 @@ impl<'a, K, I, F> Iterator for Groups<'a, K, I, F>
             let key = inner.group_key(index);
             (key, Group {
                 parent: self.parent,
-                index: index,
+                index,
                 first: Some(elt),
             })
         })
@@ -528,7 +528,7 @@ impl<'a, I> Iterator for Chunks<'a, I>
         inner.step(index).map(|elt| {
             Chunk {
                 parent: self.parent,
-                index: index,
+                index,
                 first: Some(elt),
             }
         })

--- a/src/intersperse.rs
+++ b/src/intersperse.rs
@@ -27,7 +27,7 @@ pub fn intersperse<I>(iter: I, elt: I::Item) -> Intersperse<I>
     let mut iter = iter.fuse();
     Intersperse {
         peek: iter.next(),
-        iter: iter,
+        iter,
         element: elt,
     }
 }

--- a/src/kmerge_impl.rs
+++ b/src/kmerge_impl.rs
@@ -177,7 +177,7 @@ pub fn kmerge_by<I, F>(iterable: I, mut less_than: F)
     let mut heap: Vec<_> = Vec::with_capacity(lower);
     heap.extend(iter.filter_map(|it| HeadTail::new(it.into_iter())));
     heapify(&mut heap, |a, b| less_than.kmerge_pred(&a.head, &b.head));
-    KMergeBy { heap: heap, less_than: less_than }
+    KMergeBy { heap, less_than }
 }
 
 impl<I, F> Clone for KMergeBy<I, F>

--- a/src/lazy_buffer.rs
+++ b/src/lazy_buffer.rs
@@ -13,7 +13,7 @@ where
 {
     pub fn new(it: I) -> LazyBuffer<I> {
         LazyBuffer {
-            it: it,
+            it,
             done: false,
             buffer: Vec::new(),
         }

--- a/src/merge_join.rs
+++ b/src/merge_join.rs
@@ -17,7 +17,7 @@ pub fn merge_join_by<I, J, F>(left: I, right: J, cmp_fn: F)
     MergeJoinBy {
         left: put_back(left.into_iter().fuse()),
         right: put_back(right.into_iter().fuse()),
-        cmp_fn: cmp_fn
+        cmp_fn,
     }
 }
 

--- a/src/pad_tail.rs
+++ b/src/pad_tail.rs
@@ -23,9 +23,9 @@ pub fn pad_using<I, F>(iter: I, min: usize, filler: F) -> PadUsing<I, F>
 {
     PadUsing {
         iter: iter.fuse(),
-        min: min,
+        min,
         pos: 0,
-        filler: filler,
+        filler,
     }
 }
 

--- a/src/peeking_take_while.rs
+++ b/src/peeking_take_while.rs
@@ -89,8 +89,8 @@ pub fn peeking_take_while<I, F>(iter: &mut I, f: F) -> PeekingTakeWhile<I, F>
     where I: Iterator,
 {
     PeekingTakeWhile {
-        iter: iter,
-        f: f,
+        iter,
+        f,
     }
 }
 

--- a/src/process_results_impl.rs
+++ b/src/process_results_impl.rs
@@ -75,7 +75,7 @@ pub fn process_results<I, F, T, E, R>(iterable: I, processor: F) -> Result<R, E>
     let iter = iterable.into_iter();
     let mut error = Ok(());
 
-    let result = processor(ProcessResults { error: &mut error, iter: iter });
+    let result = processor(ProcessResults { error: &mut error, iter });
 
     error.map(|_| result)
 }

--- a/src/repeatn.rs
+++ b/src/repeatn.rs
@@ -14,9 +14,9 @@ pub fn repeat_n<A>(element: A, n: usize) -> RepeatN<A>
     where A: Clone,
 {
     if n == 0 {
-        RepeatN { elt: None, n: n, }
+        RepeatN { elt: None, n, }
     } else {
-        RepeatN { elt: Some(element), n: n, }
+        RepeatN { elt: Some(element), n, }
     }
 }
 

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -102,7 +102,7 @@ pub fn unfold<A, St, F>(initial_state: St, f: F) -> Unfold<St, F>
     where F: FnMut(&mut St) -> Option<A>
 {
     Unfold {
-        f: f,
+        f,
         state: initial_state,
     }
 }
@@ -186,6 +186,6 @@ pub fn iterate<St, F>(initial_value: St, f: F) -> Iterate<St, F>
 {
     Iterate {
         state: initial_value,
-        f: f,
+        f,
     }
 }

--- a/src/tee.rs
+++ b/src/tee.rs
@@ -28,7 +28,7 @@ pub struct Tee<I>
 pub fn new<I>(iter: I) -> (Tee<I>, Tee<I>)
     where I: Iterator
 {
-    let buffer = TeeBuffer{backlog: VecDeque::new(), iter: iter, owner: false};
+    let buffer = TeeBuffer{backlog: VecDeque::new(), iter, owner: false};
     let t1 = Tee{rcbuffer: Rc::new(RefCell::new(buffer)), id: true};
     let t2 = Tee{rcbuffer: t1.rcbuffer.clone(), id: false};
     (t1, t2)

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -32,7 +32,7 @@ impl<T> TupleBuffer<T>
     fn new(buf: T::Buffer) -> Self {
         TupleBuffer {
             cur: 0,
-            buf: buf,
+            buf,
         }
     }
 }
@@ -158,8 +158,8 @@ pub fn tuple_windows<I, T>(mut iter: I) -> TupleWindows<I, T>
     }
 
     TupleWindows {
-        last: last,
-        iter: iter,
+        last,
+        iter,
     }
 }
 

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -30,9 +30,9 @@ pub fn unique_by<I, V, F>(iter: I, f: F) -> UniqueBy<I, V, F>
           I: Iterator,
 {
     UniqueBy {
-        iter: iter,
+        iter,
         used: HashMap::new(),
-        f: f,
+        f,
     }
 }
 
@@ -126,7 +126,7 @@ pub fn unique<I>(iter: I) -> Unique<I>
 {
     Unique {
         iter: UniqueBy {
-            iter: iter,
+            iter,
             used: HashMap::new(),
             f: (),
         }

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -124,7 +124,7 @@ impl<T, HK> Iter<T, HK> where HK: HintKind
         Iter {
             iterator: it,
             fuse_flag: 0,
-            hint_kind: hint_kind
+            hint_kind,
         }
     }
 }
@@ -239,12 +239,12 @@ impl<HK> qc::Arbitrary for ShiftRange<HK>
         let hint_kind = qc::Arbitrary::arbitrary(g);
 
         ShiftRange {
-            range_start: range_start,
-            range_end: range_end,
-            start_step: start_step,
-            end_step: end_step,
-            iter_count: iter_count,
-            hint_kind: hint_kind
+            range_start,
+            range_end,
+            start_step,
+            end_step,
+            iter_count,
+            hint_kind,
         }
     }
 }


### PR DESCRIPTION
I suggest that we use field init shorthand ([available since Rust 1.17](https://doc.rust-lang.org/nightly/edition-guide/rust-2018/data-types/field-init-shorthand.html)) whenever possible, as it seems easier and canonical to me.