### PR TITLE
Cleanup

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -403,12 +403,6 @@ impl<B, F, I> Iterator for Batching<I, F>
     fn next(&mut self) -> Option<Self::Item> {
         (self.f)(&mut self.iter)
     }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        // No information about closue behavior
-        (0, None)
-    }
 }
 
 /// An iterator adaptor that steps a number elements in the base iterator

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -854,8 +854,7 @@ impl<'a, I, F> Iterator for TakeWhileRef<'a, I, F>
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let (_, hi) = self.iter.size_hint();
-        (0, hi)
+        (0, self.iter.size_hint().1)
     }
 }
 
@@ -887,8 +886,7 @@ impl<I, A> Iterator for WhileSome<I>
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let sh = self.iter.size_hint();
-        (0, sh.1)
+        (0, self.iter.size_hint().1)
     }
 }
 

--- a/src/intersperse.rs
+++ b/src/intersperse.rs
@@ -115,7 +115,7 @@ impl<I, ElemF> Iterator for IntersperseWith<I, ElemF>
 {
     type Item = I::Item;
     #[inline]
-    fn next(&mut self) -> Option<I::Item> {
+    fn next(&mut self) -> Option<Self::Item> {
         if self.peek.is_some() {
             self.peek.take()
         } else {

--- a/src/peeking_take_while.rs
+++ b/src/peeking_take_while.rs
@@ -104,8 +104,7 @@ impl<'a, I, F> Iterator for PeekingTakeWhile<'a, I, F>
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let (_, hi) = self.iter.size_hint();
-        (0, hi)
+        (0, self.iter.size_hint().1)
     }
 }
 

--- a/src/process_results_impl.rs
+++ b/src/process_results_impl.rs
@@ -28,8 +28,7 @@ impl<'a, I, T, E> Iterator for ProcessResults<'a, I, E>
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let (_, hi) = self.iter.size_hint();
-        (0, hi)
+        (0, self.iter.size_hint().1)
     }
 }
 

--- a/src/rciter_impl.rs
+++ b/src/rciter_impl.rs
@@ -69,8 +69,7 @@ impl<A, I> Iterator for RcIter<I>
         // To work sanely with other API that assume they own an iterator,
         // so it can't change in other places, we can't guarantee as much
         // in our size_hint. Other clones may drain values under our feet.
-        let (_, hi) = self.rciter.borrow().size_hint();
-        (0, hi)
+        (0, self.rciter.borrow().size_hint().1)
     }
 }
 

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -131,12 +131,6 @@ impl<A, St, F> Iterator for Unfold<St, F>
     fn next(&mut self) -> Option<Self::Item> {
         (self.f)(&mut self.state)
     }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        // no possible known bounds at this point
-        (0, None)
-    }
 }
 
 /// An iterator that infinitely applies function to value and yields results.

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -81,7 +81,7 @@ impl<I, V, F> DoubleEndedIterator for UniqueBy<I, V, F>
           V: Eq + Hash,
           F: FnMut(&I::Item) -> V
 {
-    fn next_back(&mut self) -> Option<I::Item> {
+    fn next_back(&mut self) -> Option<Self::Item> {
         while let Some(v) = self.iter.next_back() {
             let key = (self.f)(&v);
             if self.used.insert(key, ()).is_none() {
@@ -124,7 +124,7 @@ impl<I> DoubleEndedIterator for Unique<I>
     where I: DoubleEndedIterator,
           I::Item: Eq + Hash + Clone
 {
-    fn next_back(&mut self) -> Option<I::Item> {
+    fn next_back(&mut self) -> Option<Self::Item> {
         while let Some(v) = self.iter.iter.next_back() {
             if let Entry::Vacant(entry) = self.iter.used.entry(v) {
                 let elt = entry.key().clone();


### PR DESCRIPTION
This implements some cleanups:

* Do not implement `size_hint` if it could be inherited from `Iterator`
* Implement `(0, internal_iter.size_hint().1)` size hints uniformly
* Canonicalize return types of `next`/`next_back`

Since it's "only" cleanups, I hope it is ok if I merge them right away.

bors r+