### PR TITLE
Try temporary fix for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,31 @@ sudo: false
 matrix:
   include:
     - rust: 1.32.0
+      script:
+        - |
+            cargo build --verbose --no-default-features &&
+            cargo build --verbose --features "$FEATURES"
     - rust: stable
+      script:
+        - |
+            cargo build --verbose --no-default-features &&
+            cargo build --verbose --features "$FEATURES" &&
+            cargo test --verbose --features "$FEATURES" &&
+            cargo bench --no-run --verbose --features "$FEATURES"
     - rust: beta
+      script:
+        - |
+            cargo build --verbose --no-default-features &&
+            cargo build --verbose --features "$FEATURES" &&
+            cargo test --verbose --features "$FEATURES" &&
+            cargo bench --no-run --verbose --features "$FEATURES"
     - rust: nightly
+      script:
+        - |
+            cargo build --verbose --no-default-features &&
+            cargo build --verbose --features "$FEATURES" &&
+            cargo test --verbose --features "$FEATURES" &&
+            cargo bench --no-run --verbose --features "$FEATURES"
 cache: cargo # https://docs.travis-ci.com/user/languages/rust/#dependency-management
 branches:
   only:
@@ -13,9 +35,3 @@ branches:
     # bors branches
     - staging
     - trying
-script:
-  - |
-      cargo build --verbose --no-default-features &&
-      cargo build --verbose --features "$FEATURES" &&
-      cargo test --verbose --features "$FEATURES" &&
-      cargo bench --no-run --verbose --features "$FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ either = { version = "1.0", default-features = false }
 
 [dev-dependencies]
 rand = "0.7"
-criterion = "=0.3.0" # TODO update criterion version once it becomes compatible with our minimum required Rust verision or bump minimum required rust version
+criterion = "=0" # TODO how could this work with our minimum supported rust version?
 
 [dev-dependencies.quickcheck]
 version = "0.9"


### PR DESCRIPTION
Unfortunately, I was not able to implement the idea @jswrenn suggested in https://github.com/rust-itertools/itertools/pull/444#issuecomment-636354286 (having an optional `dev-dependency` seems to be a problem).

Thus, I adapted @jswrenn's attempt from https://github.com/rust-itertools/itertools/pull/407/commits/3f9e669bc6f279d738f9c845c14cf550ffde9315 so that our MSRV only `build`s while stable/beta/nightly also test and bench.

To be honest, this feels pretty unsastisfactorily, but it may for now be a viable option that avoids blocking all PRs just because of a compilation error in a `dev-dependency`. Another possibility might be to downgrade `criterion`'s version (or abandon `criterion` altogether), both not particularly appealing imho.

When releasing a new version, we could still try to have one test/bench run on our MSVC (possibly with a manually adjusted `criterion` version).

(Sorry for all the noise from my side, but I'd really like to settle these kinds of problems so that we enable people to contribute without much inconvenience.)