### PR TITLE
Simpl is empty

### DIFF
--- a/src/multipeek_impl.rs
+++ b/src/multipeek_impl.rs
@@ -82,11 +82,7 @@ impl<I> Iterator for MultiPeek<I>
 
     fn next(&mut self) -> Option<I::Item> {
         self.index = 0;
-        if self.buf.is_empty() {
-            self.iter.next()
-        } else {
-            self.buf.pop_front()
-        }
+        self.buf.pop_front().or_else(|| self.iter.next())
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/put_back_n_impl.rs
+++ b/src/put_back_n_impl.rs
@@ -48,11 +48,7 @@ impl<I: Iterator> Iterator for PutBackN<I> {
     type Item = I::Item;
     #[inline]
     fn next(&mut self) -> Option<I::Item> {
-        if self.top.is_empty() {
-            self.iter.next()
-        } else {
-            self.top.pop()
-        }
+        self.top.pop().or_else(|| self.iter.next())
     }
 
     #[inline]


### PR DESCRIPTION
Taking inspiration from https://github.com/rust-itertools/itertools/pull/303#discussion_r420883592, I think we could exploit that `pop`/`pop_front` return `Option`.

Note: https://godbolt.org/z/WVTD7m seems to indicate that the compiler is doing a good job at optimizing either version.