### PR TITLE
Uniform type of `next`

### DIFF
--- a/benches/fold_specialization.rs
+++ b/benches/fold_specialization.rs
@@ -9,7 +9,7 @@ where I: Iterator
     type Item = I::Item;
 
     #[inline(always)]
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
     }
 

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -56,7 +56,7 @@ impl<I, J> Iterator for Interleave<I, J>
 {
     type Item = I::Item;
     #[inline]
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.flag = !self.flag;
         if self.flag {
             match self.a.next() {
@@ -113,7 +113,7 @@ impl<I, J> Iterator for InterleaveShortest<I, J>
     type Item = I::Item;
 
     #[inline]
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         match self.phase {
             false => match self.it0.next() {
                 None => None,
@@ -221,7 +221,7 @@ impl<I> Iterator for PutBack<I>
 {
     type Item = I::Item;
     #[inline]
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         match self.top {
             None => self.iter.next(),
             ref mut some => some.take(),
@@ -317,7 +317,7 @@ impl<I, J> Iterator for Product<I, J>
 {
     type Item = (I::Item, J::Item);
 
-    fn next(&mut self) -> Option<(I::Item, J::Item)> {
+    fn next(&mut self) -> Option<Self::Item> {
         let elt_b = match self.b.next() {
             None => {
                 self.b = self.b_orig.clone();
@@ -401,7 +401,7 @@ impl<B, F, I> Iterator for Batching<I, F>
 {
     type Item = B;
     #[inline]
-    fn next(&mut self) -> Option<B> {
+    fn next(&mut self) -> Option<Self::Item> {
         (self.f)(&mut self.iter)
     }
 
@@ -448,7 +448,7 @@ impl<I> Iterator for Step<I>
 {
     type Item = I::Item;
     #[inline]
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         let elt = self.iter.next();
         if self.skip > 0 {
             self.iter.nth(self.skip - 1);
@@ -577,7 +577,7 @@ impl<I, J, F> Iterator for MergeBy<I, J, F>
 {
     type Item = I::Item;
 
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         let less_than = match self.fused {
             Some(lt) => lt,
             None => match (self.a.peek(), self.b.peek()) {
@@ -689,7 +689,7 @@ impl<I, F> Iterator for Coalesce<I, F>
 {
     type Item = I::Item;
 
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.iter.next_with(&mut self.f)
     }
 
@@ -773,7 +773,7 @@ impl<I, Pred> Iterator for DedupBy<I, Pred>
 {
     type Item = I::Item;
 
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         let ref mut dedup_pred = self.dedup_pred;
         self.iter.next_with(|x, y| {
             if dedup_pred.dedup_pair(&x, &y) { Ok(x) } else { Err((x, y)) }
@@ -905,7 +905,7 @@ impl<'a, I, F> Iterator for TakeWhileRef<'a, I, F>
 {
     type Item = I::Item;
 
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         let old = self.iter.clone();
         match self.iter.next() {
             None => None,
@@ -946,7 +946,7 @@ impl<I, A> Iterator for WhileSome<I>
 {
     type Item = A;
 
-    fn next(&mut self) -> Option<A> {
+    fn next(&mut self) -> Option<Self::Item> {
         match self.iter.next() {
             None | Some(None) => None,
             Some(elt) => elt,
@@ -1113,7 +1113,7 @@ impl<I, R> Iterator for MapInto<I, R>
 {
     type Item = R;
 
-    fn next(&mut self) -> Option<R> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.iter
             .next()
             .map(|i| i.into())

--- a/src/intersperse.rs
+++ b/src/intersperse.rs
@@ -38,7 +38,7 @@ impl<I> Iterator for Intersperse<I>
 {
     type Item = I::Item;
     #[inline]
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         if self.peek.is_some() {
             self.peek.take()
         } else {

--- a/src/multipeek_impl.rs
+++ b/src/multipeek_impl.rs
@@ -80,7 +80,7 @@ impl<I> Iterator for MultiPeek<I>
 {
     type Item = I::Item;
 
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.index = 0;
         self.buf.pop_front().or_else(|| self.iter.next())
     }

--- a/src/pad_tail.rs
+++ b/src/pad_tail.rs
@@ -36,7 +36,7 @@ impl<I, F> Iterator for PadUsing<I, F>
     type Item = I::Item;
 
     #[inline]
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         match self.iter.next() {
             None => {
                 if self.pos < self.min {

--- a/src/pad_tail.rs
+++ b/src/pad_tail.rs
@@ -64,7 +64,7 @@ impl<I, F> DoubleEndedIterator for PadUsing<I, F>
     where I: DoubleEndedIterator + ExactSizeIterator,
           F: FnMut(usize) -> I::Item
 {
-    fn next_back(&mut self) -> Option<I::Item> {
+    fn next_back(&mut self) -> Option<Self::Item> {
         if self.min == 0 {
             self.iter.next_back()
         } else if self.iter.len() >= self.min {

--- a/src/peek_nth.rs
+++ b/src/peek_nth.rs
@@ -77,7 +77,7 @@ where
 {
     type Item = I::Item;
 
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.buf.pop_front().or_else(|| self.iter.next())
     }
 

--- a/src/put_back_n_impl.rs
+++ b/src/put_back_n_impl.rs
@@ -47,7 +47,7 @@ impl<I: Iterator> PutBackN<I> {
 impl<I: Iterator> Iterator for PutBackN<I> {
     type Item = I::Item;
     #[inline]
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.top.pop().or_else(|| self.iter.next())
     }
 

--- a/src/rciter_impl.rs
+++ b/src/rciter_impl.rs
@@ -60,7 +60,7 @@ impl<A, I> Iterator for RcIter<I>
 {
     type Item = A;
     #[inline]
-    fn next(&mut self) -> Option<A> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.rciter.borrow_mut().next()
     }
 

--- a/src/rciter_impl.rs
+++ b/src/rciter_impl.rs
@@ -78,7 +78,7 @@ impl<I> DoubleEndedIterator for RcIter<I>
     where I: DoubleEndedIterator
 {
     #[inline]
-    fn next_back(&mut self) -> Option<I::Item> {
+    fn next_back(&mut self) -> Option<Self::Item> {
         self.rciter.borrow_mut().next_back()
     }
 }

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -52,7 +52,7 @@ impl<A, F> Iterator for RepeatCall<F>
     type Item = A;
 
     #[inline]
-    fn next(&mut self) -> Option<A> {
+    fn next(&mut self) -> Option<Self::Item> {
         Some((self.f)())
     }
 
@@ -128,7 +128,7 @@ impl<A, St, F> Iterator for Unfold<St, F>
     type Item = A;
 
     #[inline]
-    fn next(&mut self) -> Option<A> {
+    fn next(&mut self) -> Option<Self::Item> {
         (self.f)(&mut self.state)
     }
 

--- a/src/tee.rs
+++ b/src/tee.rs
@@ -39,7 +39,7 @@ impl<I> Iterator for Tee<I>
           I::Item: Clone
 {
     type Item = I::Item;
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         // .borrow_mut may fail here -- but only if the user has tied some kind of weird
         // knot where the iterator refers back to itself.
         let mut buffer = self.rcbuffer.borrow_mut();

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -103,7 +103,7 @@ impl<I, T> Iterator for Tuples<I, T>
 {
     type Item = T;
 
-    fn next(&mut self) -> Option<T> {
+    fn next(&mut self) -> Option<Self::Item> {
         T::collect_from_iter(&mut self.iter, &mut self.buf)
     }
 }
@@ -173,7 +173,7 @@ impl<I, T> Iterator for TupleWindows<I, T>
 {
     type Item = T;
 
-    fn next(&mut self) -> Option<T> {
+    fn next(&mut self) -> Option<Self::Item> {
         if T::num_items() == 1 {
             return T::collect_from_iter_no_buf(&mut self.iter)
         }
@@ -224,7 +224,7 @@ impl<I, T> Iterator for CircularTupleWindows<I, T>
 {
     type Item = T;
 
-    fn next(&mut self) -> Option<T> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
     }
 }

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -54,7 +54,7 @@ impl<I, V, F> Iterator for UniqueBy<I, V, F>
 {
     type Item = I::Item;
 
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         while let Some(v) = self.iter.next() {
             let key = (self.f)(&v);
             if self.used.insert(key, ()).is_none() {
@@ -82,7 +82,7 @@ impl<I> Iterator for Unique<I>
 {
     type Item = I::Item;
 
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         while let Some(v) = self.iter.iter.next() {
             if let Entry::Vacant(entry) = self.iter.used.entry(v) {
                 let elt = entry.key().clone();

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -11,7 +11,7 @@ where
     type Item = I::Item;
 
     #[inline(always)]
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
     }
 

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -220,7 +220,7 @@ fn trait_pointers() {
         I: 'r + Iterator<Item=X>
     {
         type Item = X;
-        fn next(&mut self) -> Option<X>
+        fn next(&mut self) -> Option<Self::Item>
         {
             self.0.next()
         }


### PR DESCRIPTION
Yesterday I tried to play around and change the `Item` types of some iterators. I realized that we sometimes repeat these types (i.e. we have `type Item=X` and `fn next(&mut self) -> Option<X>`), requiring changes in two places if we want to change `Item`.

We could avoid this and make implementations more uniform by changing the return type of `next` to `Self::Item`, which is done in this PR.