### PR TITLE
Add Itertools::zip_with

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,7 @@ pub mod structs {
     pub use crate::zip_eq_impl::ZipEq;
     pub use crate::zip_longest::ZipLongest;
     pub use crate::ziptuple::Zip;
+    pub use crate::zip_with::ZipWith;
 }
 
 /// Traits helpful for using certain `Itertools` methods in generic contexts.
@@ -207,6 +208,7 @@ mod with_position;
 mod zip_eq_impl;
 mod zip_longest;
 mod ziptuple;
+mod zip_with;
 
 #[macro_export]
 /// Create an iterator over the “cartesian product” of iterators.
@@ -435,6 +437,27 @@ pub trait Itertools : Iterator {
               Self: Sized
     {
         zip_eq(self, other)
+    }
+
+    /// Create an  iterator which zips two iterators using a function to produce
+    /// an arbitrary result type. The resulting iterator will be as large as the
+    /// smallest of the two iterators given.
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// 
+    /// let mut zipped = [1, 2, 9].iter().zip_with([4, 5, 6].iter(), |x,y| x+y);
+    /// for x in vec![5, 7, 15] { 
+    ///     assert_eq!(x, zipped.next().expect("unexpected zip_with result")) 
+    /// };
+    /// ```
+    #[inline]
+    fn zip_with<J, F, S>(self, other: J, zipper: F) -> ZipWith<Self, J::IntoIter, F> 
+        where J: Sized + IntoIterator,
+              F: Fn(Self::Item, J::Item) -> S,
+              Self: Sized
+    {
+        zip_with::zip_with(self.into_iter(), other.into_iter(), zipper)
     }
 
     /// A “meta iterator adaptor”. Its closure receives a reference to the

--- a/src/zip_with.rs
+++ b/src/zip_with.rs
@@ -1,0 +1,75 @@
+use super::size_hint;
+
+/// An iterator which zips two iterators using a function to produce an arbitrary result
+/// type. The resulting iterator will be as large as the smallest of the two iterators given.
+/// 
+/// # Params
+/// * left The left (arg 1) iterator to zip.
+/// * right The right (arg 2) iterator to zip.
+/// * zipper The function(left, right) to use in zipping the iterators.
+/// 
+/// ```
+/// use itertools::Itertools;
+/// 
+/// let mut zipped = [1, 2, 9].iter().zip_with([4, 5, 6].iter(), |x,y| x+y);
+/// for x in vec![5, 7, 15] { assert_eq!(x, zipped.next().expect("unexpected zip_with result")) };
+/// ```
+pub fn zip_with<T, U, R, F>(left: T, right: U, zipper: F) -> ZipWith<T, U, F> where
+    T: Iterator,
+    U: Iterator, 
+    F: Fn(T::Item, U::Item) -> R
+{
+    ZipWith { left: left.into_iter(), right: right.into_iter(), zipper: zipper }
+}
+
+pub trait IntoZipWith: IntoIterator + Sized 
+{
+    fn zip_with<R, F, S>(self, other: R, zipper: F) -> ZipWith<Self::IntoIter, R::IntoIter, F> where 
+        R: Sized + IntoIterator,
+        F: Fn(Self::Item, R::Item) -> S
+    {
+        zip_with(self.into_iter(), other.into_iter(), zipper)
+    }
+}
+
+impl<T: Iterator> IntoZipWith for T {}
+
+/// A ZipWith implementation, zips two iterators into a function.
+///
+/// See [`.zip_with()`](../trait.Itertools.html#method.zip_with) for more information.
+#[derive(Clone, Debug)]
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct ZipWith<T, U, F> 
+{
+    left: T,
+    right: U,
+    zipper: F
+}
+
+impl<T, U, R, F> Iterator for ZipWith<T, U, F> where
+    T: Iterator,
+    U: Iterator,
+    F: Fn(T::Item, U::Item) -> R
+{
+    type Item = R;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> 
+    {
+        match self.left.next()
+        {
+            Some(l) => match self.right.next()
+            {
+                Some(r) => Some((self.zipper) (l, r)),
+                None => None
+            },
+            None => None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) 
+    {
+        size_hint::min(self.left.size_hint(), self.right.size_hint())
+    }
+}

--- a/tests/zip.rs
+++ b/tests/zip.rs
@@ -61,3 +61,40 @@ fn zip_eq_panic2()
     zip_eq(&a, &b).count();
 }
 
+#[test]
+fn zip_with_maxes() {
+    let a = [1, 2, 3, 4, 5, -1, 100];
+    let b = [7, -3, 4, 10, -2, 10, 90];
+    let maxes = a.iter().zip_with(b.iter(), std::cmp::max);
+    itertools::assert_equal(maxes, &[7, 2, 4, 10, 5, 10, 100]);
+}
+
+#[test]
+fn zip_with_short1() {
+    let a = [4, 5];
+    let b = [3, 7, 9];
+    let sums = a.iter().zip_with(b.iter(), |x,y| x + y);
+    itertools::assert_equal(sums, vec![7, 12]);
+}
+
+#[test]
+fn zip_with_short2() {
+    let a = [4, 5, 7, 11];
+    let b = [1];
+    let sums = a.iter().zip_with(b.iter(), |x,y| x - y);
+    itertools::assert_equal(sums, vec![3]);
+}
+
+#[test]
+fn zip_with_size_hint1() {
+    let a = [1, 2, 3];
+    let b = [1, 2, 3, 5, 7, 9];
+    assert_eq!(a.iter().zip_with(b.iter(), std::cmp::min).size_hint(), (3, Some(3)));
+}
+
+#[test]
+fn zip_with_size_hint2() {
+    let a = [-2, 5, 6, 7, 8, 9];
+    let b = [-1];
+    assert_eq!(a.iter().zip_with(b.iter(), std::cmp::min).size_hint(), (1, Some(1)));
+}


### PR DESCRIPTION
a simple implementation of zip_with, quite surprised it was missing. I'm still learning the basics of Rust so I would appreciate any nit picked as far as anything missing or incorrect in the implementation or documentation.