### PR TITLE
Add Itertools::filter_common.

### DIFF
--- a/src/filter_common.rs
+++ b/src/filter_common.rs
@@ -17,6 +17,7 @@ impl<I, K> FilterCommon<I, K>
         I: Iterator,
         K: PartialEq<I::Item>,
 {
+    /// Remove the first instance of an item from the filter list, returning true if an item was removed.
     fn remove_item(&mut self, item: &I::Item) -> bool {
         if let Some(index) = self.filter_list.iter().position(|x| x == item) {
             self.filter_list.remove(index);
@@ -47,7 +48,10 @@ impl<I, K> Iterator for FilterCommon<I, K>
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
+            // Return None if we've reached the end of the iterator.
             let item = self.iterator.next()?;
+            // If the element from the iterator doesn't match an element in the filter list, return true.
+            // Otherwise get the next element.
             if !self.remove_item(&item) {
                 return Some(item);
             }

--- a/src/filter_common.rs
+++ b/src/filter_common.rs
@@ -1,0 +1,56 @@
+/// Filters items from the original iterator that exist in the filter list.
+///
+/// Iterator element type is `I::Item`.
+///
+/// See [`.filter_common()`](../trait.Itertools.html#method.filter_common) for more information.
+pub struct FilterCommon<I, K>
+    where
+        I: Iterator,
+        K: PartialEq<I::Item>,
+{
+    iterator: I,
+    filter_list: Vec<K>,
+}
+
+impl<I, K> FilterCommon<I, K>
+    where
+        I: Iterator,
+        K: PartialEq<I::Item>,
+{
+    fn remove_item(&mut self, item: &I::Item) -> bool {
+        if let Some(index) = self.filter_list.iter().position(|x| x == item) {
+            self.filter_list.remove(index);
+            return true;
+        }
+        false
+    }
+}
+
+/// Create a new **FilterCommon** iterator.
+pub fn filter_common<I, K>(iterator: I, filter_list: Vec<K>) -> FilterCommon<I, K>
+    where
+        I: Iterator,
+        K: PartialEq<I::Item>,
+{
+    FilterCommon {
+        iterator,
+        filter_list,
+    }
+}
+
+impl<I, K> Iterator for FilterCommon<I, K>
+    where
+        I: Iterator,
+        K: PartialEq<I::Item>,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let item = self.iterator.next()?;
+            if !self.remove_item(&item) {
+                return Some(item);
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,8 @@ pub mod structs {
     pub use crate::combinations_with_replacement::CombinationsWithReplacement;
     pub use crate::cons_tuples_impl::ConsTuples;
     pub use crate::exactly_one_err::ExactlyOneError;
+    #[cfg(feature = "use_std")]
+    pub use crate::filter_common::FilterCommon;
     pub use crate::format::{Format, FormatWith};
     #[cfg(feature = "use_std")]
     pub use crate::groupbylazy::{IntoChunks, Chunk, Chunks, GroupBy, Group, Groups};
@@ -178,6 +180,8 @@ mod combinations;
 mod combinations_with_replacement;
 mod exactly_one_err;
 mod diff;
+#[cfg(feature = "use_std")]
+mod filter_common;
 mod format;
 #[cfg(feature = "use_std")]
 mod group_map;
@@ -2772,6 +2776,31 @@ pub trait Itertools : Iterator {
         Self: Sized,
     {
         multipeek_impl::multipeek(self)
+    }
+
+    /// Filters items from the original iterator that exist in the filter list.
+    /// Elements are removed from the vec when they are matched, meaning if there are n instances
+    /// of an element in the iterator and k instances in the filter list, then the last (n - k)
+    /// instances will remain in the new iterator.
+    ///
+    /// # Examples
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let filter_list = vec![1i32, 2, 2];
+    /// let mut iter = vec![0i32, 0, 1, 1, 2, 2].into_iter().filter_common(filter_list);
+    /// assert_eq!(iter.next(), Some(0));
+    /// assert_eq!(iter.next(), Some(0));
+    /// assert_eq!(iter.next(), Some(1));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    #[cfg(feature = "use_std")]
+    fn filter_common<K>(self, filter_list: Vec<K>) -> FilterCommon<Self, K>
+        where
+            Self: Sized,
+            K: PartialEq<Self::Item>
+    {
+        filter_common::filter_common(self, filter_list)
     }
 }
 

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -913,3 +913,25 @@ fn tree_fold1() {
         assert_eq!(actual, expected);
     }
 }
+
+#[test]
+fn filter_common() {
+    let filter_list = vec![5, 5, 5, 5, 5];
+    for n in 1..=5 {
+        let mut iter = std::iter::repeat(5).take(n).filter_common(filter_list.clone());
+        assert_eq!(iter.next(), None);
+    }
+    let filter_list = vec![1, 2, 3, 4, 5];
+    let mut iter = vec![1, 2, 3, 4, 5, 4, 3, 2, 1].into_iter().filter_common(filter_list);
+    assert_eq!(iter.next(), Some(4));
+    assert_eq!(iter.next(), Some(3));
+    assert_eq!(iter.next(), Some(2));
+    assert_eq!(iter.next(), Some(1));
+    assert_eq!(iter.next(), None);
+    let filter_list = vec![1, 2, 2, 3, 3, 3, 4, 4, 4, 4];
+    let mut iter = vec![1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4].into_iter().filter_common(filter_list);
+    assert_eq!(iter.next(), Some(1));
+    assert_eq!(iter.next(), Some(1));
+    assert_eq!(iter.next(), Some(2));
+    assert_eq!(iter.next(), None);
+}


### PR DESCRIPTION
This came about due to a situation where I needed to remove different combinations of items from an iterator, with the catch that I only wanted to remove the exact values, so duplicates were not all removed, meaning I couldn't simply filter. I'll admit this is fairly niche, and there are still a few outstanding questions I have:

- I'm fairly unsure of the terminology used here. I've tried to search around for similar concepts but I couldn't find anything that wasn't more analagous to a simple filter. If anyone has any other suggestions I'd be very appreciative. Even thinking about it now it should probably be something along the lines of filter_exclusive.
- It seems logical that when removing items from the filter list it would be more efficient to remove the last item, rather than the first if duplicates are present, but I haven't done any benchmarking and I'm not sure if it's worth the additional complexity, although admittedly it shouldn't be too bad.
- I don't think there's another adaptor that takes a Vec as an argument to the method, and while it would be more efficient in the case where the filter list is constructed as a vector to take it as an argument, rather than converting to an iterator and back, I realise there isn't a precedent for this.