### PR TITLE
Implement DedupBy in terms of Coalesce

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -649,7 +649,9 @@ impl<I, T> CoalesceCore<I, T>
 ///
 /// See [`.coalesce()`](../trait.Itertools.html#method.coalesce) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-pub struct Coalesce<I, F>
+pub type Coalesce<I, F> = CoalesceBy<I, F>;
+
+pub struct CoalesceBy<I, F>
     where I: Iterator
 {
     iter: CoalesceCore<I, I::Item>,
@@ -668,18 +670,18 @@ impl<F, Item, T> CoalescePredicate<Item, T> for F
     }
 }
 
-impl<I: Clone, F: Clone> Clone for Coalesce<I, F>
+impl<I: Clone, F: Clone> Clone for CoalesceBy<I, F>
     where I: Iterator,
           I::Item: Clone
 {
     clone_fields!(iter, f);
 }
 
-impl<I, F> fmt::Debug for Coalesce<I, F>
+impl<I, F> fmt::Debug for CoalesceBy<I, F>
     where I: Iterator + fmt::Debug,
           I::Item: fmt::Debug,
 {
-    debug_fmt_fields!(Coalesce, iter);
+    debug_fmt_fields!(CoalesceBy, iter);
 }
 
 /// Create a new `Coalesce`.
@@ -695,7 +697,7 @@ pub fn coalesce<I, F>(mut iter: I, f: F) -> Coalesce<I, F>
     }
 }
 
-impl<I, F> Iterator for Coalesce<I, F>
+impl<I, F> Iterator for CoalesceBy<I, F>
     where I: Iterator,
           F: CoalescePredicate<I::Item, I::Item>
 {

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -703,6 +703,8 @@ impl<I, F, T> Iterator for CoalesceBy<I, F, T>
     }
 }
 
+impl<I: Iterator, F: CoalescePredicate<I::Item, T>, T> FusedIterator for CoalesceBy<I, F, T> {}
+
 /// An iterator adaptor that removes repeated duplicates, determining equality using a comparison function.
 ///
 /// See [`.dedup_by()`](../trait.Itertools.html#method.dedup_by) or [`.dedup()`](../trait.Itertools.html#method.dedup) for more information.
@@ -812,8 +814,6 @@ pub fn dedup_with_count<I>(iter: I) -> DedupWithCount<I>
 {
     dedup_by_with_count(iter, DedupEq)
 }
-
-impl<I: Iterator, Pred: DedupPredicate<I::Item>> FusedIterator for DedupByWithCount<I, Pred> {}
 
 /// An iterator adaptor that borrows from a `Clone`-able iterator
 /// to only pick off elements while the predicate returns `true`.

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -649,12 +649,12 @@ impl<I, T> CoalesceCore<I, T>
 ///
 /// See [`.coalesce()`](../trait.Itertools.html#method.coalesce) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-pub type Coalesce<I, F> = CoalesceBy<I, F>;
+pub type Coalesce<I, F> = CoalesceBy<I, F, <I as Iterator>::Item>;
 
-pub struct CoalesceBy<I, F>
+pub struct CoalesceBy<I, F, T>
     where I: Iterator
 {
-    iter: CoalesceCore<I, I::Item>,
+    iter: CoalesceCore<I, T>,
     f: F,
 }
 
@@ -670,16 +670,15 @@ impl<F, Item, T> CoalescePredicate<Item, T> for F
     }
 }
 
-impl<I: Clone, F: Clone> Clone for CoalesceBy<I, F>
+impl<I: Clone, F: Clone, T: Clone> Clone for CoalesceBy<I, F, T>
     where I: Iterator,
-          I::Item: Clone
 {
     clone_fields!(iter, f);
 }
 
-impl<I, F> fmt::Debug for CoalesceBy<I, F>
+impl<I, F, T> fmt::Debug for CoalesceBy<I, F, T>
     where I: Iterator + fmt::Debug,
-          I::Item: fmt::Debug,
+          T: fmt::Debug,
 {
     debug_fmt_fields!(CoalesceBy, iter);
 }
@@ -697,11 +696,11 @@ pub fn coalesce<I, F>(mut iter: I, f: F) -> Coalesce<I, F>
     }
 }
 
-impl<I, F> Iterator for CoalesceBy<I, F>
+impl<I, F, T> Iterator for CoalesceBy<I, F, T>
     where I: Iterator,
-          F: CoalescePredicate<I::Item, I::Item>
+          F: CoalescePredicate<I::Item, T>
 {
-    type Item = I::Item;
+    type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
         let f = &mut self.f;

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -754,6 +754,29 @@ quickcheck! {
 }
 
 quickcheck! {
+    fn dedup_via_coalesce(a: Vec<i32>) -> bool {
+        let mut b = a.clone();
+        b.dedup();
+        itertools::equal(
+            &b,
+            a
+                .iter()
+                .coalesce(|x, y| {
+                    if x==y {
+                        Ok(x)
+                    } else {
+                        Err((x, y))
+                    }
+                })
+                .fold(vec![], |mut v, n| {
+                    v.push(n);
+                    v
+                })
+        )
+    }
+}
+
+quickcheck! {
     fn equal_dedup(a: Vec<i32>) -> bool {
         let mut b = a.clone();
         b.dedup();

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -110,6 +110,26 @@ fn dedup() {
 }
 
 #[test]
+fn coalesce() {
+    let data = vec![-1., -2., -3., 3., 1., 0., -1.];
+    let it = data.iter().cloned().coalesce(|x, y|
+        if (x >= 0.) == (y >= 0.) {
+            Ok(x + y)
+        } else {
+            Err((x, y))
+        }
+    );
+    itertools::assert_equal(it.clone(), vec![-6., 4., -1.]);
+    assert_eq!(
+        it.fold(vec![], |mut v, n| {
+            v.push(n);
+            v
+        }),
+        vec![-6., 4., -1.]
+    );
+}
+
+#[test]
 fn dedup_by() {
     let xs = [(0, 0), (0, 1), (1, 1), (2, 1), (0, 2), (3, 1), (0, 3), (1, 3)];
     let ys = [(0, 0), (0, 1), (0, 2), (3, 1), (0, 3)];


### PR DESCRIPTION
During the discussion of https://github.com/rust-itertools/itertools/pull/423#issuecomment-629713830, we found that `DedupBy`/`DedupByWithCount` could actually be implemented in terms of `Coalesce`. This simplifies the implementation quite a bit and lets derived adaptors inherit specializations.

* Implement `fold` on `Coalesce` so that all the adaptors derived from it inherit the specialization (currently, only `DedupBy` has this specialization).
* Introduce `CoalescePredicate` (similar to `DedupPredicate`) to allow for different customizations of `Coalesce`.
* Introduce parametrizable `CoalesceBy`: Base for `Coalesce`, `DedupBy`, `DedupByWithCount`.
* Implement `DedupBy`/`DedupByWithCount` in terms of `CoalesceBy` (using particular `impl`s).
* At last, the indirection through `CoalesceCore` is not needed anymore.