### PR TITLE
Add into_grouping_map for efficient group-and-fold operations

### DIFF
--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -380,12 +380,32 @@ impl<I, K, V> GroupingMap<I>
         self.min_by(|v1, v2| f(&v1).cmp(&f(&v2)))
     }
 
+    /// Groups elements from the `GroupingMap` source by key and find the maximum and minimum of
+    /// each group.
+    /// 
+    /// See [.minmax_by()](../trait.Itertools.html#method.minmax) for the non-grouping version.
+    /// 
+    /// Differences from the non grouping version:
+    /// - It never produces a `MinMaxResult::NoElements`
+    /// - It doesn't have any speedup
+    /// 
+    /// Returns a `HashMap` associating the key of each group with the minimum and maximum of that group.
     pub fn minmax(self) -> HashMap<K, MinMaxResult<V>>
         where V: Ord,
     {
         self.minmax_by(V::cmp)
     }
 
+    /// Groups elements from the `GroupingMap` source by key and find the maximum and minimum of
+    /// each group with respect to the specified comparison function.
+    /// 
+    /// See [.minmax()](../trait.Itertools.html#method.minmax) for the non-grouping version.
+    /// 
+    /// Differences from the non grouping version:
+    /// - It never produces a `MinMaxResult::NoElements`
+    /// - It doesn't have any speedup
+    /// 
+    /// Returns a `HashMap` associating the key of each group with the minimum and maximum of that group.
     pub fn minmax_by<F>(self, mut compare: F) -> HashMap<K, MinMaxResult<V>>
         where F: FnMut(&V, &V) -> Ordering,
     {
@@ -413,6 +433,16 @@ impl<I, K, V> GroupingMap<I>
         })
     }
 
+    /// Groups elements from the `GroupingMap` source by key and find the elements of each group
+    /// that gives the minimum and maximum from the specified function.
+    /// 
+    /// See [.minmax()](../trait.Itertools.html#method.minmax) for the non-grouping version.
+    /// 
+    /// Differences from the non grouping version:
+    /// - It never produces a `MinMaxResult::NoElements`
+    /// - It doesn't have any speedup
+    /// 
+    /// Returns a `HashMap` associating the key of each group with the minimum and maximum of that group.
     pub fn minmax_by_key<F, CK>(self, mut f: F) -> HashMap<K, MinMaxResult<V>>
         where F: FnMut(&V) -> CK,
               CK: Ord,

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -37,10 +37,8 @@ pub fn new<I, K, V>(iter: I) -> GroupingMap<I>
 }
 
 /// `GroupingMapBy` is an intermediate struct for efficient group-and-fold operations.
-/// It groups elements by the key returned by the specified function and at the same
-/// time fold each group using some aggregating operation.
 /// 
-/// No method on this type performs temporary allocations.
+/// See [`GroupingMap`](./struct.GroupingMap.html) for more informations.
 #[must_use = "GroupingMapBy is lazy and do nothing unless consumed"]
 pub type GroupingMapBy<I, F> = GroupingMap<MapForGrouping<I, F>>;
 

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -30,6 +30,22 @@ where
     I: Iterator<Item = (K, V)>,
     K: Hash + Eq,
 {
+    /// Groups elements from the `GroupingMap` source by key and applies `operation` to the elements
+    /// of each group sequentially, passing the key, the previously accumulated value
+    /// and the current element as arguments, and stores the results in an `HashMap`.
+    ///
+    /// The `operation` function is invoked on each element with the following parameters:
+    ///  - a reference to the key of the group this element belongs to;
+    ///  - the current value of the accumulator of the group or `None` if it's the first element
+    ///    encountered in the group;
+    ///  - the element from the source being aggregated;
+    /// If `operation` returns `Some(element)` then the accumulator is updated with `element`,
+    /// otherwise the previous accumulation is discarded.
+    ///
+    /// Return a `HashMap` associating the key of each group with the result of aggregation of the group elements.
+    ///
+    /// This is the generic way to perform any operations on a `Grouping`.
+    /// It's suggested to use it only to implement custom operations when the already provided ones are not enough.
     pub fn aggregate<FO, R>(self, mut operation: FO) -> HashMap<K, R>
     where
         FO: FnMut(Option<R>, &K, V) -> Option<R>,

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -63,6 +63,7 @@ where
     /// assert_eq!(lookup[&1], 14);
     /// assert!(!lookup.contains_key(&2));
     /// assert_eq!(lookup[&3], 7);
+    /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn aggregate<FO, R>(self, mut operation: FO) -> HashMap<K, R>
     where

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -62,6 +62,18 @@ where
         destination_map
     }
 
+    /// Groups elements from the `GroupingMap` source by key and applies `operation` to the elements
+    /// of each group sequentially, passing the previously accumulated value, a reference to the key
+    /// and the current element as arguments, and stores the results in a new map.
+    ///
+    /// `init` is the value from which will be cloned the initial value of each accumulator.
+    ///
+    /// `operation` is a function that is invoked on each element with the following parameters:
+    ///  - the current value of the accumulator of the group;
+    ///  - a reference to the key of the group this element belongs to;
+    ///  - the element from the source being accumulated.
+    ///
+    /// Return a `HashMap` associating the key of each group with the result of folding the group elements.
     pub fn fold<FO, R>(self, init: R, mut operation: FO) -> HashMap<K, R>
     where
         R: Clone,

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::cmp::Ordering;
 use std::hash::Hash;
 use std::iter::Iterator;
+use std::ops::{Add, Mul};
 
 /// A wrapper to allow for an easy [`into_grouping_map_by`](../trait.Itertools.html#method.into_grouping_map_by)
 pub struct MapForGrouping<I, F>(I, F);
@@ -504,5 +505,55 @@ impl<I, K, V> GroupingMap<I>
               CK: Ord,
     {
         self.minmax_by(|v1, v2| f(&v1).cmp(&f(&v2)))
+    }
+    
+    /// Groups elements from the `GroupingMap` source by key and sums them.
+    /// 
+    /// This is just a shorthand for `self.fold_first(|acc, _, val| acc + val)`.
+    /// It is more limited than `Iterator::sum` since it doesn't use the `Sum` trait.
+    /// 
+    /// Returns a `HashMap` associating the key of each group with the sum of each group.
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// 
+    /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .sum();
+    /// 
+    /// assert_eq!(lookup[&0], 3 + 9 + 12);
+    /// assert_eq!(lookup[&1], 1 + 4 + 7);
+    /// assert_eq!(lookup[&2], 5 + 8);
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
+    pub fn sum(self) -> HashMap<K, V>
+        where V: Add<V, Output = V>
+    {
+        self.fold_first(|acc, _, val| acc + val)
+    }
+
+    /// Groups elements from the `GroupingMap` source by key and multiply them.
+    /// 
+    /// This is just a shorthand for `self.fold_first(|acc, _, val| acc * val)`.
+    /// It is more limited than `Iterator::product` since it doesn't use the `Product` trait.
+    /// 
+    /// Returns a `HashMap` associating the key of each group with the product of each group.
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// 
+    /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .product();
+    /// 
+    /// assert_eq!(lookup[&0], 3 * 9 * 12);
+    /// assert_eq!(lookup[&1], 1 * 4 * 7);
+    /// assert_eq!(lookup[&2], 5 * 8);
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
+    pub fn product(self) -> HashMap<K, V>
+        where V: Mul<V, Output = V>,
+    {
+        self.fold_first(|acc, _, val| acc * val)
     }
 }

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -30,7 +30,7 @@ where
     I: Iterator<Item = (K, V)>,
     K: Hash + Eq,
 {
-    pub fn aggregate<FO, R>(mut self, mut operation: FO) -> HashMap<K, R>
+    pub fn aggregate<FO, R>(self, mut operation: FO) -> HashMap<K, R>
     where
         FO: FnMut(Option<R>, &K, V) -> Option<R>,
     {

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -8,6 +8,7 @@ use std::iter::Iterator;
 use std::ops::{Add, Mul};
 
 /// A wrapper to allow for an easy [`into_grouping_map_by`](../trait.Itertools.html#method.into_grouping_map_by)
+#[derive(Clone, Debug)]
 pub struct MapForGrouping<I, F>(I, F);
 
 impl<I, F> MapForGrouping<I, F> {
@@ -46,6 +47,7 @@ pub type GroupingMapBy<I, F> = GroupingMap<MapForGrouping<I, F>>;
 /// using some aggregating operation.
 /// 
 /// No method on this struct performs temporary allocations.
+#[derive(Clone, Debug)]
 #[must_use = "GroupingMap is lazy and do nothing unless consumed"]
 pub struct GroupingMap<I> {
     iter: I,

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -103,9 +103,9 @@ where
     ///     .into_grouping_map()
     ///     .fold(0, |acc, _, val| acc + val);
     /// 
-    /// assert_eq!(lookup[&0], 9);
-    /// assert_eq!(lookup[&1], 12);
-    /// assert_eq!(lookup[&2], 7);
+    /// assert_eq!(lookup[&0], 9);   // 3 + 6
+    /// assert_eq!(lookup[&1], 12);  // 1 + 4 + 7
+    /// assert_eq!(lookup[&2], 7);   // 2 + 5
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn fold<FO, R>(self, init: R, mut operation: FO) -> HashMap<K, R>

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -192,6 +192,27 @@ where
     /// Groups elements from the `GroupingMap` source by key and counts them.
     /// 
     /// Return a `HashMap` associating the key of each group with the number of elements in that group.
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// 
+    /// let lookup = "This is a string".chars()
+    ///     .map(|c| (c, c))
+    ///     .into_grouping_map()
+    ///     .count();
+    /// 
+    /// assert_eq!(lookup[&'T'], 1);
+    /// assert_eq!(lookup[&'h'], 1);
+    /// assert_eq!(lookup[&'i'], 3);
+    /// assert_eq!(lookup[&'s'], 3);
+    /// assert_eq!(lookup[&' '], 3);
+    /// assert_eq!(lookup[&'a'], 1);
+    /// assert_eq!(lookup[&'t'], 1);
+    /// assert_eq!(lookup[&'r'], 1);
+    /// assert_eq!(lookup[&'n'], 1);
+    /// assert_eq!(lookup[&'g'], 1);
+    /// assert_eq!(lookup.len(), 10);
+    /// ```
     pub fn count(self) -> HashMap<K, usize> {
         self.fold(0, |acc, _, _| acc + 1)
     }

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -48,22 +48,23 @@ where
     /// ```
     /// use itertools::Itertools;
     /// 
-    /// let data = vec![10, 5, 7, 9, 0, 4, 2];
+    /// let data = vec![2, 8, 5, 7, 9, 0, 4, 10];
     /// let lookup = data.into_iter()
     ///     .map(|n| (n % 4, n))
     ///     .into_grouping_map()
     ///     .aggregate(|acc, _, val| {
-    ///         match val {
-    ///             0 | 2 => None,
-    ///             _ => Some(acc.unwrap_or(0) + val)
+    ///         if val == 0 || val == 10 {
+    ///             None
+    ///         } else {
+    ///             Some(acc.unwrap_or(0) + val)
     ///         }
     ///     });
     /// 
-    /// assert_eq!(lookup[&0], 4);
-    /// assert_eq!(lookup[&1], 14);
-    /// assert!(!lookup.contains_key(&2));
-    /// assert_eq!(lookup[&3], 7);
-    /// assert_eq!(lookup.len(), 3);
+    /// assert_eq!(lookup[&0], 4);        // 0 resets the accumulator so only 4 is summed
+    /// assert_eq!(lookup[&1], 14);       // 5 + 9
+    /// assert_eq!(lookup.get(&2), None); // 10 resets the accumulator and nothing is summed afterward
+    /// assert_eq!(lookup[&3], 7);        // 7
+    /// assert_eq!(lookup.len(), 3);      // The final keys are only 0, 1 and 2
     /// ```
     pub fn aggregate<FO, R>(self, mut operation: FO) -> HashMap<K, R>
     where

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -111,6 +111,8 @@ where
         })
     }
 
+    /// Groups elements from the `GroupingMap` source by key and collects the elements of each group in
+    /// an instance of `C`. The iteration order is preserved when inserting elements. 
     pub fn collect<C>(self) -> HashMap<K, C>
     where
         C: Default + Extend<V>,

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -460,7 +460,7 @@ impl<I, K, V> GroupingMap<I>
                     } else {
                         MinMaxResult::MinMax(e, val)
                     }
-                },
+                }
                 Some(MinMaxResult::MinMax(min, max)) => {
                     if compare(&val, &min) == Ordering::Less {
                         MinMaxResult::MinMax(val, max)
@@ -469,9 +469,9 @@ impl<I, K, V> GroupingMap<I>
                     } else {
                         MinMaxResult::MinMax(min, max)
                     }
-                },
+                }
                 None => MinMaxResult::OneElement(val),
-                Some(MinMaxResult::NoElements) => unreachable!()
+                Some(MinMaxResult::NoElements) => unreachable!(),
             })
         })
     }

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "use_std")]
 
 use std::collections::HashMap;
+use std::cmp::Ordering;
 use std::hash::Hash;
 use std::iter::Iterator;
 
@@ -226,5 +227,49 @@ impl<I, K, V> GroupingMap<I>
     /// ```
     pub fn count(self) -> HashMap<K, usize> {
         self.fold(0, |acc, _, _| acc + 1)
+    }
+
+    pub fn max(self) -> HashMap<K, V>
+        where V: Ord,
+    {
+        self.fold_first(|acc, _, val| std::cmp::max(acc, val))
+    }
+
+    pub fn max_by<F>(self, mut compare: F) -> HashMap<K, V>
+        where F: FnMut(&V, &V) -> Ordering,
+    {
+        self.fold_first(|acc, _, val| match compare(&acc, &val) {
+            Ordering::Less | Ordering::Equal => val,
+            Ordering::Greater => acc
+        })
+    }
+
+    pub fn max_by_key<F, CK>(self, mut f: F) -> HashMap<K, V>
+        where F: FnMut(&V) -> CK,
+              CK: Ord,
+    {
+        self.max_by(|v1, v2| f(&v1).cmp(&f(&v2)))
+    }
+
+    pub fn min(self) -> HashMap<K, V>
+        where V: Ord,
+    {
+        self.fold_first(|acc, _, val| std::cmp::min(acc, val))
+    }
+
+    pub fn min_by<F>(self, mut compare: F) -> HashMap<K, V>
+        where F: FnMut(&V, &V) -> Ordering,
+    {
+        self.fold_first(|acc, _, val| match compare(&acc, &val) {
+            Ordering::Less | Ordering::Equal => acc,
+            Ordering::Greater => val
+        })
+    }
+
+    pub fn min_by_key<F, CK>(self, mut f: F) -> HashMap<K, V>
+        where F: FnMut(&V) -> CK,
+              CK: Ord,
+    {
+        self.min_by(|v1, v2| f(&v1).cmp(&f(&v2)))
     }
 }

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -426,11 +426,7 @@ impl<I, K, V> GroupingMap<I>
     /// Groups elements from the `GroupingMap` source by key and find the maximum and minimum of
     /// each group with respect to the specified comparison function.
     /// 
-    /// See [.minmax()](../trait.Itertools.html#method.minmax) for the non-grouping version.
-    /// 
-    /// Differences from the non grouping version:
-    /// - It never produces a `MinMaxResult::NoElements`
-    /// - It doesn't have any speedup
+    /// It has the same differences from the non-grouping version as `minmax`.
     /// 
     /// Returns a `HashMap` associating the key of each group with the minimum and maximum of that group.
     /// 
@@ -477,11 +473,7 @@ impl<I, K, V> GroupingMap<I>
     /// Groups elements from the `GroupingMap` source by key and find the elements of each group
     /// that gives the minimum and maximum from the specified function.
     /// 
-    /// See [.minmax()](../trait.Itertools.html#method.minmax) for the non-grouping version.
-    /// 
-    /// Differences from the non grouping version:
-    /// - It never produces a `MinMaxResult::NoElements`
-    /// - It doesn't have any speedup
+    /// It has the same differences from the non-grouping version as `minmax`.
     /// 
     /// Returns a `HashMap` associating the key of each group with the minimum and maximum of that group.
     /// 

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -82,9 +82,9 @@ impl<I, K, V> GroupingMap<I>
     ///     });
     /// 
     /// assert_eq!(lookup[&0], 4);        // 0 resets the accumulator so only 4 is summed
-    /// assert_eq!(lookup[&1], 14);       // 5 + 9
+    /// assert_eq!(lookup[&1], 5 + 9);
     /// assert_eq!(lookup.get(&2), None); // 10 resets the accumulator and nothing is summed afterward
-    /// assert_eq!(lookup[&3], 7);        // 7
+    /// assert_eq!(lookup[&3], 7);
     /// assert_eq!(lookup.len(), 3);      // The final keys are only 0, 1 and 2
     /// ```
     pub fn aggregate<FO, R>(self, mut operation: FO) -> HashMap<K, R>
@@ -122,9 +122,9 @@ impl<I, K, V> GroupingMap<I>
     ///     .into_grouping_map_by(|&n| n % 3)
     ///     .fold(0, |acc, _, val| acc + val);
     /// 
-    /// assert_eq!(lookup[&0], 9);   // 3 + 6
-    /// assert_eq!(lookup[&1], 12);  // 1 + 4 + 7
-    /// assert_eq!(lookup[&2], 7);   // 2 + 5
+    /// assert_eq!(lookup[&0], 3 + 6);
+    /// assert_eq!(lookup[&1], 1 + 4 + 7);
+    /// assert_eq!(lookup[&2], 2 + 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn fold<FO, R>(self, init: R, mut operation: FO) -> HashMap<K, R>
@@ -159,9 +159,9 @@ impl<I, K, V> GroupingMap<I>
     ///     .into_grouping_map_by(|&n| n % 3)
     ///     .fold_first(|acc, _, val| acc + val);
     /// 
-    /// assert_eq!(lookup[&0], 9);   // 3 + 6
-    /// assert_eq!(lookup[&1], 12);  // 1 + 4 + 7
-    /// assert_eq!(lookup[&2], 7);   // 2 + 5
+    /// assert_eq!(lookup[&0], 3 + 6);
+    /// assert_eq!(lookup[&1], 1 + 4 + 7);
+    /// assert_eq!(lookup[&2], 2 + 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn fold_first<FO>(self, mut operation: FO) -> HashMap<K, V>
@@ -188,9 +188,9 @@ impl<I, K, V> GroupingMap<I>
     ///     .into_grouping_map_by(|&n| n % 3)
     ///     .collect::<HashSet<_>>();
     /// 
-    /// assert_eq!(lookup[&0], vec![0, 3, 6].into_iter().collect());
-    /// assert_eq!(lookup[&1], vec![1, 4].into_iter().collect());
-    /// assert_eq!(lookup[&2], vec![2, 5].into_iter().collect());
+    /// assert_eq!(lookup[&0], vec![0, 3, 6].into_iter().collect::<HashSet<_>>());
+    /// assert_eq!(lookup[&1], vec![1, 4].into_iter().collect::<HashSet<_>>());
+    /// assert_eq!(lookup[&2], vec![2, 5].into_iter().collect::<HashSet<_>>());
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn collect<C>(self) -> HashMap<K, C>

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -92,6 +92,20 @@ where
     ///  - the element from the source being accumulated.
     ///
     /// Return a `HashMap` associating the key of each group with the result of folding the group elements.
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// 
+    /// let lookup = (1..=7)
+    ///     .map(|n| (n % 3, n))
+    ///     .into_grouping_map()
+    ///     .fold(0, |acc, _, val| acc + val);
+    /// 
+    /// assert_eq!(lookup[&0], 9);
+    /// assert_eq!(lookup[&1], 12);
+    /// assert_eq!(lookup[&2], 7);
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn fold<FO, R>(self, init: R, mut operation: FO) -> HashMap<K, R>
     where
         R: Clone,

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -461,7 +461,7 @@ impl<I, K, V> GroupingMap<I>
                 Some(MinMaxResult::MinMax(min, max)) => {
                     if compare(key, &val, &min) == Ordering::Less {
                         MinMaxResult::MinMax(val, max)
-                    } else if compare(key, &val, &max) == Ordering::Greater {
+                    } else if compare(key, &val, &max) != Ordering::Less {
                         MinMaxResult::MinMax(min, val)
                     } else {
                         MinMaxResult::MinMax(min, max)

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -15,10 +15,9 @@ impl<I, F> MapForGrouping<I, F> {
 }
 
 impl<K, V, I, F> Iterator for MapForGrouping<I, F>
-where
-    I: Iterator<Item = V>,
-    K: Hash + Eq,
-    F: FnMut(&V) -> K,
+    where I: Iterator<Item = V>,
+          K: Hash + Eq,
+          F: FnMut(&V) -> K,
 {
     type Item = (K, V);
     fn next(&mut self) -> Option<Self::Item> {
@@ -29,9 +28,8 @@ where
 
 /// Creates a new `GroupingMap` from `iter`
 pub fn new<I, K, V>(iter: I) -> GroupingMap<I>
-where
-    I: Iterator<Item = (K, V)>,
-    K: Hash + Eq,
+    where I: Iterator<Item = (K, V)>,
+          K: Hash + Eq,
 {
     GroupingMap { iter }
 }
@@ -47,9 +45,8 @@ pub struct GroupingMap<I> {
 }
 
 impl<I, K, V> GroupingMap<I>
-where
-    I: Iterator<Item = (K, V)>,
-    K: Hash + Eq,
+    where I: Iterator<Item = (K, V)>,
+          K: Hash + Eq,
 {
     /// This is the generic way to perform any operations on a `GroupingMap`.
     /// It's suggested to use this method only to implement custom operations
@@ -90,8 +87,7 @@ where
     /// assert_eq!(lookup.len(), 3);      // The final keys are only 0, 1 and 2
     /// ```
     pub fn aggregate<FO, R>(self, mut operation: FO) -> HashMap<K, R>
-    where
-        FO: FnMut(Option<R>, &K, V) -> Option<R>,
+        where FO: FnMut(Option<R>, &K, V) -> Option<R>,
     {
         let mut destination_map = HashMap::new();
 
@@ -131,9 +127,8 @@ where
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn fold<FO, R>(self, init: R, mut operation: FO) -> HashMap<K, R>
-    where
-        R: Clone,
-        FO: FnMut(R, &K, V) -> R,
+        where R: Clone,
+              FO: FnMut(R, &K, V) -> R,
     {
         self.aggregate(|acc, key, val| {
             let acc = acc.unwrap_or_else(|| init.clone());
@@ -169,8 +164,7 @@ where
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn fold_first<FO>(self, mut operation: FO) -> HashMap<K, V>
-    where
-        FO: FnMut(V, &K, V) -> V,
+        where FO: FnMut(V, &K, V) -> V,
     {
         self.aggregate(|acc, key, val| {
             Some(match acc {
@@ -199,8 +193,7 @@ where
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn collect<C>(self) -> HashMap<K, C>
-    where
-        C: Default + Extend<V>,
+        where C: Default + Extend<V>,
     {
         self.aggregate(|acc, _, v| {
             let mut acc = acc.unwrap_or_else(C::default);

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -402,7 +402,7 @@ impl<I, K, V> GroupingMap<I>
     /// If several elements are equally maximum, the last element is picked.
     /// If several elements are equally minimum, the first element is picked.
     /// 
-    /// See [.minmax_by()](../trait.Itertools.html#method.minmax) for the non-grouping version.
+    /// See [.minmax()](../trait.Itertools.html#method.minmax) for the non-grouping version.
     /// 
     /// Differences from the non grouping version:
     /// - It never produces a `MinMaxResult::NoElements`

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -215,33 +215,6 @@ impl<I, K, V> GroupingMap<I>
         destination_map
     }
 
-    /// Groups elements from the `GroupingMap` source by key and counts them.
-    /// 
-    /// Return a `HashMap` associating the key of each group with the number of that group's elements.
-    /// 
-    /// ```
-    /// use itertools::Itertools;
-    /// 
-    /// let lookup = "This is a string".chars()
-    ///     .into_grouping_map_by(|&c| c)
-    ///     .count();
-    /// 
-    /// assert_eq!(lookup[&'T'], 1);
-    /// assert_eq!(lookup[&'h'], 1);
-    /// assert_eq!(lookup[&'i'], 3);
-    /// assert_eq!(lookup[&'s'], 3);
-    /// assert_eq!(lookup[&' '], 3);
-    /// assert_eq!(lookup[&'a'], 1);
-    /// assert_eq!(lookup[&'t'], 1);
-    /// assert_eq!(lookup[&'r'], 1);
-    /// assert_eq!(lookup[&'n'], 1);
-    /// assert_eq!(lookup[&'g'], 1);
-    /// assert_eq!(lookup.len(), 10);
-    /// ```
-    pub fn count(self) -> HashMap<K, usize> {
-        self.fold(0, |acc, _, _| acc + 1)
-    }
-
     /// Groups elements from the `GroupingMap` source by key and finds the maximum of each group.
     /// 
     /// If several elements are equally maximum, the last element is picked.

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -27,7 +27,7 @@ where
     I: Iterator<Item = (K, V)>,
     K: Hash + Eq,
 {
-    /// This is the generic way to perform any operations on a `Grouping`.
+    /// This is the generic way to perform any operations on a `GroupingMap`.
     /// It's suggested to use this method only to implement custom operations
     /// when the already provided ones are not enough.
     /// 

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -258,7 +258,7 @@ impl<I, K, V> GroupingMap<I>
     pub fn max(self) -> HashMap<K, V>
         where V: Ord,
     {
-        self.max_by(V::cmp)
+        self.max_by(|_, v1, v2| V::cmp(v1, v2))
     }
 
     /// Groups elements from the `GroupingMap` source by key and finds the maximum of each group
@@ -273,7 +273,7 @@ impl<I, K, V> GroupingMap<I>
     /// 
     /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
     ///     .into_grouping_map_by(|&n| n % 3)
-    ///     .max_by(|x, y| y.cmp(x));
+    ///     .max_by(|_key, x, y| y.cmp(x));
     /// 
     /// assert_eq!(lookup[&0], 3);
     /// assert_eq!(lookup[&1], 1);
@@ -281,9 +281,9 @@ impl<I, K, V> GroupingMap<I>
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn max_by<F>(self, mut compare: F) -> HashMap<K, V>
-        where F: FnMut(&V, &V) -> Ordering,
+        where F: FnMut(&K, &V, &V) -> Ordering,
     {
-        self.fold_first(|acc, _, val| match compare(&acc, &val) {
+        self.fold_first(|acc, key, val| match compare(key, &acc, &val) {
             Ordering::Less | Ordering::Equal => val,
             Ordering::Greater => acc
         })
@@ -301,7 +301,7 @@ impl<I, K, V> GroupingMap<I>
     /// 
     /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
     ///     .into_grouping_map_by(|&n| n % 3)
-    ///     .max_by_key(|&val| val % 4);
+    ///     .max_by_key(|_key, &val| val % 4);
     /// 
     /// assert_eq!(lookup[&0], 3);
     /// assert_eq!(lookup[&1], 7);
@@ -309,10 +309,10 @@ impl<I, K, V> GroupingMap<I>
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn max_by_key<F, CK>(self, mut f: F) -> HashMap<K, V>
-        where F: FnMut(&V) -> CK,
+        where F: FnMut(&K, &V) -> CK,
               CK: Ord,
     {
-        self.max_by(|v1, v2| f(&v1).cmp(&f(&v2)))
+        self.max_by(|key, v1, v2| f(key, &v1).cmp(&f(key, &v2)))
     }
 
     /// Groups elements from the `GroupingMap` source by key and finds the minimum of each group.
@@ -336,7 +336,7 @@ impl<I, K, V> GroupingMap<I>
     pub fn min(self) -> HashMap<K, V>
         where V: Ord,
     {
-        self.min_by(V::cmp)
+        self.min_by(|_, v1, v2| V::cmp(v1, v2))
     }
 
     /// Groups elements from the `GroupingMap` source by key and finds the minimum of each group
@@ -351,7 +351,7 @@ impl<I, K, V> GroupingMap<I>
     /// 
     /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
     ///     .into_grouping_map_by(|&n| n % 3)
-    ///     .min_by(|x, y| y.cmp(x));
+    ///     .min_by(|_key, x, y| y.cmp(x));
     /// 
     /// assert_eq!(lookup[&0], 12);
     /// assert_eq!(lookup[&1], 7);
@@ -359,9 +359,9 @@ impl<I, K, V> GroupingMap<I>
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn min_by<F>(self, mut compare: F) -> HashMap<K, V>
-        where F: FnMut(&V, &V) -> Ordering,
+        where F: FnMut(&K, &V, &V) -> Ordering,
     {
-        self.fold_first(|acc, _, val| match compare(&acc, &val) {
+        self.fold_first(|acc, key, val| match compare(key, &acc, &val) {
             Ordering::Less | Ordering::Equal => acc,
             Ordering::Greater => val
         })
@@ -379,7 +379,7 @@ impl<I, K, V> GroupingMap<I>
     /// 
     /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
     ///     .into_grouping_map_by(|&n| n % 3)
-    ///     .min_by_key(|&val| val % 4);
+    ///     .min_by_key(|_key, &val| val % 4);
     /// 
     /// assert_eq!(lookup[&0], 12);
     /// assert_eq!(lookup[&1], 4);
@@ -387,10 +387,10 @@ impl<I, K, V> GroupingMap<I>
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn min_by_key<F, CK>(self, mut f: F) -> HashMap<K, V>
-        where F: FnMut(&V) -> CK,
+        where F: FnMut(&K, &V) -> CK,
               CK: Ord,
     {
-        self.min_by(|v1, v2| f(&v1).cmp(&f(&v2)))
+        self.min_by(|key, v1, v2| f(key, &v1).cmp(&f(key, &v2)))
     }
 
     /// Groups elements from the `GroupingMap` source by key and find the maximum and minimum of
@@ -420,7 +420,7 @@ impl<I, K, V> GroupingMap<I>
     pub fn minmax(self) -> HashMap<K, MinMaxResult<V>>
         where V: Ord,
     {
-        self.minmax_by(V::cmp)
+        self.minmax_by(|_, v1, v2| V::cmp(v1, v2))
     }
 
     /// Groups elements from the `GroupingMap` source by key and find the maximum and minimum of
@@ -440,7 +440,7 @@ impl<I, K, V> GroupingMap<I>
     /// 
     /// let lookup = vec![1, 3, 4, 5, 7, 9, 12].into_iter()
     ///     .into_grouping_map_by(|&n| n % 3)
-    ///     .minmax_by(|x, y| y.cmp(x));
+    ///     .minmax_by(|_key, x, y| y.cmp(x));
     /// 
     /// assert_eq!(lookup[&0], MinMax(12, 3));
     /// assert_eq!(lookup[&1], MinMax(7, 1));
@@ -448,21 +448,21 @@ impl<I, K, V> GroupingMap<I>
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn minmax_by<F>(self, mut compare: F) -> HashMap<K, MinMaxResult<V>>
-        where F: FnMut(&V, &V) -> Ordering,
+        where F: FnMut(&K, &V, &V) -> Ordering,
     {
-        self.aggregate(|acc, _, val| {
+        self.aggregate(|acc, key, val| {
             Some(match acc {
                 Some(MinMaxResult::OneElement(e)) => {
-                    if compare(&val, &e) == Ordering::Less {
+                    if compare(key, &val, &e) == Ordering::Less {
                         MinMaxResult::MinMax(val, e)
                     } else {
                         MinMaxResult::MinMax(e, val)
                     }
                 }
                 Some(MinMaxResult::MinMax(min, max)) => {
-                    if compare(&val, &min) == Ordering::Less {
+                    if compare(key, &val, &min) == Ordering::Less {
                         MinMaxResult::MinMax(val, max)
-                    } else if compare(&val, &min) == Ordering::Greater {
+                    } else if compare(key, &val, &min) == Ordering::Greater {
                         MinMaxResult::MinMax(min, val)
                     } else {
                         MinMaxResult::MinMax(min, max)
@@ -491,7 +491,7 @@ impl<I, K, V> GroupingMap<I>
     /// 
     /// let lookup = vec![1, 3, 4, 5, 7, 9, 12].into_iter()
     ///     .into_grouping_map_by(|&n| n % 3)
-    ///     .minmax_by_key(|&val| val % 4);
+    ///     .minmax_by_key(|_key, &val| val % 4);
     /// 
     /// assert_eq!(lookup[&0], MinMax(12, 3));
     /// assert_eq!(lookup[&1], MinMax(4, 7));
@@ -499,10 +499,10 @@ impl<I, K, V> GroupingMap<I>
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn minmax_by_key<F, CK>(self, mut f: F) -> HashMap<K, MinMaxResult<V>>
-        where F: FnMut(&V) -> CK,
+        where F: FnMut(&K, &V) -> CK,
               CK: Ord,
     {
-        self.minmax_by(|v1, v2| f(&v1).cmp(&f(&v2)))
+        self.minmax_by(|key, v1, v2| f(key, &v1).cmp(&f(key, &v2)))
     }
     
     /// Groups elements from the `GroupingMap` source by key and sums them.

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -229,12 +229,47 @@ impl<I, K, V> GroupingMap<I>
         self.fold(0, |acc, _, _| acc + 1)
     }
 
+    /// Groups elements from the `GroupingMap` source by key and finds the maximum of each group.
+    /// 
+    /// If several elements are equally maximum, the last element is picked.
+    /// 
+    /// Returns a `HashMap` associating the key of each group with the maximum of that group.
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// 
+    /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .max();
+    /// 
+    /// assert_eq!(lookup[&0], 12);
+    /// assert_eq!(lookup[&1], 7);
+    /// assert_eq!(lookup[&2], 8);
+    /// ```
     pub fn max(self) -> HashMap<K, V>
         where V: Ord,
     {
         self.fold_first(|acc, _, val| std::cmp::max(acc, val))
     }
 
+    /// Groups elements from the `GroupingMap` source by key and finds the maximum of each group
+    /// with respect to the specified comparison function.
+    /// 
+    /// If several elements are equally maximum, the last element is picked.
+    /// 
+    /// Returns a `HashMap` associating the key of each group with the maximum of that group.
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// 
+    /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .max_by(|x, y| y.cmp(x));
+    /// 
+    /// assert_eq!(lookup[&0], 3);
+    /// assert_eq!(lookup[&1], 1);
+    /// assert_eq!(lookup[&2], 5);
+    /// ```
     pub fn max_by<F>(self, mut compare: F) -> HashMap<K, V>
         where F: FnMut(&V, &V) -> Ordering,
     {
@@ -244,6 +279,24 @@ impl<I, K, V> GroupingMap<I>
         })
     }
 
+    /// Groups elements from the `GroupingMap` source by key and finds the element of each group
+    /// that gives the maximum from the specified function.
+    /// 
+    /// If several elements are equally maximum, the last element is picked.
+    /// 
+    /// Returns a `HashMap` associating the key of each group with the maximum of that group.
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// 
+    /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .max_by_key(|&val| val % 4);
+    /// 
+    /// assert_eq!(lookup[&0], 3);
+    /// assert_eq!(lookup[&1], 7);
+    /// assert_eq!(lookup[&2], 5);
+    /// ```
     pub fn max_by_key<F, CK>(self, mut f: F) -> HashMap<K, V>
         where F: FnMut(&V) -> CK,
               CK: Ord,
@@ -251,12 +304,47 @@ impl<I, K, V> GroupingMap<I>
         self.max_by(|v1, v2| f(&v1).cmp(&f(&v2)))
     }
 
+    /// Groups elements from the `GroupingMap` source by key and finds the minimum of each group.
+    /// 
+    /// If several elements are equally minimum, the first element is picked.
+    /// 
+    /// Returns a `HashMap` associating the key of each group with the minimum of that group.
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// 
+    /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .min();
+    /// 
+    /// assert_eq!(lookup[&0], 3);
+    /// assert_eq!(lookup[&1], 1);
+    /// assert_eq!(lookup[&2], 5);
+    /// ```
     pub fn min(self) -> HashMap<K, V>
         where V: Ord,
     {
         self.fold_first(|acc, _, val| std::cmp::min(acc, val))
     }
 
+    /// Groups elements from the `GroupingMap` source by key and finds the minimum of each group
+    /// with respect to the specified comparison function.
+    /// 
+    /// If several elements are equally minimum, the first element is picked.
+    /// 
+    /// Returns a `HashMap` associating the key of each group with the minimum of that group.
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// 
+    /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .min_by(|x, y| y.cmp(x));
+    /// 
+    /// assert_eq!(lookup[&0], 12);
+    /// assert_eq!(lookup[&1], 7);
+    /// assert_eq!(lookup[&2], 8);
+    /// ```
     pub fn min_by<F>(self, mut compare: F) -> HashMap<K, V>
         where F: FnMut(&V, &V) -> Ordering,
     {
@@ -266,6 +354,24 @@ impl<I, K, V> GroupingMap<I>
         })
     }
 
+    /// Groups elements from the `GroupingMap` source by key and finds the element of each group
+    /// that gives the minimum from the specified function.
+    /// 
+    /// If several elements are equally minimum, the first element is picked.
+    /// 
+    /// Returns a `HashMap` associating the key of each group with the minimum of that group.
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// 
+    /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .min_by_key(|&val| val % 4);
+    /// 
+    /// assert_eq!(lookup[&0], 12);
+    /// assert_eq!(lookup[&1], 4);
+    /// assert_eq!(lookup[&2], 8);
+    /// ```
     pub fn min_by_key<F, CK>(self, mut f: F) -> HashMap<K, V>
         where F: FnMut(&V) -> CK,
               CK: Ord,

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -85,6 +85,20 @@ where
         })
     }
 
+    /// Groups elements from the `GroupingMap` source by key and applies `operation` to the elements
+    /// of each group sequentially, passing the previously accumulated value, a reference to the key
+    /// and the current element as arguments, and stores the results in a new map.
+    ///
+    /// This is similar to [`fold`] but the initial value of the accumulator is the first element of the group.
+    ///
+    /// `operation` is a function that is invoked on each element with the following parameters:
+    ///  - the current value of the accumulator of the group;
+    ///  - a reference to the key of the group this element belongs to;
+    ///  - the element from the source being accumulated.
+    ///
+    /// Return a `HashMap` associating the key of each group with the result of folding the group elements.
+    /// 
+    /// [`fold`]: #tymethod.fold
     pub fn fold_first<FO>(self, mut operation: FO) -> HashMap<K, V>
     where
         FO: FnMut(V, &K, V) -> V,

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -71,8 +71,9 @@ impl<I, K, V> GroupingMap<I>
     /// If `operation` returns `Some(element)` then the accumulator is updated with `element`,
     /// otherwise the previous accumulation is discarded.
     ///
-    /// Return a `HashMap` associating the key of each group with the result of aggregation of the group elements.
-    /// If there's no result then there won't be an entry associated to that key.
+    /// Return a `HashMap` associating the key of each group with the result of aggregation of
+    /// that group's elements. If the aggregation of the last element of a group discards the
+    /// accumulator then there won't be an entry associated to that group's key.
     /// 
     /// ```
     /// use itertools::Itertools;
@@ -120,7 +121,7 @@ impl<I, K, V> GroupingMap<I>
     ///  - a reference to the key of the group this element belongs to;
     ///  - the element from the source being accumulated.
     ///
-    /// Return a `HashMap` associating the key of each group with the result of folding the group elements.
+    /// Return a `HashMap` associating the key of each group with the result of folding that group's elements.
     /// 
     /// ```
     /// use itertools::Itertools;
@@ -155,7 +156,7 @@ impl<I, K, V> GroupingMap<I>
     ///  - a reference to the key of the group this element belongs to;
     ///  - the element from the source being accumulated.
     ///
-    /// Return a `HashMap` associating the key of each group with the result of folding the group elements.
+    /// Return a `HashMap` associating the key of each group with the result of folding that group's elements.
     /// 
     /// [`fold`]: #tymethod.fold
     /// 
@@ -185,7 +186,7 @@ impl<I, K, V> GroupingMap<I>
     /// Groups elements from the `GroupingMap` source by key and collects the elements of each group in
     /// an instance of `C`. The iteration order is preserved when inserting elements. 
     /// 
-    /// Return a `HashMap` associating the key of each group with the collection containing the elements of that group.
+    /// Return a `HashMap` associating the key of each group with the collection containing that group's elements.
     /// 
     /// ```
     /// use itertools::Itertools;
@@ -212,7 +213,7 @@ impl<I, K, V> GroupingMap<I>
 
     /// Groups elements from the `GroupingMap` source by key and counts them.
     /// 
-    /// Return a `HashMap` associating the key of each group with the number of elements in that group.
+    /// Return a `HashMap` associating the key of each group with the number of that group's elements.
     /// 
     /// ```
     /// use itertools::Itertools;
@@ -241,7 +242,7 @@ impl<I, K, V> GroupingMap<I>
     /// 
     /// If several elements are equally maximum, the last element is picked.
     /// 
-    /// Returns a `HashMap` associating the key of each group with the maximum of that group.
+    /// Returns a `HashMap` associating the key of each group with the maximum of that group's elements.
     /// 
     /// ```
     /// use itertools::Itertools;
@@ -266,7 +267,7 @@ impl<I, K, V> GroupingMap<I>
     /// 
     /// If several elements are equally maximum, the last element is picked.
     /// 
-    /// Returns a `HashMap` associating the key of each group with the maximum of that group.
+    /// Returns a `HashMap` associating the key of each group with the maximum of that group's elements.
     /// 
     /// ```
     /// use itertools::Itertools;
@@ -294,7 +295,7 @@ impl<I, K, V> GroupingMap<I>
     /// 
     /// If several elements are equally maximum, the last element is picked.
     /// 
-    /// Returns a `HashMap` associating the key of each group with the maximum of that group.
+    /// Returns a `HashMap` associating the key of each group with the maximum of that group's elements.
     /// 
     /// ```
     /// use itertools::Itertools;
@@ -319,7 +320,7 @@ impl<I, K, V> GroupingMap<I>
     /// 
     /// If several elements are equally minimum, the first element is picked.
     /// 
-    /// Returns a `HashMap` associating the key of each group with the minimum of that group.
+    /// Returns a `HashMap` associating the key of each group with the minimum of that group's elements.
     /// 
     /// ```
     /// use itertools::Itertools;
@@ -344,7 +345,7 @@ impl<I, K, V> GroupingMap<I>
     /// 
     /// If several elements are equally minimum, the first element is picked.
     /// 
-    /// Returns a `HashMap` associating the key of each group with the minimum of that group.
+    /// Returns a `HashMap` associating the key of each group with the minimum of that group's elements.
     /// 
     /// ```
     /// use itertools::Itertools;
@@ -372,7 +373,7 @@ impl<I, K, V> GroupingMap<I>
     /// 
     /// If several elements are equally minimum, the first element is picked.
     /// 
-    /// Returns a `HashMap` associating the key of each group with the minimum of that group.
+    /// Returns a `HashMap` associating the key of each group with the minimum of that group's elements.
     /// 
     /// ```
     /// use itertools::Itertools;
@@ -402,7 +403,7 @@ impl<I, K, V> GroupingMap<I>
     /// - It never produces a `MinMaxResult::NoElements`
     /// - It doesn't have any speedup
     /// 
-    /// Returns a `HashMap` associating the key of each group with the minimum and maximum of that group.
+    /// Returns a `HashMap` associating the key of each group with the minimum and maximum of that group's elements.
     /// 
     /// ```
     /// use itertools::Itertools;
@@ -428,7 +429,7 @@ impl<I, K, V> GroupingMap<I>
     /// 
     /// It has the same differences from the non-grouping version as `minmax`.
     /// 
-    /// Returns a `HashMap` associating the key of each group with the minimum and maximum of that group.
+    /// Returns a `HashMap` associating the key of each group with the minimum and maximum of that group's elements.
     /// 
     /// ```
     /// use itertools::Itertools;
@@ -475,7 +476,7 @@ impl<I, K, V> GroupingMap<I>
     /// 
     /// It has the same differences from the non-grouping version as `minmax`.
     /// 
-    /// Returns a `HashMap` associating the key of each group with the minimum and maximum of that group.
+    /// Returns a `HashMap` associating the key of each group with the minimum and maximum of that group's elements.
     /// 
     /// ```
     /// use itertools::Itertools;
@@ -502,7 +503,7 @@ impl<I, K, V> GroupingMap<I>
     /// This is just a shorthand for `self.fold_first(|acc, _, val| acc + val)`.
     /// It is more limited than `Iterator::sum` since it doesn't use the `Sum` trait.
     /// 
-    /// Returns a `HashMap` associating the key of each group with the sum of that group.
+    /// Returns a `HashMap` associating the key of each group with the sum of that group's elements.
     /// 
     /// ```
     /// use itertools::Itertools;
@@ -527,7 +528,7 @@ impl<I, K, V> GroupingMap<I>
     /// This is just a shorthand for `self.fold_first(|acc, _, val| acc * val)`.
     /// It is more limited than `Iterator::product` since it doesn't use the `Product` trait.
     /// 
-    /// Returns a `HashMap` associating the key of each group with the product of that group.
+    /// Returns a `HashMap` associating the key of each group with the product of that group's elements.
     /// 
     /// ```
     /// use itertools::Itertools;

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -510,7 +510,7 @@ impl<I, K, V> GroupingMap<I>
     /// This is just a shorthand for `self.fold_first(|acc, _, val| acc + val)`.
     /// It is more limited than `Iterator::sum` since it doesn't use the `Sum` trait.
     /// 
-    /// Returns a `HashMap` associating the key of each group with the sum of each group.
+    /// Returns a `HashMap` associating the key of each group with the sum of that group.
     /// 
     /// ```
     /// use itertools::Itertools;
@@ -535,7 +535,7 @@ impl<I, K, V> GroupingMap<I>
     /// This is just a shorthand for `self.fold_first(|acc, _, val| acc * val)`.
     /// It is more limited than `Iterator::product` since it doesn't use the `Product` trait.
     /// 
-    /// Returns a `HashMap` associating the key of each group with the product of each group.
+    /// Returns a `HashMap` associating the key of each group with the product of that group.
     /// 
     /// ```
     /// use itertools::Itertools;

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -56,7 +56,7 @@ impl<I, K, V> GroupingMap<I>
     where I: Iterator<Item = (K, V)>,
           K: Hash + Eq,
 {
-    /// This is the generic way to perform any operations on a `GroupingMap`.
+    /// This is the generic way to perform any operation on a `GroupingMap`.
     /// It's suggested to use this method only to implement custom operations
     /// when the already provided ones are not enough.
     /// 
@@ -68,6 +68,7 @@ impl<I, K, V> GroupingMap<I>
     ///  - the current value of the accumulator of the group if there is currently one;
     ///  - a reference to the key of the group this element belongs to;
     ///  - the element from the source being aggregated;
+    /// 
     /// If `operation` returns `Some(element)` then the accumulator is updated with `element`,
     /// otherwise the previous accumulation is discarded.
     ///

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -4,6 +4,29 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::iter::Iterator;
 
+#[doc(hidden)]
+/// A wrapper to allow for an easy [`into_grouping_map_by`](../trait.Itertools.html#method.into_grouping_map_by)
+pub struct MapForGrouping<I, F>(I, F);
+
+impl<I, F> MapForGrouping<I, F> {
+    pub(crate) fn new(iter: I, key_mapper: F) -> Self {
+        Self(iter, key_mapper)
+    }
+}
+
+impl<K, V, I, F> Iterator for MapForGrouping<I, F>
+where
+    I: Iterator<Item = V>,
+    K: Hash + Eq,
+    F: FnMut(&V) -> K,
+{
+    type Item = (K, V);
+    fn next(&mut self) -> Option<Self::Item> {
+        let val = self.0.next()?;
+        Some(((self.1)(&val), val))
+    }
+}
+
 /// Creates a new `GroupingMap` from `iter`
 pub fn new<I, K, V>(iter: I) -> GroupingMap<I>
 where

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -27,6 +27,10 @@ where
     I: Iterator<Item = (K, V)>,
     K: Hash + Eq,
 {
+    /// This is the generic way to perform any operations on a `Grouping`.
+    /// It's suggested to use this method only to implement custom operations
+    /// when the already provided ones are not enough.
+    /// 
     /// Groups elements from the `GroupingMap` source by key and applies `operation` to the elements
     /// of each group sequentially, passing the previously accumulated value, a reference to the key
     /// and the current element as arguments, and stores the results in an `HashMap`.
@@ -40,9 +44,6 @@ where
     ///
     /// Return a `HashMap` associating the key of each group with the result of aggregation of the group elements.
     /// If there's no result then there won't be an entry associated to that key.
-    ///
-    /// This is the generic way to perform any operations on a `Grouping`.
-    /// It's suggested to use it only to implement custom operations when the already provided ones are not enough.
     pub fn aggregate<FO, R>(self, mut operation: FO) -> HashMap<K, R>
     where
         FO: FnMut(Option<R>, &K, V) -> Option<R>,

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -36,6 +36,14 @@ pub fn new<I, K, V>(iter: I) -> GroupingMap<I>
 }
 
 /// `GroupingMap` is an intermediate struct for efficient group-and-fold operations.
+/// It groups elements by the key returned by the specified function and at the same
+/// time fold each group using some aggregating operation.
+/// 
+/// No method on this type performs temporary allocations.
+#[must_use = "GroupingMapBy is lazy and do nothing unless consumed"]
+pub type GroupingMapBy<I, F> = GroupingMap<MapForGrouping<I, F>>;
+
+/// `GroupingMap` is an intermediate struct for efficient group-and-fold operations.
 /// It groups elements by their key and at the same time fold each group
 /// using some aggregating operation.
 /// 

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -163,6 +163,21 @@ where
     /// an instance of `C`. The iteration order is preserved when inserting elements. 
     /// 
     /// Return a `HashMap` associating the key of each group with the collection containing the elements of that group.
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// use std::collections::HashSet;
+    /// 
+    /// let lookup = vec![0, 1, 2, 3, 4, 5, 6, 2, 3, 6].into_iter()
+    ///     .map(|n| (n % 3, n))
+    ///     .into_grouping_map()
+    ///     .collect::<HashSet<_>>();
+    /// 
+    /// assert_eq!(lookup[&0], vec![0, 3, 6].into_iter().collect());
+    /// assert_eq!(lookup[&1], vec![1, 4].into_iter().collect());
+    /// assert_eq!(lookup[&2], vec![2, 5].into_iter().collect());
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn collect<C>(self) -> HashMap<K, C>
     where
         C: Default + Extend<V>,

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -404,6 +404,20 @@ impl<I, K, V> GroupingMap<I>
     /// - It doesn't have any speedup
     /// 
     /// Returns a `HashMap` associating the key of each group with the minimum and maximum of that group.
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// use itertools::MinMaxResult::{OneElement, MinMax};
+    /// 
+    /// let lookup = vec![1, 3, 4, 5, 7, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .minmax();
+    /// 
+    /// assert_eq!(lookup[&0], MinMax(3, 12));
+    /// assert_eq!(lookup[&1], MinMax(1, 7));
+    /// assert_eq!(lookup[&2], OneElement(5));
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn minmax(self) -> HashMap<K, MinMaxResult<V>>
         where V: Ord,
     {
@@ -420,6 +434,20 @@ impl<I, K, V> GroupingMap<I>
     /// - It doesn't have any speedup
     /// 
     /// Returns a `HashMap` associating the key of each group with the minimum and maximum of that group.
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// use itertools::MinMaxResult::{OneElement, MinMax};
+    /// 
+    /// let lookup = vec![1, 3, 4, 5, 7, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .minmax_by(|x, y| y.cmp(x));
+    /// 
+    /// assert_eq!(lookup[&0], MinMax(12, 3));
+    /// assert_eq!(lookup[&1], MinMax(7, 1));
+    /// assert_eq!(lookup[&2], OneElement(5));
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn minmax_by<F>(self, mut compare: F) -> HashMap<K, MinMaxResult<V>>
         where F: FnMut(&V, &V) -> Ordering,
     {
@@ -457,6 +485,20 @@ impl<I, K, V> GroupingMap<I>
     /// - It doesn't have any speedup
     /// 
     /// Returns a `HashMap` associating the key of each group with the minimum and maximum of that group.
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// use itertools::MinMaxResult::{OneElement, MinMax};
+    /// 
+    /// let lookup = vec![1, 3, 4, 5, 7, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .minmax_by_key(|&val| val % 4);
+    /// 
+    /// assert_eq!(lookup[&0], MinMax(12, 3));
+    /// assert_eq!(lookup[&1], MinMax(4, 7));
+    /// assert_eq!(lookup[&2], OneElement(5));
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn minmax_by_key<F, CK>(self, mut f: F) -> HashMap<K, MinMaxResult<V>>
         where F: FnMut(&V) -> CK,
               CK: Ord,

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -124,6 +124,9 @@ where
         })
     }
 
+    /// Groups elements from the `GroupingMap` source by key and counts them.
+    /// 
+    /// Return a `HashMap` associating the key of each group with the number of elements in that group.
     pub fn count(self) -> HashMap<K, usize> {
         self.fold(0, |acc, _, _| acc + 1)
     }

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::iter::Iterator;
 
+/// Creates a new `GroupingMap` from `iter`
 pub fn new<I, K, V>(iter: I) -> GroupingMap<I>
 where
     I: Iterator<Item = (K, V)>,
@@ -12,6 +13,14 @@ where
     GroupingMap { iter }
 }
 
+/// `GroupingMap` is an intermediate struct for efficient "group-and-fold" operations.
+/// It groups elements by their key and at the same time fold each group
+/// using some aggregating operation.
+/// 
+/// No method on this struct performs temporary allocations.
+/// 
+// See [`.into_grouping_map()`](../trait.Itertools.html#method.into_grouping_map)
+// for more information.
 pub struct GroupingMap<I> {
     iter: I,
 }

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -13,14 +13,11 @@ where
     GroupingMap { iter }
 }
 
-/// `GroupingMap` is an intermediate struct for efficient "group-and-fold" operations.
+/// `GroupingMap` is an intermediate struct for efficient group-and-fold operations.
 /// It groups elements by their key and at the same time fold each group
 /// using some aggregating operation.
 /// 
 /// No method on this struct performs temporary allocations.
-/// 
-// See [`.into_grouping_map()`](../trait.Itertools.html#method.into_grouping_map)
-// for more information.
 pub struct GroupingMap<I> {
     iter: I,
 }

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -80,7 +80,7 @@ impl<I, K, V> GroupingMap<I>
     /// let data = vec![2, 8, 5, 7, 9, 0, 4, 10];
     /// let lookup = data.into_iter()
     ///     .into_grouping_map_by(|&n| n % 4)
-    ///     .aggregate(|acc, _, val| {
+    ///     .aggregate(|acc, _key, val| {
     ///         if val == 0 || val == 10 {
     ///             None
     ///         } else {
@@ -127,7 +127,7 @@ impl<I, K, V> GroupingMap<I>
     /// 
     /// let lookup = (1..=7)
     ///     .into_grouping_map_by(|&n| n % 3)
-    ///     .fold(0, |acc, _, val| acc + val);
+    ///     .fold(0, |acc, _key, val| acc + val);
     /// 
     /// assert_eq!(lookup[&0], 3 + 6);
     /// assert_eq!(lookup[&1], 1 + 4 + 7);
@@ -164,7 +164,7 @@ impl<I, K, V> GroupingMap<I>
     /// 
     /// let lookup = (1..=7)
     ///     .into_grouping_map_by(|&n| n % 3)
-    ///     .fold_first(|acc, _, val| acc + val);
+    ///     .fold_first(|acc, _key, val| acc + val);
     /// 
     /// assert_eq!(lookup[&0], 3 + 6);
     /// assert_eq!(lookup[&1], 1 + 4 + 7);

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -459,7 +459,7 @@ impl<I, K, V> GroupingMap<I>
                 Some(MinMaxResult::MinMax(min, max)) => {
                     if compare(key, &val, &min) == Ordering::Less {
                         MinMaxResult::MinMax(val, max)
-                    } else if compare(key, &val, &min) == Ordering::Greater {
+                    } else if compare(key, &val, &max) == Ordering::Greater {
                         MinMaxResult::MinMax(min, val)
                     } else {
                         MinMaxResult::MinMax(min, max)

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::iter::Iterator;
 
-#[doc(hidden)]
 /// A wrapper to allow for an easy [`into_grouping_map_by`](../trait.Itertools.html#method.into_grouping_map_by)
 pub struct MapForGrouping<I, F>(I, F);
 

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -23,8 +23,7 @@ impl<K, V, I, F> Iterator for MapForGrouping<I, F>
 {
     type Item = (K, V);
     fn next(&mut self) -> Option<Self::Item> {
-        let val = self.0.next()?;
-        Some(((self.1)(&val), val))
+        self.0.next().map(|val| ((self.1)(&val), val))
     }
 }
 

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -133,6 +133,20 @@ where
     /// Return a `HashMap` associating the key of each group with the result of folding the group elements.
     /// 
     /// [`fold`]: #tymethod.fold
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// 
+    /// let lookup = (1..=7)
+    ///     .map(|n| (n % 3, n))
+    ///     .into_grouping_map()
+    ///     .fold_first(|acc, _, val| acc + val);
+    /// 
+    /// assert_eq!(lookup[&0], 9);   // 3 + 6
+    /// assert_eq!(lookup[&1], 12);  // 1 + 4 + 7
+    /// assert_eq!(lookup[&2], 7);   // 2 + 5
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn fold_first<FO>(self, mut operation: FO) -> HashMap<K, V>
     where
         FO: FnMut(V, &K, V) -> V,

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -250,7 +250,7 @@ impl<I, K, V> GroupingMap<I>
     pub fn max(self) -> HashMap<K, V>
         where V: Ord,
     {
-        self.fold_first(|acc, _, val| std::cmp::max(acc, val))
+        self.max_by(V::cmp)
     }
 
     /// Groups elements from the `GroupingMap` source by key and finds the maximum of each group
@@ -325,7 +325,7 @@ impl<I, K, V> GroupingMap<I>
     pub fn min(self) -> HashMap<K, V>
         where V: Ord,
     {
-        self.fold_first(|acc, _, val| std::cmp::min(acc, val))
+        self.min_by(V::cmp)
     }
 
     /// Groups elements from the `GroupingMap` source by key and finds the minimum of each group

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -44,6 +44,26 @@ where
     ///
     /// Return a `HashMap` associating the key of each group with the result of aggregation of the group elements.
     /// If there's no result then there won't be an entry associated to that key.
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// 
+    /// let data = vec![10, 5, 7, 9, 0, 4, 2];
+    /// let lookup = data.into_iter()
+    ///     .map(|n| (n % 4, n))
+    ///     .into_grouping_map()
+    ///     .aggregate(|acc, _, val| {
+    ///         match val {
+    ///             0 | 2 => None,
+    ///             _ => Some(acc.unwrap_or(0) + val)
+    ///         }
+    ///     });
+    /// 
+    /// assert_eq!(lookup[&0], 4);
+    /// assert_eq!(lookup[&1], 14);
+    /// assert!(!lookup.contains_key(&2));
+    /// assert_eq!(lookup[&3], 7);
+    /// ```
     pub fn aggregate<FO, R>(self, mut operation: FO) -> HashMap<K, R>
     where
         FO: FnMut(Option<R>, &K, V) -> Option<R>,

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -41,6 +41,7 @@ where
 /// using some aggregating operation.
 /// 
 /// No method on this struct performs temporary allocations.
+#[must_use = "GroupingMap is lazy and do nothing unless consumed"]
 pub struct GroupingMap<I> {
     iter: I,
 }
@@ -73,8 +74,7 @@ where
     /// 
     /// let data = vec![2, 8, 5, 7, 9, 0, 4, 10];
     /// let lookup = data.into_iter()
-    ///     .map(|n| (n % 4, n))
-    ///     .into_grouping_map()
+    ///     .into_grouping_map_by(|&n| n % 4)
     ///     .aggregate(|acc, _, val| {
     ///         if val == 0 || val == 10 {
     ///             None
@@ -122,8 +122,7 @@ where
     /// use itertools::Itertools;
     /// 
     /// let lookup = (1..=7)
-    ///     .map(|n| (n % 3, n))
-    ///     .into_grouping_map()
+    ///     .into_grouping_map_by(|&n| n % 3)
     ///     .fold(0, |acc, _, val| acc + val);
     /// 
     /// assert_eq!(lookup[&0], 9);   // 3 + 6
@@ -161,8 +160,7 @@ where
     /// use itertools::Itertools;
     /// 
     /// let lookup = (1..=7)
-    ///     .map(|n| (n % 3, n))
-    ///     .into_grouping_map()
+    ///     .into_grouping_map_by(|&n| n % 3)
     ///     .fold_first(|acc, _, val| acc + val);
     /// 
     /// assert_eq!(lookup[&0], 9);   // 3 + 6
@@ -192,8 +190,7 @@ where
     /// use std::collections::HashSet;
     /// 
     /// let lookup = vec![0, 1, 2, 3, 4, 5, 6, 2, 3, 6].into_iter()
-    ///     .map(|n| (n % 3, n))
-    ///     .into_grouping_map()
+    ///     .into_grouping_map_by(|&n| n % 3)
     ///     .collect::<HashSet<_>>();
     /// 
     /// assert_eq!(lookup[&0], vec![0, 3, 6].into_iter().collect());
@@ -220,8 +217,7 @@ where
     /// use itertools::Itertools;
     /// 
     /// let lookup = "This is a string".chars()
-    ///     .map(|c| (c, c))
-    ///     .into_grouping_map()
+    ///     .into_grouping_map_by(|&c| c)
     ///     .count();
     /// 
     /// assert_eq!(lookup[&'T'], 1);

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -113,6 +113,8 @@ where
 
     /// Groups elements from the `GroupingMap` source by key and collects the elements of each group in
     /// an instance of `C`. The iteration order is preserved when inserting elements. 
+    /// 
+    /// Return a `HashMap` associating the key of each group with the collection containing the elements of that group.
     pub fn collect<C>(self) -> HashMap<K, C>
     where
         C: Default + Extend<V>,

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -399,6 +399,9 @@ impl<I, K, V> GroupingMap<I>
     /// Groups elements from the `GroupingMap` source by key and find the maximum and minimum of
     /// each group.
     /// 
+    /// If several elements are equally maximum, the last element is picked.
+    /// If several elements are equally minimum, the first element is picked.
+    /// 
     /// See [.minmax_by()](../trait.Itertools.html#method.minmax) for the non-grouping version.
     /// 
     /// Differences from the non grouping version:
@@ -428,6 +431,9 @@ impl<I, K, V> GroupingMap<I>
 
     /// Groups elements from the `GroupingMap` source by key and find the maximum and minimum of
     /// each group with respect to the specified comparison function.
+    /// 
+    /// If several elements are equally maximum, the last element is picked.
+    /// If several elements are equally minimum, the first element is picked.
     /// 
     /// It has the same differences from the non-grouping version as `minmax`.
     /// 
@@ -475,6 +481,9 @@ impl<I, K, V> GroupingMap<I>
 
     /// Groups elements from the `GroupingMap` source by key and find the elements of each group
     /// that gives the minimum and maximum from the specified function.
+    /// 
+    /// If several elements are equally maximum, the last element is picked.
+    /// If several elements are equally minimum, the first element is picked.
     /// 
     /// It has the same differences from the non-grouping version as `minmax`.
     /// 

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -204,11 +204,13 @@ impl<I, K, V> GroupingMap<I>
     pub fn collect<C>(self) -> HashMap<K, C>
         where C: Default + Extend<V>,
     {
-        self.aggregate(|acc, _, v| {
-            let mut acc = acc.unwrap_or_else(C::default);
-            acc.extend(Some(v));
-            Some(acc)
-        })
+        let mut destination_map = HashMap::new();
+
+        for (key, val) in self.iter {
+            destination_map.entry(key).or_insert_with(C::default).extend(Some(val));
+        }
+
+        destination_map
     }
 
     /// Groups elements from the `GroupingMap` source by key and counts them.

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -31,18 +31,18 @@ where
     K: Hash + Eq,
 {
     /// Groups elements from the `GroupingMap` source by key and applies `operation` to the elements
-    /// of each group sequentially, passing the key, the previously accumulated value
+    /// of each group sequentially, passing the previously accumulated value, a reference to the key
     /// and the current element as arguments, and stores the results in an `HashMap`.
     ///
     /// The `operation` function is invoked on each element with the following parameters:
+    ///  - the current value of the accumulator of the group if there is currently one;
     ///  - a reference to the key of the group this element belongs to;
-    ///  - the current value of the accumulator of the group or `None` if it's the first element
-    ///    encountered in the group;
     ///  - the element from the source being aggregated;
     /// If `operation` returns `Some(element)` then the accumulator is updated with `element`,
     /// otherwise the previous accumulation is discarded.
     ///
     /// Return a `HashMap` associating the key of each group with the result of aggregation of the group elements.
+    /// If there's no result then there won't be an entry associated to that key.
     ///
     /// This is the generic way to perform any operations on a `Grouping`.
     /// It's suggested to use it only to implement custom operations when the already provided ones are not enough.

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -246,6 +246,7 @@ impl<I, K, V> GroupingMap<I>
     /// assert_eq!(lookup[&0], 12);
     /// assert_eq!(lookup[&1], 7);
     /// assert_eq!(lookup[&2], 8);
+    /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn max(self) -> HashMap<K, V>
         where V: Ord,
@@ -270,6 +271,7 @@ impl<I, K, V> GroupingMap<I>
     /// assert_eq!(lookup[&0], 3);
     /// assert_eq!(lookup[&1], 1);
     /// assert_eq!(lookup[&2], 5);
+    /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn max_by<F>(self, mut compare: F) -> HashMap<K, V>
         where F: FnMut(&V, &V) -> Ordering,
@@ -297,6 +299,7 @@ impl<I, K, V> GroupingMap<I>
     /// assert_eq!(lookup[&0], 3);
     /// assert_eq!(lookup[&1], 7);
     /// assert_eq!(lookup[&2], 5);
+    /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn max_by_key<F, CK>(self, mut f: F) -> HashMap<K, V>
         where F: FnMut(&V) -> CK,
@@ -321,6 +324,7 @@ impl<I, K, V> GroupingMap<I>
     /// assert_eq!(lookup[&0], 3);
     /// assert_eq!(lookup[&1], 1);
     /// assert_eq!(lookup[&2], 5);
+    /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn min(self) -> HashMap<K, V>
         where V: Ord,
@@ -345,6 +349,7 @@ impl<I, K, V> GroupingMap<I>
     /// assert_eq!(lookup[&0], 12);
     /// assert_eq!(lookup[&1], 7);
     /// assert_eq!(lookup[&2], 8);
+    /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn min_by<F>(self, mut compare: F) -> HashMap<K, V>
         where F: FnMut(&V, &V) -> Ordering,
@@ -372,6 +377,7 @@ impl<I, K, V> GroupingMap<I>
     /// assert_eq!(lookup[&0], 12);
     /// assert_eq!(lookup[&1], 4);
     /// assert_eq!(lookup[&2], 8);
+    /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn min_by_key<F, CK>(self, mut f: F) -> HashMap<K, V>
         where F: FnMut(&V) -> CK,

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -36,7 +36,7 @@ pub fn new<I, K, V>(iter: I) -> GroupingMap<I>
     GroupingMap { iter }
 }
 
-/// `GroupingMap` is an intermediate struct for efficient group-and-fold operations.
+/// `GroupingMapBy` is an intermediate struct for efficient group-and-fold operations.
 /// It groups elements by the key returned by the specified function and at the same
 /// time fold each group using some aggregating operation.
 /// 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub mod structs {
     pub use crate::exactly_one_err::ExactlyOneError;
     pub use crate::format::{Format, FormatWith};
     #[cfg(feature = "use_std")]
-    pub use crate::grouping_map::GroupingMap;
+    pub use crate::grouping_map::{GroupingMap, GroupingMapBy};
     #[cfg(feature = "use_std")]
     pub use crate::groupbylazy::{IntoChunks, Chunk, Chunks, GroupBy, Group, Groups};
     pub use crate::intersperse::{Intersperse, IntersperseWith};
@@ -155,8 +155,6 @@ pub use crate::concat_impl::concat;
 pub use crate::cons_tuples_impl::cons_tuples;
 pub use crate::diff::diff_with;
 pub use crate::diff::Diff;
-#[cfg(feature = "use_std")]
-pub use crate::grouping_map::MapForGrouping;
 #[cfg(feature = "use_std")]
 pub use crate::kmerge_impl::{kmerge_by};
 pub use crate::minmax::MinMaxResult;
@@ -2360,12 +2358,12 @@ pub trait Itertools : Iterator {
     /// See [`GroupingMap`](./structs/struct.GroupingMap.html) for more informations
     /// on what operations are available.
     #[cfg(feature = "use_std")]
-    fn into_grouping_map_by<K, V, F>(self, key_mapper: F) -> GroupingMap<MapForGrouping<Self, F>>
+    fn into_grouping_map_by<K, V, F>(self, key_mapper: F) -> GroupingMapBy<Self, F>
         where Self: Iterator<Item=V> + Sized,
               K: Hash + Eq,
               F: FnMut(&V) -> K
     {
-        grouping_map::new(MapForGrouping::new(self, key_mapper))
+        grouping_map::new(grouping_map::MapForGrouping::new(self, key_mapper))
     }
 
     /// Return the minimum and maximum elements in the iterator.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2335,7 +2335,12 @@ pub trait Itertools : Iterator {
     /// Constructs a `GroupingMap` to be used later with one of the efficient 
     /// group-and-fold operations it allows to perform.
     /// 
-    /// See [`GroupingMap`](./structs/struct.GroupingMap.html) for more informations.
+    /// The input iterator must yield item in the form of `(K, V)` where the
+    /// value of type `K` will be used as key to identify the groups and the
+    /// value of type `V` as value for the folding operation.
+    /// 
+    /// See [`GroupingMap`](./structs/struct.GroupingMap.html) for more informations
+    /// on what operations are available.
     #[cfg(feature = "use_std")]
     fn into_grouping_map<K, V>(self) -> GroupingMap<Self>
         where Self: Iterator<Item=(K, V)> + Sized,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,8 @@ pub mod structs {
     pub use crate::exactly_one_err::ExactlyOneError;
     pub use crate::format::{Format, FormatWith};
     #[cfg(feature = "use_std")]
+    pub use crate::grouping_map::GroupingMap;
+    #[cfg(feature = "use_std")]
     pub use crate::groupbylazy::{IntoChunks, Chunk, Chunks, GroupBy, Group, Groups};
     pub use crate::intersperse::{Intersperse, IntersperseWith};
     #[cfg(feature = "use_std")]
@@ -179,6 +181,8 @@ mod combinations_with_replacement;
 mod exactly_one_err;
 mod diff;
 mod format;
+#[cfg(feature = "use_std")]
+mod grouping_map;
 #[cfg(feature = "use_std")]
 mod group_map;
 #[cfg(feature = "use_std")]
@@ -2326,6 +2330,14 @@ pub trait Itertools : Iterator {
               K: Hash + Eq,
     {
         group_map::into_group_map(self)
+    }
+
+    #[cfg(feature = "use_std")]
+    fn into_grouping_map<K, V>(self) -> GroupingMap<Self>
+        where Self: Iterator<Item=(K, V)> + Sized,
+            K: Hash + Eq,
+    {
+        grouping_map::new(self)
     }
 
     /// Return the minimum and maximum elements in the iterator.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub mod structs {
     pub use crate::exactly_one_err::ExactlyOneError;
     pub use crate::format::{Format, FormatWith};
     #[cfg(feature = "use_std")]
-    pub use crate::grouping_map::{GroupingMap, MapForGrouping};
+    pub use crate::grouping_map::GroupingMap;
     #[cfg(feature = "use_std")]
     pub use crate::groupbylazy::{IntoChunks, Chunk, Chunks, GroupBy, Group, Groups};
     pub use crate::intersperse::{Intersperse, IntersperseWith};
@@ -155,6 +155,8 @@ pub use crate::concat_impl::concat;
 pub use crate::cons_tuples_impl::cons_tuples;
 pub use crate::diff::diff_with;
 pub use crate::diff::Diff;
+#[cfg(feature = "use_std")]
+pub use crate::grouping_map::MapForGrouping;
 #[cfg(feature = "use_std")]
 pub use crate::kmerge_impl::{kmerge_by};
 pub use crate::minmax::MinMaxResult;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2339,7 +2339,7 @@ pub trait Itertools : Iterator {
     #[cfg(feature = "use_std")]
     fn into_grouping_map<K, V>(self) -> GroupingMap<Self>
         where Self: Iterator<Item=(K, V)> + Sized,
-            K: Hash + Eq,
+              K: Hash + Eq,
     {
         grouping_map::new(self)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub mod structs {
     pub use crate::exactly_one_err::ExactlyOneError;
     pub use crate::format::{Format, FormatWith};
     #[cfg(feature = "use_std")]
-    pub use crate::grouping_map::GroupingMap;
+    pub use crate::grouping_map::{GroupingMap, MapForGrouping};
     #[cfg(feature = "use_std")]
     pub use crate::groupbylazy::{IntoChunks, Chunk, Chunks, GroupBy, Group, Groups};
     pub use crate::intersperse::{Intersperse, IntersperseWith};
@@ -2347,6 +2347,23 @@ pub trait Itertools : Iterator {
               K: Hash + Eq,
     {
         grouping_map::new(self)
+    }
+
+    /// Constructs a `GroupingMap` to be used later with one of the efficient 
+    /// group-and-fold operations it allows to perform.
+    /// 
+    /// The values from this iterator will be used as values for the folding operation
+    /// while the keys will be obtained from the values by calling `key_mapper`.
+    /// 
+    /// See [`GroupingMap`](./structs/struct.GroupingMap.html) for more informations
+    /// on what operations are available.
+    #[cfg(feature = "use_std")]
+    fn into_grouping_map_by<K, V, F>(self, key_mapper: F) -> GroupingMap<MapForGrouping<Self, F>>
+        where Self: Iterator<Item=V> + Sized,
+              K: Hash + Eq,
+              F: FnMut(&V) -> K
+    {
+        grouping_map::new(MapForGrouping::new(self, key_mapper))
     }
 
     /// Return the minimum and maximum elements in the iterator.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2332,6 +2332,10 @@ pub trait Itertools : Iterator {
         group_map::into_group_map(self)
     }
 
+    /// Constructs a `GroupingMap` to be used later with one of the efficient 
+    /// group-and-fold operations it allows to perform.
+    /// 
+    /// See [`GroupingMap`](./structs/struct.GroupingMap.html) for more informations.
     #[cfg(feature = "use_std")]
     fn into_grouping_map<K, V>(self) -> GroupingMap<Self>
         where Self: Iterator<Item=(K, V)> + Sized,

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -1346,4 +1346,29 @@ quickcheck! {
             );
         }
     }
+
+    // This should check that if multiple elements are equally minimum or maximum
+    // then `max`, `min` and `minmax` pick the first minimum and the last maximum.
+    // This is to be consistent with `std::iter::max` and `std::iter::min`.
+    fn correct_grouping_map_by_min_max_minmax_order_modulo_key() -> () {
+        use itertools::MinMaxResult;
+
+        let lookup = (0..=10)
+            .into_grouping_map_by(|_| 0)
+            .max_by(|_, _, _| Ordering::Equal);
+
+        assert_eq!(lookup[&0], 10);
+
+        let lookup = (0..=10)
+            .into_grouping_map_by(|_| 0)
+            .min_by(|_, _, _| Ordering::Equal);
+
+        assert_eq!(lookup[&0], 0);
+        
+        let lookup = (0..=10)
+            .into_grouping_map_by(|_| 0)
+            .minmax_by(|_, _, _| Ordering::Equal);
+
+        assert_eq!(lookup[&0], MinMaxResult::MinMax(0, 10));
+    }
 }

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -8,7 +8,7 @@ use std::default::Default;
 use std::num::Wrapping;
 use std::ops::Range;
 use std::cmp::{max, min, Ordering};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use itertools::Itertools;
 use itertools::{
     multizip,
@@ -1213,6 +1213,23 @@ quickcheck! {
                     Some(acc.unwrap_or(0) + val)
                 }
             });
+        
+        let group_map_lookup = a.iter()
+            .map(|&b| b as u64)
+            .map(|i| (i % modulo, i))
+            .into_group_map()
+            .into_iter()
+            .filter_map(|(key, vals)| {
+                vals.into_iter().fold(None, |acc, val| {
+                    if val % (modulo - 1) == 0 {
+                        None
+                    } else {
+                        Some(acc.unwrap_or(0) + val)
+                    }
+                }).map(|new_val| (key, new_val))
+            })
+            .collect::<HashMap<_,_>>();
+        assert_eq!(lookup, group_map_lookup);
 
         for m in 0..modulo {
             assert_eq!(
@@ -1240,6 +1257,15 @@ quickcheck! {
                 acc + val
             });
 
+        let group_map_lookup = a.iter()
+            .map(|&b| b as u64)
+            .map(|i| (i % modulo, i))
+            .into_group_map()
+            .into_iter()
+            .map(|(key, vals)| (key, vals.into_iter().fold(0u64, |acc, val| acc + val)))
+            .collect::<HashMap<_,_>>();
+        assert_eq!(lookup, group_map_lookup);
+
         for (&key, &sum) in lookup.iter() {
             assert_eq!(sum, a.iter().map(|&b| b as u64).filter(|&val| val % modulo == key).sum::<u64>());
         }
@@ -1253,6 +1279,16 @@ quickcheck! {
                 assert!(val % modulo == key);
                 acc + val
             });
+
+        // TODO: Swap `fold1` with stdlib's `fold_first` when it's stabilized
+        let group_map_lookup = a.iter()
+            .map(|&b| b as u64)
+            .map(|i| (i % modulo, i))
+            .into_group_map()
+            .into_iter()
+            .map(|(key, vals)| (key, vals.into_iter().fold1(|acc, val| acc + val).unwrap()))
+            .collect::<HashMap<_,_>>();
+        assert_eq!(lookup, group_map_lookup);
 
         for (&key, &sum) in lookup.iter() {
             assert_eq!(sum, a.iter().map(|&b| b as u64).filter(|&val| val % modulo == key).sum::<u64>());
@@ -1272,6 +1308,14 @@ quickcheck! {
         let count = a.len();
         let lookup = a.iter().copied().into_grouping_map_by(|i| i % modulo).count();
 
+        let group_map_lookup = a.iter().copied()
+            .map(|i| (i % modulo, i))
+            .into_group_map()
+            .into_iter()
+            .map(|(key, vals)| (key, vals.len()))
+            .collect::<HashMap<_,_>>();
+        assert_eq!(lookup, group_map_lookup);
+
         assert_eq!(lookup.values().sum::<usize>(), count);
 
         for (&key, &count) in lookup.iter() {
@@ -1283,8 +1327,50 @@ quickcheck! {
         let modulo = if modulo == 0 { 1 } else { modulo }; // Avoid `% 0`
         let lookup = a.iter().copied().into_grouping_map_by(|i| i % modulo).max();
 
+        let group_map_lookup = a.iter().copied()
+            .map(|i| (i % modulo, i))
+            .into_group_map()
+            .into_iter()
+            .map(|(key, vals)| (key, vals.into_iter().max().unwrap()))
+            .collect::<HashMap<_,_>>();
+        assert_eq!(lookup, group_map_lookup);
+
         for (&key, &max) in lookup.iter() {
             assert_eq!(Some(max), a.iter().copied().filter(|&val| val % modulo == key).max());
+        }
+    }
+
+    fn correct_grouping_map_by_max_by_modulo_key(a: Vec<u8>, modulo: u8) -> () {
+        let modulo = if modulo == 0 { 1 } else { modulo }; // Avoid `% 0`
+        let lookup = a.iter().copied().into_grouping_map_by(|i| i % modulo).max_by(|_, v1, v2| v1.cmp(v2));
+
+        let group_map_lookup = a.iter().copied()
+            .map(|i| (i % modulo, i))
+            .into_group_map()
+            .into_iter()
+            .map(|(key, vals)| (key, vals.into_iter().max_by(|v1, v2| v1.cmp(v2)).unwrap()))
+            .collect::<HashMap<_,_>>();
+        assert_eq!(lookup, group_map_lookup);
+
+        for (&key, &max) in lookup.iter() {
+            assert_eq!(Some(max), a.iter().copied().filter(|&val| val % modulo == key).max_by(|v1, v2| v1.cmp(v2)));
+        }
+    }
+
+    fn correct_grouping_map_by_max_by_key_modulo_key(a: Vec<u8>, modulo: u8) -> () {
+        let modulo = if modulo == 0 { 1 } else { modulo }; // Avoid `% 0`
+        let lookup = a.iter().copied().into_grouping_map_by(|i| i % modulo).max_by_key(|_, &val| val);
+
+        let group_map_lookup = a.iter().copied()
+            .map(|i| (i % modulo, i))
+            .into_group_map()
+            .into_iter()
+            .map(|(key, vals)| (key, vals.into_iter().max_by_key(|&val| val).unwrap()))
+            .collect::<HashMap<_,_>>();
+        assert_eq!(lookup, group_map_lookup);
+
+        for (&key, &max) in lookup.iter() {
+            assert_eq!(Some(max), a.iter().copied().filter(|&val| val % modulo == key).max_by_key(|&val| val));
         }
     }
     
@@ -1292,8 +1378,50 @@ quickcheck! {
         let modulo = if modulo == 0 { 1 } else { modulo }; // Avoid `% 0`
         let lookup = a.iter().copied().into_grouping_map_by(|i| i % modulo).min();
 
+        let group_map_lookup = a.iter().copied()
+            .map(|i| (i % modulo, i))
+            .into_group_map()
+            .into_iter()
+            .map(|(key, vals)| (key, vals.into_iter().min().unwrap()))
+            .collect::<HashMap<_,_>>();
+        assert_eq!(lookup, group_map_lookup);
+
         for (&key, &min) in lookup.iter() {
             assert_eq!(Some(min), a.iter().copied().filter(|&val| val % modulo == key).min());
+        }
+    }
+
+    fn correct_grouping_map_by_min_by_modulo_key(a: Vec<u8>, modulo: u8) -> () {
+        let modulo = if modulo == 0 { 1 } else { modulo }; // Avoid `% 0`
+        let lookup = a.iter().copied().into_grouping_map_by(|i| i % modulo).min_by(|_, v1, v2| v1.cmp(v2));
+
+        let group_map_lookup = a.iter().copied()
+            .map(|i| (i % modulo, i))
+            .into_group_map()
+            .into_iter()
+            .map(|(key, vals)| (key, vals.into_iter().min_by(|v1, v2| v1.cmp(v2)).unwrap()))
+            .collect::<HashMap<_,_>>();
+        assert_eq!(lookup, group_map_lookup);
+
+        for (&key, &min) in lookup.iter() {
+            assert_eq!(Some(min), a.iter().copied().filter(|&val| val % modulo == key).min_by(|v1, v2| v1.cmp(v2)));
+        }
+    }
+
+    fn correct_grouping_map_by_min_by_key_modulo_key(a: Vec<u8>, modulo: u8) -> () {
+        let modulo = if modulo == 0 { 1 } else { modulo }; // Avoid `% 0`
+        let lookup = a.iter().copied().into_grouping_map_by(|i| i % modulo).min_by_key(|_, &val| val);
+
+        let group_map_lookup = a.iter().copied()
+            .map(|i| (i % modulo, i))
+            .into_group_map()
+            .into_iter()
+            .map(|(key, vals)| (key, vals.into_iter().min_by_key(|&val| val).unwrap()))
+            .collect::<HashMap<_,_>>();
+        assert_eq!(lookup, group_map_lookup);
+
+        for (&key, &min) in lookup.iter() {
+            assert_eq!(Some(min), a.iter().copied().filter(|&val| val % modulo == key).min_by_key(|&val| val));
         }
     }
     
@@ -1301,8 +1429,50 @@ quickcheck! {
         let modulo = if modulo == 0 { 1 } else { modulo }; // Avoid `% 0`
         let lookup = a.iter().copied().into_grouping_map_by(|i| i % modulo).minmax();
 
+        let group_map_lookup = a.iter().copied()
+            .map(|i| (i % modulo, i))
+            .into_group_map()
+            .into_iter()
+            .map(|(key, vals)| (key, vals.into_iter().minmax()))
+            .collect::<HashMap<_,_>>();
+        assert_eq!(lookup, group_map_lookup);
+
         for (&key, &minmax) in lookup.iter() {
             assert_eq!(minmax, a.iter().copied().filter(|&val| val % modulo == key).minmax());
+        }
+    }
+
+    fn correct_grouping_map_by_minmax_by_modulo_key(a: Vec<u8>, modulo: u8) -> () {
+        let modulo = if modulo == 0 { 1 } else { modulo }; // Avoid `% 0`
+        let lookup = a.iter().copied().into_grouping_map_by(|i| i % modulo).minmax_by(|_, v1, v2| v1.cmp(v2));
+
+        let group_map_lookup = a.iter().copied()
+            .map(|i| (i % modulo, i))
+            .into_group_map()
+            .into_iter()
+            .map(|(key, vals)| (key, vals.into_iter().minmax_by(|v1, v2| v1.cmp(v2))))
+            .collect::<HashMap<_,_>>();
+        assert_eq!(lookup, group_map_lookup);
+
+        for (&key, &minmax) in lookup.iter() {
+            assert_eq!(minmax, a.iter().copied().filter(|&val| val % modulo == key).minmax_by(|v1, v2| v1.cmp(v2)));
+        }
+    }
+
+    fn correct_grouping_map_by_minmax_by_key_modulo_key(a: Vec<u8>, modulo: u8) -> () {
+        let modulo = if modulo == 0 { 1 } else { modulo }; // Avoid `% 0`
+        let lookup = a.iter().copied().into_grouping_map_by(|i| i % modulo).minmax_by_key(|_, &val| val);
+
+        let group_map_lookup = a.iter().copied()
+            .map(|i| (i % modulo, i))
+            .into_group_map()
+            .into_iter()
+            .map(|(key, vals)| (key, vals.into_iter().minmax_by_key(|&val| val)))
+            .collect::<HashMap<_,_>>();
+        assert_eq!(lookup, group_map_lookup);
+
+        for (&key, &minmax) in lookup.iter() {
+            assert_eq!(minmax, a.iter().copied().filter(|&val| val % modulo == key).minmax_by_key(|&val| val));
         }
     }
 
@@ -1311,6 +1481,14 @@ quickcheck! {
         let lookup = a.iter().map(|&b| b as u64) // Avoid overflows
             .into_grouping_map_by(|i| i % modulo)
             .sum();
+
+        let group_map_lookup = a.iter().map(|&b| b as u64)
+            .map(|i| (i % modulo, i))
+            .into_group_map()
+            .into_iter()
+            .map(|(key, vals)| (key, vals.into_iter().sum()))
+            .collect::<HashMap<_,_>>();
+        assert_eq!(lookup, group_map_lookup);
 
         for (&key, &sum) in lookup.iter() {
             assert_eq!(sum, a.iter().map(|&b| b as u64).filter(|&val| val % modulo == key).sum::<u64>());
@@ -1322,6 +1500,14 @@ quickcheck! {
         let lookup = a.iter().map(|&b| Wrapping(b as u64)) // Avoid overflows
             .into_grouping_map_by(|i| i % modulo)
             .product();
+
+        let group_map_lookup = a.iter().map(|&b| Wrapping(b as u64))
+            .map(|i| (i % modulo, i))
+            .into_group_map()
+            .into_iter()
+            .map(|(key, vals)| (key, vals.into_iter().product::<Wrapping<u64>>()))
+            .collect::<HashMap<_,_>>();
+        assert_eq!(lookup, group_map_lookup);
 
         for (&key, &prod) in lookup.iter() {
             assert_eq!(

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -1200,19 +1200,6 @@ quickcheck! {
         assert_eq!(lookup_grouping_map, lookup_grouping_map_by);
     }
 
-    fn correct_grouping_map_by_modulo_key(a: Vec<u8>, modulo: u8) -> () {
-        let modulo = if modulo == 0 { 1 } else { modulo }; // Avoid `% 0`
-        let count = a.len();
-        let lookup = a.into_iter().into_grouping_map_by(|i| i % modulo).collect::<Vec<_>>();
-
-        assert_eq!(lookup.len(), (0..modulo).filter(|i| lookup.contains_key(i)).count());
-        assert_eq!(lookup.values().flat_map(|vals| vals.iter()).count(), count);
-
-        for (&key, vals) in lookup.iter() {
-            assert!(vals.iter().all(|&val| val % modulo == key));
-        }
-    }
-
     fn correct_grouping_map_by_aggregate_modulo_key(a: Vec<u8>, modulo: u8) -> () {
         let modulo = if modulo < 2 { 2 } else { modulo } as u64; // Avoid `% 0`
         let lookup = a.iter()

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -1303,26 +1303,6 @@ quickcheck! {
         assert_eq!(lookup_grouping_map, lookup_group_map);
     }
 
-    fn correct_grouping_map_by_count_modulo_key(a: Vec<u8>, modulo: u8) -> () {
-        let modulo = if modulo == 0 { 1 } else { modulo }; // Avoid `% 0`
-        let count = a.len();
-        let lookup = a.iter().copied().into_grouping_map_by(|i| i % modulo).count();
-
-        let group_map_lookup = a.iter().copied()
-            .map(|i| (i % modulo, i))
-            .into_group_map()
-            .into_iter()
-            .map(|(key, vals)| (key, vals.len()))
-            .collect::<HashMap<_,_>>();
-        assert_eq!(lookup, group_map_lookup);
-
-        assert_eq!(lookup.values().sum::<usize>(), count);
-
-        for (&key, &count) in lookup.iter() {
-            assert_eq!(count, a.iter().filter(|&val| val % modulo == key).count());
-        }
-    }
-
     fn correct_grouping_map_by_max_modulo_key(a: Vec<u8>, modulo: u8) -> () {
         let modulo = if modulo == 0 { 1 } else { modulo }; // Avoid `% 0`
         let lookup = a.iter().copied().into_grouping_map_by(|i| i % modulo).max();


### PR DESCRIPTION
Adds two functions on the `Itertools` trait, `into_grouping_map` and `into_grouping_map_by`. 

`into_grouping_map` expects an iter of `(K, V)` where the `K` will be used as key and `V` as value. 
`into_grouping_map_by` expect only an iter of `V` as values, the keys will be calculated using the provided functions. 

Both of them return a `GroupingMap`, which is just a wrapper on an iterator. Since it introduces a lot of related methods I thought it would be better to separate them from the `Itertools` trait. This also prevents duplicating every method for the `_by` version.

All of these functions have in common the fact they perform efficient group-and-fold operations without allocating temporary vecs like you would normally do if you used `into_group_map` + `into_iter` + `map` + `collect::<HashMap<_, _>>()`.

Here's the possible issues I can see, I would like to hear some feedback before trying to fix any of them:
- name: I initially though of `grouping_by` which is the java/kotlin equivalent, but later changed it to `into_grouping_map` to match the already existing `into_group_map` and to differentiate from `group_by`;
- `fold_first`: the equivalent function in the `Itertools` trait is `fold1` but there's an unstable stdlib function that does the same thing and is called `fold_first`. I decided to be consistent with the stdlib;
- `minmax` return type is the already existing `MinMaxResult`, but the `NoElements` variant is never returned. I didn't want to duplicate that struct thinking it could cause confusion (and if I did what name could I have chosen?);
- `sum` and `product`: They dont' use the `Sum` and `Product` traits but instead require `V: Add<V, Output=V>` and `V: Mul<V, Output=V>`. They're pretty much a wrapper around `fold_first`. I don't really know if they're meaningful or if I should just remove them;
- almost every closure takes as one of the parameters a reference to the key. It bloats them a bit, but could be useful if computing the key is a relatively expensive operation.
- no `scan` function. Even though it is an iterator adapter I could sort of "collect" it into a `Vec` (more like extend) but I don't really see an use for this;
- ~~no integration tests for the `_by` and `_by_key` versions of `min`, `max` and `minmax`. To be fair I was a bit lazy, but I also couldn't find any integration test for the normal `minmax_by` and `minmax_by_key` so I though it was fine;~~ added;
- no benchmark (I don't think it is required but probably would be cool to compare this with `into_group_map`;
- I didn't want to touch the rest of the library, but I guess we could implement `into_group_map` in terms of `into_grouping_map`?

Related issues: #457, #309
Related PR: #406 (in particular relates to the `into_group_map_by_fold` function that was proposed but later removed)