### PR TITLE
Improve `tuple_windows()` doc (add a reference to `pairwise`)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,6 +561,8 @@ pub trait Itertools : Iterator {
     /// ```
     /// use itertools::Itertools;
     /// let mut v = Vec::new();
+    ///
+    /// // pairwise iteration
     /// for (a, b) in (1..5).tuple_windows() {
     ///     v.push((a, b));
     /// }


### PR DESCRIPTION
As shown in #388, tuple_windows can be hard to find if you come from other
environment (python, RxJs, …) since people may expect to find a `pairwise()`
method instead.