### PR TITLE
add caching to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
     - rust: stable
     - rust: beta
     - rust: nightly
+cache: cargo # https://docs.travis-ci.com/user/languages/rust/#dependency-management
 branches:
   only:
     - master


### PR DESCRIPTION
This is so that the pipeline does not download and compile all the dependencies all the time. Its recompiles them when a new compiler is used.