### PR TITLE
Create counts method and tests for it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2807,6 +2807,30 @@ pub trait Itertools : Iterator {
     {
         multipeek_impl::multipeek(self)
     }
+
+    /// Collect the items in this iterator and return a `HashMap` which
+    /// contains each item that appears in the iterator and the number
+    /// of times it appears.
+    ///
+    /// # Examples
+    /// ```
+    /// # use itertools::Itertools;
+    /// let counts = [1, 1, 1, 3, 3, 5].into_iter().counts();
+    /// assert_eq!(counts[&1], 3);
+    /// assert_eq!(counts[&3], 2);
+    /// assert_eq!(counts[&5], 1);
+    /// assert_eq!(counts.get(&0), None);
+    /// ```
+    #[cfg(feature = "use_std")]
+    fn counts(self) -> HashMap<Self::Item, usize>
+    where
+        Self: Sized,
+        Self::Item: Eq + Hash,
+    {
+        let mut counts = HashMap::new();
+        self.for_each(|item| *counts.entry(item).or_default() += 1);
+        counts
+    }
 }
 
 impl<T: ?Sized> Itertools for T where T: Iterator { }

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -1188,3 +1188,24 @@ quickcheck! {
         }
     }
 }
+
+quickcheck! {
+    #[test]
+    fn counts(nums: Vec<isize>) -> TestResult {
+        let counts = nums.iter().counts();
+        for (&item, &count) in counts.iter() {
+            if count <= 0 {
+                return TestResult::failed();
+            }
+            if count != nums.iter().filter(|&x| x == item).count() {
+                return TestResult::failed();
+            }
+        }
+        for item in nums.iter() {
+            if !counts.contains_key(item) {
+                return TestResult::failed();
+            }
+        }
+        TestResult::passed()
+    }
+}

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -913,16 +913,3 @@ fn tree_fold1() {
         assert_eq!(actual, expected);
     }
 }
-
-#[test]
-fn counts() {
-    let a: [usize; 0] = [];
-    assert_eq!(0, a.iter().counts().len());
-    let b = [1, 1, 1, 2, 2, 3];
-    let b_counts = b.iter().counts();
-    assert_eq!(3, b_counts.len());
-    assert_eq!(Some(&3), b_counts.get(&1));
-    assert_eq!(Some(&2), b_counts.get(&2));
-    assert_eq!(Some(&1), b_counts.get(&3));
-    assert_eq!(None, b_counts.get(&4));
-}

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -913,3 +913,16 @@ fn tree_fold1() {
         assert_eq!(actual, expected);
     }
 }
+
+#[test]
+fn counts() {
+    let a: [usize; 0] = [];
+    assert_eq!(0, a.iter().counts().len());
+    let b = [1, 1, 1, 2, 2, 3];
+    let b_counts = b.iter().counts();
+    assert_eq!(3, b_counts.len());
+    assert_eq!(Some(&3), b_counts.get(&1));
+    assert_eq!(Some(&2), b_counts.get(&2));
+    assert_eq!(Some(&1), b_counts.get(&3));
+    assert_eq!(None, b_counts.get(&4));
+}


### PR DESCRIPTION
Creates the function described in #467 (I went with the name `counts`).

It currently uses `for_each` and makes a `HashMap` manually because the PR for the `into_grouping_map` function is still being worked on, but this function could easily be changed to call it once that PR is merged, if desired.