### PR TITLE
Unify convenience map functions

### DIFF
--- a/src/adaptors/map.rs
+++ b/src/adaptors/map.rs
@@ -1,0 +1,120 @@
+use std::iter::FromIterator;
+use std::marker::PhantomData;
+
+#[derive(Clone)]
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct MapSpecialCase<I, F> {
+    iter: I,
+    f: F,
+}
+
+pub trait MapSpecialCaseFn<T> {
+    type Out;
+    fn call(&mut self, t: T) -> Self::Out;
+}
+
+impl<I, R> Iterator for MapSpecialCase<I, R>
+where
+    I: Iterator,
+    R: MapSpecialCaseFn<I::Item>,
+{
+    type Item = R::Out;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|i| self.f.call(i))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
+    fn fold<Acc, Fold>(self, init: Acc, mut fold_f: Fold) -> Acc
+    where
+        Fold: FnMut(Acc, Self::Item) -> Acc,
+    {
+        let mut f = self.f;
+        self.iter.fold(init, move |acc, v| fold_f(acc, f.call(v)))
+    }
+
+    fn collect<C>(self) -> C
+    where
+        C: FromIterator<Self::Item>,
+    {
+        let mut f = self.f;
+        self.iter.map(move |v| f.call(v)).collect()
+    }
+}
+
+impl<I, R> DoubleEndedIterator for MapSpecialCase<I, R>
+where
+    I: DoubleEndedIterator,
+    R: MapSpecialCaseFn<I::Item>,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(|i| self.f.call(i))
+    }
+}
+
+impl<I, R> ExactSizeIterator for MapSpecialCase<I, R>
+where
+    I: ExactSizeIterator,
+    R: MapSpecialCaseFn<I::Item>,
+{
+}
+
+/// An iterator adapter to apply a transformation within a nested `Result::Ok`.
+///
+/// See [`.map_ok()`](../trait.Itertools.html#method.map_ok) for more information.
+pub type MapOk<I, F> = MapSpecialCase<I, MapSpecialCaseFnOk<F>>;
+
+/// See [`MapOk`](struct.MapOk.html).
+#[deprecated(note = "Use MapOk instead", since = "0.10")]
+pub type MapResults<I, F> = MapOk<I, F>;
+
+impl<F, T, U, E> MapSpecialCaseFn<Result<T, E>> for MapSpecialCaseFnOk<F>
+where
+    F: FnMut(T) -> U,
+{
+    type Out = Result<U, E>;
+    fn call(&mut self, t: Result<T, E>) -> Self::Out {
+        t.map(|v| self.0(v))
+    }
+}
+
+#[derive(Clone)]
+pub struct MapSpecialCaseFnOk<F>(F);
+
+/// Create a new `MapOk` iterator.
+pub fn map_ok<I, F, T, U, E>(iter: I, f: F) -> MapOk<I, F>
+where
+    I: Iterator<Item = Result<T, E>>,
+    F: FnMut(T) -> U,
+{
+    MapSpecialCase {
+        iter,
+        f: MapSpecialCaseFnOk(f),
+    }
+}
+
+/// An iterator adapter to apply `Into` conversion to each element.
+///
+/// See [`.map_into()`](../trait.Itertools.html#method.map_into) for more information.
+pub type MapInto<I, R> = MapSpecialCase<I, MapSpecialCaseFnInto<R>>;
+
+impl<T: Into<U>, U> MapSpecialCaseFn<T> for MapSpecialCaseFnInto<U> {
+    type Out = U;
+    fn call(&mut self, t: T) -> Self::Out {
+        t.into()
+    }
+}
+
+#[derive(Clone)]
+pub struct MapSpecialCaseFnInto<U>(PhantomData<U>);
+
+/// Create a new [`MapInto`](struct.MapInto.html) iterator.
+pub fn map_into<I, R>(iter: I) -> MapInto<I, R> {
+    MapSpecialCase {
+        iter,
+        f: MapSpecialCaseFnInto(PhantomData),
+    }
+}

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -863,6 +863,13 @@ impl<I, R> Iterator for MapSpecialCase<I, R>
         let mut f = self.f;
         self.iter.fold(init, move |acc, v| fold_f(acc, f.call(v)))
     }
+
+    fn collect<C>(self) -> C
+        where C: FromIterator<Self::Item>
+    {
+        let mut f = self.f;
+        self.iter.map(move |v| f.call(v)).collect()
+    }
 }
 
 impl<I, R> DoubleEndedIterator for MapSpecialCase<I, R>

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -8,7 +8,9 @@ mod coalesce;
 mod map;
 mod multi_product;
 pub use self::coalesce::*;
-pub use self::map::*;
+pub use self::map::{map_into, map_ok, MapInto, MapOk};
+#[allow(deprecated)]
+pub use self::map::MapResults;
 #[cfg(feature = "use_std")]
 pub use self::multi_product::*;
 

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -5,8 +5,10 @@
 //! except according to those terms.
 
 mod coalesce;
+mod map;
 mod multi_product;
 pub use self::coalesce::*;
+pub use self::map::*;
 #[cfg(feature = "use_std")]
 pub use self::multi_product::*;
 
@@ -805,122 +807,6 @@ macro_rules! impl_tuple_combination {
 impl_tuple_combination!(Tuple2Combination Tuple1Combination ; A, A, A ; a);
 impl_tuple_combination!(Tuple3Combination Tuple2Combination ; A, A, A, A ; a b);
 impl_tuple_combination!(Tuple4Combination Tuple3Combination ; A, A, A, A, A; a b c);
-
-pub trait MapSpecialCaseFn<T> {
-    type Out;
-    fn call(&mut self, t: T) -> Self::Out;
-}
-
-#[derive(Clone)]
-pub struct MapSpecialCaseFnInto<U>(PhantomData<U>);
-
-impl<T: Into<U>, U> MapSpecialCaseFn<T> for MapSpecialCaseFnInto<U> {
-    type Out = U;
-    fn call(&mut self, t: T) -> Self::Out {
-        t.into()
-    }
-}
-
-#[derive(Clone)]
-#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-pub struct MapSpecialCase<I, F> {
-    iter: I,
-    f: F,
-}
-
-/// An iterator adapter to apply `Into` conversion to each element.
-///
-/// See [`.map_into()`](../trait.Itertools.html#method.map_into) for more information.
-pub type MapInto<I, R> = MapSpecialCase<I, MapSpecialCaseFnInto<R>>;
-
-/// Create a new [`MapInto`](struct.MapInto.html) iterator.
-pub fn map_into<I, R>(iter: I) -> MapInto<I, R> {
-    MapSpecialCase {
-        iter,
-        f: MapSpecialCaseFnInto(PhantomData),
-    }
-}
-
-impl<I, R> Iterator for MapSpecialCase<I, R>
-    where I: Iterator,
-          R: MapSpecialCaseFn<I::Item>,
-{
-    type Item = R::Out;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter
-            .next()
-            .map( |i| self.f.call(i))
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
-    }
-
-    fn fold<Acc, Fold>(self, init: Acc, mut fold_f: Fold) -> Acc
-        where Fold: FnMut(Acc, Self::Item) -> Acc,
-    {
-        let mut f = self.f;
-        self.iter.fold(init, move |acc, v| fold_f(acc, f.call(v)))
-    }
-
-    fn collect<C>(self) -> C
-        where C: FromIterator<Self::Item>
-    {
-        let mut f = self.f;
-        self.iter.map(move |v| f.call(v)).collect()
-    }
-}
-
-impl<I, R> DoubleEndedIterator for MapSpecialCase<I, R>
-    where I: DoubleEndedIterator,
-          R: MapSpecialCaseFn<I::Item>,
-{
-    fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter
-            .next_back()
-            .map(|i| self.f.call(i))
-    }
-}
-
-impl<I, R> ExactSizeIterator for MapSpecialCase<I, R>
-where
-    I: ExactSizeIterator,
-    R: MapSpecialCaseFn<I::Item>,
-{}
-
-/// See [`MapOk`](struct.MapOk.html).
-#[deprecated(note="Use MapOk instead", since="0.10")]
-pub type MapResults<I, F> = MapOk<I, F>;
-
-#[derive(Clone)]
-pub struct MapSpecialCaseFnOk<F>(F);
-
-impl<F, T, U, E> MapSpecialCaseFn<Result<T, E>> for MapSpecialCaseFnOk<F>
-    where
-        F: FnMut(T)->U
-{
-    type Out = Result<U, E>;
-    fn call(&mut self, t: Result<T, E>) -> Self::Out {
-        t.map(|v| self.0(v))
-    }
-}
-
-/// An iterator adapter to apply a transformation within a nested `Result::Ok`.
-///
-/// See [`.map_ok()`](../trait.Itertools.html#method.map_ok) for more information.
-pub type MapOk<I, F> = MapSpecialCase<I, MapSpecialCaseFnOk<F>>;
-
-/// Create a new `MapOk` iterator.
-pub fn map_ok<I, F, T, U, E>(iter: I, f: F) -> MapOk<I, F>
-    where I: Iterator<Item = Result<T, E>>,
-          F: FnMut(T) -> U,
-{
-    MapSpecialCase {
-        iter,
-        f: MapSpecialCaseFnOk(f),
-    }
-}
 
 /// An iterator adapter to filter values within a nested `Result::Ok`.
 ///

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -86,3 +86,15 @@ quickcheck! {
         test_specializations(&i1.into_iter().merge_join_by(i2.into_iter(), std::cmp::Ord::cmp));
     }
 }
+
+quickcheck! {
+    fn map_into(v: Vec<u8>) -> () {
+        test_specializations(&v.into_iter().map_into::<u32>());
+    }
+}
+
+quickcheck! {
+    fn map_ok(v: Vec<Result<u8, char>>) -> () {
+        test_specializations(&v.into_iter().map_ok(|u| u.checked_add(1)));
+    }
+}


### PR DESCRIPTION
In response to https://github.com/rust-itertools/itertools/pull/283: I think we should employ a uniform architecture for our `map`-specializations (as they already diverged). This PR is meant to unify the implementations so we essentially only need to parametrize the mapping function:

* Generalize `MapInto` to `MapSpecialCase` (which can be used as basis for all our map convenience functions) and define `MapInto` in terms of `MapSpecialCase`
* Specialize `collect` (was specialized on `MapOk`, so I guess we want to keep it for now)
* Define `MapOk` in terms of `MapSpecialCase`
* Simple tests for specialized `size_hint`, `fold`, `collect`
* As at this point probably all existing PRs involving `map_xyz` are conflicting anyway, move them to an own module (similar to `coalesce`)