### PR TITLE
modify example of unfold so that it uses the initial_state value

### DIFF
--- a/src/sources.rs
+++ b/src/sources.rs
@@ -76,22 +76,21 @@ impl<A, F> Iterator for RepeatCall<F>
 ///
 /// use itertools::unfold;
 ///
-/// let (mut x1, mut x2) = (1u32, 1u32);
-/// let mut fibonacci = unfold((), move |_| {
+/// let mut fibonacci = unfold((1u32, 1u32), |(x1, x2)| {
 ///     // Attempt to get the next Fibonacci number
-///     let next = x1.saturating_add(x2);
+///     let next = x1.saturating_add(*x2);
 ///
 ///     // Shift left: ret <- x1 <- x2 <- next
-///     let ret = x1;
-///     x1 = x2;
-///     x2 = next;
+///     let ret = *x1;
+///     *x1 = *x2;
+///     *x2 = next;
 ///
 ///     // If addition has saturated at the maximum, we are finished
-///     if ret == x1 && ret > 1 {
-///         return None;
+///     if ret == *x1 && ret > 1 {
+///         None
+///     } else {
+///         Some(ret)
 ///     }
-///
-///     Some(ret)
 /// });
 ///
 /// itertools::assert_equal(fibonacci.by_ref().take(8),


### PR DESCRIPTION
The example of `itertools::unfold` could easily be written with `std::iter::from_fn` because it ignores `initial_value` and uses captured variables instead:

```rust
let (mut x1, mut x2) = (1u32, 1u32);
let mut fibonacci = std::iter::from_fn(move || {
    // Attempt to get the next Fibonacci number
    let next = x1.saturating_add(x2);

    // Shift left: ret <- x1 <- x2 <- next
    let ret = x1;
    x1 = x2;
    x2 = next;

    // If addition has saturated at the maximum, we are finished
    if ret == x1 && ret > 1 {
        return None;
    }

    Some(ret)
});

itertools::assert_equal(fibonacci.by_ref().take(8),
                        vec![1, 1, 2, 3, 5, 8, 13, 21]);
assert_eq!(fibonacci.last(), Some(2_971_215_073))
```

`initial_value` is basically the whole point of `itertools::unfold`, the thing that distinguishes it from `std::iter::from_fn`, so I rewrote the example.