### PR TITLE
Clean up specializations tests

### DIFF
--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -18,7 +18,6 @@ where
 fn check_specialized<'a, V, IterItem, Iter, F>(iterator: &Iter, mapper: F)
 where
     V: Eq + Debug,
-    IterItem: 'a,
     Iter: Iterator<Item = IterItem> + Clone + 'a,
     F: Fn(Box<dyn Iterator<Item = IterItem> + 'a>) -> V,
 {
@@ -28,12 +27,12 @@ where
     )
 }
 
-fn check_specialized_count_last_nth_sizeh<'a, IterItem, Iter>(
+fn check_specialized_count_last_nth_sizeh<IterItem, Iter>(
     it: &Iter,
     known_expected_size: Option<usize>,
 ) where
-    IterItem: 'a + Eq + Debug,
-    Iter: Iterator<Item = IterItem> + Clone + 'a,
+    IterItem: Eq + Debug,
+    Iter: Iterator<Item = IterItem> + Clone,
 {
     let size = it.clone().count();
     if let Some(expected_size) = known_expected_size {

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -27,7 +27,7 @@ where
     )
 }
 
-fn check_specialized_count_last_nth_sizeh<IterItem, Iter>(
+fn test_specializations<IterItem, Iter>(
     it: &Iter,
     known_expected_size: Option<usize>,
 ) where
@@ -69,12 +69,12 @@ fn put_back_test(test_vec: Vec<i32>, known_expected_size: Option<usize>) {
     {
         // Lexical lifetimes support
         let pb = itertools::put_back(test_vec.iter());
-        check_specialized_count_last_nth_sizeh(&pb, known_expected_size);
+        test_specializations(&pb, known_expected_size);
     }
 
     let mut pb = itertools::put_back(test_vec.into_iter());
     pb.put_back(1);
-    check_specialized_count_last_nth_sizeh(&pb, known_expected_size.map(|x| x + 1));
+    test_specializations(&pb, known_expected_size.map(|x| x + 1));
 }
 
 #[test]
@@ -92,11 +92,11 @@ fn merge_join_by_test(i1: Vec<usize>, i2: Vec<usize>, known_expected_size: Optio
     let i1 = i1.into_iter();
     let i2 = i2.into_iter();
     let mjb = i1.clone().merge_join_by(i2.clone(), std::cmp::Ord::cmp);
-    check_specialized_count_last_nth_sizeh(&mjb, known_expected_size);
+    test_specializations(&mjb, known_expected_size);
 
     // And the other way around
     let mjb = i2.merge_join_by(i1, std::cmp::Ord::cmp);
-    check_specialized_count_last_nth_sizeh(&mjb, known_expected_size);
+    test_specializations(&mjb, known_expected_size);
 }
 
 #[test]

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -84,11 +84,6 @@ fn put_back_test(test_vec: Vec<i32>) {
     test_specializations(&pb);
 }
 
-#[test]
-fn put_back() {
-    put_back_test(vec![7, 4, 1]);
-}
-
 quickcheck! {
     fn put_back_qc(test_vec: Vec<i32>) -> () {
         put_back_test(test_vec)
@@ -104,13 +99,6 @@ fn merge_join_by_test(i1: Vec<usize>, i2: Vec<usize>) {
     // And the other way around
     let mjb = i2.merge_join_by(i1, std::cmp::Ord::cmp);
     test_specializations(&mjb);
-}
-
-#[test]
-fn merge_join_by() {
-    let i1 = vec![1, 3, 5, 7, 8, 9];
-    let i2 = vec![0, 3, 4, 5];
-    merge_join_by_test(i1, i2);
 }
 
 quickcheck! {

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -13,11 +13,6 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
     }
-
-    #[inline(always)]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.0.size_hint()
-    }
 }
 
 fn check_specialized<'a, V, IterItem, Iter, F>(iterator: &Iter, mapper: F)

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -29,15 +29,11 @@ where
 
 fn test_specializations<IterItem, Iter>(
     it: &Iter,
-    known_expected_size: Option<usize>,
 ) where
     IterItem: Eq + Debug + Clone,
     Iter: Iterator<Item = IterItem> + Clone,
 {
     let size = it.clone().count();
-    if let Some(expected_size) = known_expected_size {
-        assert_eq!(size, expected_size);
-    }
     check_specialized(it, |i| i.count());
     check_specialized(it, |i| i.last());
     for n in 0..size + 2 {
@@ -65,49 +61,49 @@ fn test_specializations<IterItem, Iter>(
     });
 }
 
-fn put_back_test(test_vec: Vec<i32>, known_expected_size: Option<usize>) {
+fn put_back_test(test_vec: Vec<i32>) {
     {
         // Lexical lifetimes support
         let pb = itertools::put_back(test_vec.iter());
-        test_specializations(&pb, known_expected_size);
+        test_specializations(&pb);
     }
 
     let mut pb = itertools::put_back(test_vec.into_iter());
     pb.put_back(1);
-    test_specializations(&pb, known_expected_size.map(|x| x + 1));
+    test_specializations(&pb);
 }
 
 #[test]
 fn put_back() {
-    put_back_test(vec![7, 4, 1], Some(3));
+    put_back_test(vec![7, 4, 1]);
 }
 
 quickcheck! {
     fn put_back_qc(test_vec: Vec<i32>) -> () {
-        put_back_test(test_vec, None)
+        put_back_test(test_vec)
     }
 }
 
-fn merge_join_by_test(i1: Vec<usize>, i2: Vec<usize>, known_expected_size: Option<usize>) {
+fn merge_join_by_test(i1: Vec<usize>, i2: Vec<usize>) {
     let i1 = i1.into_iter();
     let i2 = i2.into_iter();
     let mjb = i1.clone().merge_join_by(i2.clone(), std::cmp::Ord::cmp);
-    test_specializations(&mjb, known_expected_size);
+    test_specializations(&mjb);
 
     // And the other way around
     let mjb = i2.merge_join_by(i1, std::cmp::Ord::cmp);
-    test_specializations(&mjb, known_expected_size);
+    test_specializations(&mjb);
 }
 
 #[test]
 fn merge_join_by() {
     let i1 = vec![1, 3, 5, 7, 8, 9];
     let i2 = vec![0, 3, 4, 5];
-    merge_join_by_test(i1, i2, Some(8));
+    merge_join_by_test(i1, i2);
 }
 
 quickcheck! {
     fn merge_join_by_qc(i1: Vec<usize>, i2: Vec<usize>) -> () {
-        merge_join_by_test(i1, i2, None)
+        merge_join_by_test(i1, i2)
     }
 }

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -72,37 +72,17 @@ fn test_specializations<IterItem, Iter>(
     }
 }
 
-fn put_back_test(test_vec: Vec<i32>) {
-    {
-        // Lexical lifetimes support
-        let pb = itertools::put_back(test_vec.iter());
-        test_specializations(&pb);
-    }
-
-    let mut pb = itertools::put_back(test_vec.into_iter());
-    pb.put_back(1);
-    test_specializations(&pb);
-}
-
 quickcheck! {
     fn put_back_qc(test_vec: Vec<i32>) -> () {
-        put_back_test(test_vec)
+        test_specializations(&itertools::put_back(test_vec.iter()));
+        let mut pb = itertools::put_back(test_vec.into_iter());
+        pb.put_back(1);
+        test_specializations(&pb);
     }
-}
-
-fn merge_join_by_test(i1: Vec<usize>, i2: Vec<usize>) {
-    let i1 = i1.into_iter();
-    let i2 = i2.into_iter();
-    let mjb = i1.clone().merge_join_by(i2.clone(), std::cmp::Ord::cmp);
-    test_specializations(&mjb);
-
-    // And the other way around
-    let mjb = i2.merge_join_by(i1, std::cmp::Ord::cmp);
-    test_specializations(&mjb);
 }
 
 quickcheck! {
     fn merge_join_by_qc(i1: Vec<usize>, i2: Vec<usize>) -> () {
-        merge_join_by_test(i1, i2)
+        test_specializations(&i1.into_iter().merge_join_by(i2.into_iter(), std::cmp::Ord::cmp));
     }
 }

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -31,7 +31,7 @@ fn check_specialized_count_last_nth_sizeh<IterItem, Iter>(
     it: &Iter,
     known_expected_size: Option<usize>,
 ) where
-    IterItem: Eq + Debug,
+    IterItem: Eq + Debug + Clone,
     Iter: Iterator<Item = IterItem> + Clone,
 {
     let size = it.clone().count();
@@ -54,13 +54,6 @@ fn check_specialized_count_last_nth_sizeh<IterItem, Iter>(
         }
         it_sh.next();
     }
-}
-
-fn check_specialized_fold<IterItem, Iter>(it: &Iter)
-where
-    IterItem: Eq + Debug + Clone,
-    Iter: Iterator<Item = IterItem> + Clone,
-{
     check_specialized(it, |i| {
         let mut parameters_from_fold = vec![];
         let fold_result = i.fold(vec![], |mut acc, v: IterItem| {
@@ -77,13 +70,11 @@ fn put_back_test(test_vec: Vec<i32>, known_expected_size: Option<usize>) {
         // Lexical lifetimes support
         let pb = itertools::put_back(test_vec.iter());
         check_specialized_count_last_nth_sizeh(&pb, known_expected_size);
-        check_specialized_fold(&pb);
     }
 
     let mut pb = itertools::put_back(test_vec.into_iter());
     pb.put_back(1);
     check_specialized_count_last_nth_sizeh(&pb, known_expected_size.map(|x| x + 1));
-    check_specialized_fold(&pb)
 }
 
 #[test]
@@ -102,12 +93,10 @@ fn merge_join_by_test(i1: Vec<usize>, i2: Vec<usize>, known_expected_size: Optio
     let i2 = i2.into_iter();
     let mjb = i1.clone().merge_join_by(i2.clone(), std::cmp::Ord::cmp);
     check_specialized_count_last_nth_sizeh(&mjb, known_expected_size);
-    check_specialized_fold(&mjb);
 
     // And the other way around
     let mjb = i2.merge_join_by(i1, std::cmp::Ord::cmp);
     check_specialized_count_last_nth_sizeh(&mjb, known_expected_size);
-    check_specialized_fold(&mjb);
 }
 
 #[test]


### PR DESCRIPTION
In response to this comment https://github.com/rust-itertools/itertools/issues/413#issuecomment-657670781:

> If the contribution is an optimized specialization of an `Iterator` method (such as `nth` or `fold`), the specialization needs to be very thoroughly tested (preferably with quickcheck tests) to ensure it behaves identically (_especially_ on edge cases, and with when it panics).

I thought about having a simple way to test specializations: If we had *one* test function testing all specializations, we would have an easy way to quickcheck specializations for our iterators.

We already had quite a bit in place, so I took it and streamlined it a bit.

* `fold` is tested by remembering all elements provided to the closure (instead of only XORing elements).
* cleaned up some things (unused specialization of `size_hint`, some redundant lifetimes, superfluous arguments)
* test all specializations in one function (instead of only some specializations in two functions)
* remove manual special case tests in favor of quickcheck'd ones

If we decide to do it like this, we can, in a future commit, just do the following for all iterators (possibly via a macro) to test specializations uniformly (and hopefully reliably):

```
quickcheck! {
    fn test_specializations_qc(params_for_iterator) -> () {
        test_specializations(&make_iterator_to_be_tested(params_for_iterator));
    }
}
```

This way, we would also test methods that are not even specialized, but for simplicity, I'd be willing to accept this. If we see that it slows things down considerably, we could still devise a simple solution that would allow to specify the methods to be tested.