### PR TITLE
more no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ test = false
 
 [dependencies]
 either = { version = "1.0", default-features = false }
+hashbrown = { version = "0.8", optional = true}
 
 [dev-dependencies]
 rand = "0.7"
@@ -38,6 +39,7 @@ version = "0.2"
 
 [features]
 default = ["use_std"]
+use_alloc = ["hashbrown"]
 use_std = []
 
 [profile]

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -11,7 +11,6 @@ pub use self::coalesce::*;
 pub use self::map::{map_into, map_ok, MapInto, MapOk};
 #[allow(deprecated)]
 pub use self::map::MapResults;
-#[cfg(feature = "use_std")]
 pub use self::multi_product::*;
 
 use std::fmt;

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -1,5 +1,5 @@
-#![cfg(feature = "use_std")]
 
+use crate::lib::Vec;
 use crate::size_hint;
 use crate::Itertools;
 

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use crate::lib::Vec;
 
 use super::lazy_buffer::LazyBuffer;
 

--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -1,5 +1,9 @@
 use std::fmt;
 
+#[cfg(not(feature = "use_std"))]
+use crate::lib::vec;
+use crate::lib::Vec;
+
 use super::lazy_buffer::LazyBuffer;
 
 /// An iterator to iterate through all the `n`-length combinations in an iterator, with replacement.

--- a/src/free.rs
+++ b/src/free.rs
@@ -4,10 +4,10 @@
 //! argument, so the resulting code may be easier to read.
 
 #[cfg(feature = "use_std")]
+use crate::VecIntoIter;
+#[cfg(feature = "use_std")]
 use std::fmt::Display;
 use std::iter::{self, Zip};
-#[cfg(feature = "use_std")]
-type VecIntoIter<T> = ::std::vec::IntoIter<T>;
 
 #[cfg(feature = "use_std")]
 use crate::Itertools;
@@ -17,13 +17,11 @@ pub use crate::adaptors::{
     merge,
     put_back,
 };
-#[cfg(feature = "use_std")]
 pub use crate::put_back_n_impl::put_back_n;
 #[cfg(feature = "use_std")]
 pub use crate::multipeek_impl::multipeek;
 #[cfg(feature = "use_std")]
 pub use crate::peek_nth::peek_nth;
-#[cfg(feature = "use_std")]
 pub use crate::kmerge_impl::kmerge;
 pub use crate::zip_eq_impl::zip_eq;
 pub use crate::merge_join::merge_join_by;

--- a/src/group_map.rs
+++ b/src/group_map.rs
@@ -1,6 +1,5 @@
-#![cfg(feature = "use_std")]
 
-use std::collections::HashMap;
+use crate::lib::{HashMap, Vec};
 use std::hash::Hash;
 use std::iter::Iterator;
 
@@ -21,6 +20,7 @@ pub fn into_group_map<I, K, V>(iter: I) -> HashMap<K, Vec<V>>
     lookup
 }
 
+#[cfg(feature = "use_std")]
 pub fn into_group_map_by<I, K, V>(iter: I, f: impl Fn(&V) -> K) -> HashMap<K, Vec<V>>
     where
         I: Iterator<Item=V>,

--- a/src/groupbylazy.rs
+++ b/src/groupbylazy.rs
@@ -1,5 +1,5 @@
 use std::cell::{Cell, RefCell};
-use std::vec;
+use crate::lib::{vec, Vec};
 
 /// A trait to unify FnMut for GroupBy with the chunk key in IntoChunks
 trait KeyFunction<A> {

--- a/src/kmerge_impl.rs
+++ b/src/kmerge_impl.rs
@@ -1,5 +1,6 @@
 use crate::size_hint;
 use crate::Itertools;
+use crate::lib::Vec;
 
 use std::mem::replace;
 use std::fmt;

--- a/src/lazy_buffer.rs
+++ b/src/lazy_buffer.rs
@@ -1,4 +1,5 @@
 use std::ops::Index;
+use crate::lib::Vec;
 
 #[derive(Debug, Clone)]
 pub struct LazyBuffer<I: Iterator> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,18 +52,41 @@ extern crate core as std;
 
 pub use either::Either;
 
-#[cfg(feature = "use_std")]
-use std::collections::HashMap;
-use std::iter::{IntoIterator, once};
+#[cfg(all(not(feature = "use_std"), feature = "use_alloc"))]
+extern crate alloc;
+
+
+#[doc(hidden)]
+pub mod lib {
+    #[cfg(all(not(feature = "use_std"), feature = "use_alloc"))]
+    pub use alloc::vec;
+    #[cfg(all(not(feature = "use_std"), feature = "use_alloc"))]
+    pub use alloc::vec::Vec;
+    #[cfg(feature = "use_std")]
+    pub use std::vec::{self, Vec};
+
+    #[cfg(all(not(feature = "use_std"), feature = "use_alloc"))]
+    pub use alloc::rc::Rc;
+    #[cfg(feature = "use_std")]
+    pub use std::rc::Rc;
+
+    #[cfg(all(not(feature = "use_std"), feature = "use_alloc"))]
+    pub use alloc::collections::VecDeque;
+    #[cfg(all(not(feature = "use_std"), feature = "use_alloc"))]
+    pub use hashbrown::{hash_map::Entry, HashMap, HashSet};
+    #[cfg(feature = "use_std")]
+    pub use std::collections::{hash_map::Entry, HashMap, HashSet, VecDeque};
+}
+
+use lib::*;
+
 use std::cmp::Ordering;
 use std::fmt;
-#[cfg(feature = "use_std")]
 use std::hash::Hash;
 #[cfg(feature = "use_std")]
 use std::fmt::Write;
-#[cfg(feature = "use_std")]
-type VecIntoIter<T> = ::std::vec::IntoIter<T>;
-#[cfg(feature = "use_std")]
+use std::iter::{once, IntoIterator};
+type VecIntoIter<T> = vec::IntoIter<T>;
 use std::iter::FromIterator;
 
 #[macro_use]
@@ -98,21 +121,17 @@ pub mod structs {
         Positions,
         Update,
     };
+    
     #[allow(deprecated)]
     pub use crate::adaptors::{MapResults, Step};
-    #[cfg(feature = "use_std")]
     pub use crate::adaptors::MultiProduct;
-    #[cfg(feature = "use_std")]
     pub use crate::combinations::Combinations;
-    #[cfg(feature = "use_std")]
     pub use crate::combinations_with_replacement::CombinationsWithReplacement;
     pub use crate::cons_tuples_impl::ConsTuples;
     pub use crate::exactly_one_err::ExactlyOneError;
     pub use crate::format::{Format, FormatWith};
-    #[cfg(feature = "use_std")]
     pub use crate::groupbylazy::{IntoChunks, Chunk, Chunks, GroupBy, Group, Groups};
     pub use crate::intersperse::{Intersperse, IntersperseWith};
-    #[cfg(feature = "use_std")]
     pub use crate::kmerge_impl::{KMerge, KMergeBy};
     pub use crate::merge_join::MergeJoinBy;
     #[cfg(feature = "use_std")]
@@ -120,21 +139,17 @@ pub mod structs {
     #[cfg(feature = "use_std")]
     pub use crate::peek_nth::PeekNth;
     pub use crate::pad_tail::PadUsing;
-    pub use crate::peeking_take_while::PeekingTakeWhile;
     #[cfg(feature = "use_std")]
+    pub use crate::peeking_take_while::PeekingTakeWhile;
     pub use crate::permutations::Permutations;
     pub use crate::process_results_impl::ProcessResults;
-    #[cfg(feature = "use_std")]
     pub use crate::put_back_n_impl::PutBackN;
-    #[cfg(feature = "use_std")]
     pub use crate::rciter_impl::RcIter;
     pub use crate::repeatn::RepeatN;
     #[allow(deprecated)]
     pub use crate::sources::{RepeatCall, Unfold, Iterate};
-    #[cfg(feature = "use_std")]
     pub use crate::tee::Tee;
     pub use crate::tuple_impl::{TupleBuffer, TupleWindows, CircularTupleWindows, Tuples};
-    #[cfg(feature = "use_std")]
     pub use crate::unique_impl::{Unique, UniqueBy};
     pub use crate::with_position::WithPosition;
     pub use crate::zip_eq_impl::ZipEq;
@@ -153,9 +168,9 @@ pub use crate::concat_impl::concat;
 pub use crate::cons_tuples_impl::cons_tuples;
 pub use crate::diff::diff_with;
 pub use crate::diff::Diff;
-#[cfg(feature = "use_std")]
 pub use crate::kmerge_impl::{kmerge_by};
 pub use crate::minmax::MinMaxResult;
+#[cfg(feature = "use_std")]
 pub use crate::peeking_take_while::PeekingNext;
 pub use crate::process_results_impl::process_results;
 pub use crate::repeatn::repeat_n;
@@ -172,21 +187,15 @@ pub mod free;
 pub use crate::free::*;
 mod concat_impl;
 mod cons_tuples_impl;
-#[cfg(feature = "use_std")]
 mod combinations;
-#[cfg(feature = "use_std")]
 mod combinations_with_replacement;
 mod exactly_one_err;
 mod diff;
 mod format;
-#[cfg(feature = "use_std")]
 mod group_map;
-#[cfg(feature = "use_std")]
 mod groupbylazy;
 mod intersperse;
-#[cfg(feature = "use_std")]
 mod kmerge_impl;
-#[cfg(feature = "use_std")]
 mod lazy_buffer;
 mod merge_join;
 mod minmax;
@@ -195,21 +204,17 @@ mod multipeek_impl;
 mod pad_tail;
 #[cfg(feature = "use_std")]
 mod peek_nth;
-mod peeking_take_while;
 #[cfg(feature = "use_std")]
+mod peeking_take_while;
 mod permutations;
 mod process_results_impl;
-#[cfg(feature = "use_std")]
 mod put_back_n_impl;
-#[cfg(feature = "use_std")]
 mod rciter_impl;
 mod repeatn;
 mod size_hint;
 mod sources;
-#[cfg(feature = "use_std")]
 mod tee;
 mod tuple_impl;
-#[cfg(feature = "use_std")]
 mod unique_impl;
 mod with_position;
 mod zip_eq_impl;
@@ -530,7 +535,6 @@ pub trait Itertools : Iterator {
     /// }
     /// assert_eq!(data_grouped, vec![(true, vec![1, 3]), (false, vec![-2, -2]), (true, vec![1, 0, 1, 2])]);
     /// ```
-    #[cfg(feature = "use_std")]
     fn group_by<K, F>(self, key: F) -> GroupBy<K, Self, F>
         where Self: Sized,
               F: FnMut(&Self::Item) -> K,
@@ -566,7 +570,6 @@ pub trait Itertools : Iterator {
     ///     assert_eq!(4, chunk.sum());
     /// }
     /// ```
-    #[cfg(feature = "use_std")]
     fn chunks(self, size: usize) -> IntoChunks<Self>
         where Self: Sized,
     {
@@ -704,7 +707,6 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(t2, 0..4);
     /// itertools::assert_equal(t1, 1..4);
     /// ```
-    #[cfg(feature = "use_std")]
     fn tee(self) -> (Tee<Self>, Tee<Self>)
         where Self: Sized,
               Self::Item: Clone
@@ -911,7 +913,6 @@ pub trait Itertools : Iterator {
     /// let it = vec![a, b, c].into_iter().kmerge();
     /// itertools::assert_equal(it, vec![0, 1, 2, 3, 4, 5]);
     /// ```
-    #[cfg(feature = "use_std")]
     fn kmerge(self) -> KMerge<<Self::Item as IntoIterator>::IntoIter>
         where Self: Sized,
               Self::Item: IntoIterator,
@@ -940,7 +941,6 @@ pub trait Itertools : Iterator {
     /// assert_eq!(it.next(), Some(0.));
     /// assert_eq!(it.last(), Some(-7.));
     /// ```
-    #[cfg(feature = "use_std")]
     fn kmerge_by<F>(self, first: F)
         -> KMergeBy<<Self::Item as IntoIterator>::IntoIter, F>
         where Self: Sized,
@@ -996,7 +996,6 @@ pub trait Itertools : Iterator {
     /// assert_eq!(multi_prod.next(), Some(vec![1, 3, 5]));
     /// assert_eq!(multi_prod.next(), None);
     /// ```
-    #[cfg(feature = "use_std")]
     fn multi_cartesian_product(self) -> MultiProduct<<Self::Item as IntoIterator>::IntoIter>
         where Self: Iterator + Sized,
               Self::Item: IntoIterator,
@@ -1147,7 +1146,6 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(data.into_iter().unique(),
     ///                         vec![10, 20, 30, 40, 50]);
     /// ```
-    #[cfg(feature = "use_std")]
     fn unique(self) -> Unique<Self>
         where Self: Sized,
               Self::Item: Clone + Eq + Hash
@@ -1173,7 +1171,6 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(data.into_iter().unique_by(|s| s.len()),
     ///                         vec!["a", "bb", "ccc"]);
     /// ```
-    #[cfg(feature = "use_std")]
     fn unique_by<V, F>(self, f: F) -> UniqueBy<Self, V, F>
         where Self: Sized,
               V: Eq + Hash,
@@ -1194,6 +1191,7 @@ pub trait Itertools : Iterator {
     ///
     /// See also [`.take_while_ref()`](#method.take_while_ref)
     /// which is a similar adaptor.
+    #[cfg(feature = "use_std")]
     fn peeking_take_while<F>(&mut self, accept: F) -> PeekingTakeWhile<Self, F>
         where Self: Sized + PeekingNext,
               F: FnMut(&Self::Item) -> bool,
@@ -1316,7 +1314,6 @@ pub trait Itertools : Iterator {
     ///     vec![2, 2],
     /// ]);
     /// ```
-    #[cfg(feature = "use_std")]
     fn combinations(self, k: usize) -> Combinations<Self>
         where Self: Sized,
               Self::Item: Clone
@@ -1343,7 +1340,6 @@ pub trait Itertools : Iterator {
     ///     vec![3, 3],
     /// ]);
     /// ```
-    #[cfg(feature = "use_std")]
     fn combinations_with_replacement(self, k: usize) -> CombinationsWithReplacement<Self>
     where
         Self: Sized,
@@ -1389,7 +1385,6 @@ pub trait Itertools : Iterator {
     ///
     /// Note: The source iterator is collected lazily, and will not be
     /// re-iterated if the permutations adaptor is completed and re-iterated.
-    #[cfg(feature = "use_std")]
     fn permutations(self, k: usize) -> Permutations<Self>
         where Self: Sized,
               Self::Item: Clone
@@ -1681,7 +1676,6 @@ pub trait Itertools : Iterator {
 
     /// `.collect_vec()` is simply a type specialization of `.collect()`,
     /// for convenience.
-    #[cfg(feature = "use_std")]
     fn collect_vec(self) -> Vec<Self::Item>
         where Self: Sized
     {
@@ -1708,7 +1702,6 @@ pub trait Itertools : Iterator {
     ///     Ok(())
     /// }
     /// ```
-    #[cfg(feature = "use_std")]
     fn try_collect<T, U, E>(self) -> Result<U, E>
     where
         Self: Sized + Iterator<Item = Result<T, E>>,
@@ -2189,7 +2182,6 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(text.chars().sorted(),
     ///                         "abcdef".chars());
     /// ```
-    #[cfg(feature = "use_std")]
     fn sorted(self) -> VecIntoIter<Self::Item>
         where Self: Sized,
               Self::Item: Ord
@@ -2224,7 +2216,6 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(oldest_people_first,
     ///                         vec!["Jill", "Jack", "Jane", "John"]);
     /// ```
-    #[cfg(feature = "use_std")]
     fn sorted_by<F>(self, cmp: F) -> VecIntoIter<Self::Item>
         where Self: Sized,
               F: FnMut(&Self::Item, &Self::Item) -> Ordering,
@@ -2257,7 +2248,6 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(oldest_people_first,
     ///                         vec!["Jill", "Jack", "Jane", "John"]);
     /// ```
-    #[cfg(feature = "use_std")]
     fn sorted_by_key<K, F>(self, f: F) -> VecIntoIter<Self::Item>
         where Self: Sized,
               K: Ord,
@@ -2320,7 +2310,6 @@ pub trait Itertools : Iterator {
     /// assert_eq!(lookup[&2], vec![12, 42]);
     /// assert_eq!(lookup[&3], vec![13, 33]);
     /// ```
-    #[cfg(feature = "use_std")]
     fn into_group_map<K, V>(self) -> HashMap<K, Vec<V>>
         where Self: Iterator<Item=(K, V)> + Sized,
               K: Hash + Eq,
@@ -2821,7 +2810,6 @@ pub trait Itertools : Iterator {
     /// assert_eq!(counts[&5], 1);
     /// assert_eq!(counts.get(&0), None);
     /// ```
-    #[cfg(feature = "use_std")]
     fn counts(self) -> HashMap<Self::Item, usize>
     where
         Self: Sized,

--- a/src/multipeek_impl.rs
+++ b/src/multipeek_impl.rs
@@ -1,7 +1,10 @@
+
+#![cfg(feature = "use_std")]
 use std::iter::Fuse;
 use std::collections::VecDeque;
 use crate::size_hint;
 use crate::PeekingNext;
+
 
 /// See [`multipeek()`](../fn.multipeek.html) for more information.
 #[derive(Clone, Debug)]

--- a/src/peek_nth.rs
+++ b/src/peek_nth.rs
@@ -1,6 +1,7 @@
+use crate::lib::VecDeque;
+#[cfg(feature = "use_std")]
 use crate::size_hint;
 use crate::PeekingNext;
-use std::collections::VecDeque;
 use std::iter::Fuse;
 
 /// See [`peek_nth()`](../fn.peek_nth.html) for more information.

--- a/src/permutations.rs
+++ b/src/permutations.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 use std::iter::once;
 
+use crate::lib::Vec;
+
 use super::lazy_buffer::LazyBuffer;
 
 /// An iterator adaptor that iterates through all the `k`-permutations of the

--- a/src/put_back_n_impl.rs
+++ b/src/put_back_n_impl.rs
@@ -1,5 +1,7 @@
 use crate::size_hint;
 
+use crate::lib::Vec;
+
 /// An iterator adaptor that allows putting multiple
 /// items in front of the iterator.
 ///

--- a/src/rciter_impl.rs
+++ b/src/rciter_impl.rs
@@ -1,6 +1,8 @@
 
 use std::iter::IntoIterator;
-use std::rc::Rc;
+
+use crate::lib::Rc;
+
 use std::cell::RefCell;
 
 /// A wrapper for `Rc<RefCell<I>>`, that implements the `Iterator` trait.
@@ -44,6 +46,7 @@ pub struct RcIter<I> {
 /// iterator methods. It can only happen if the `RcIter` is reentered in
 /// `.next()`, i.e. if it somehow participates in an “iterator knot”
 /// where it is an adaptor of itself.
+#[cfg(feature = "use_std")]
 pub fn rciter<I>(iterable: I) -> RcIter<I::IntoIter>
     where I: IntoIterator
 {

--- a/src/tee.rs
+++ b/src/tee.rs
@@ -1,8 +1,8 @@
 use super::size_hint;
 
 use std::cell::RefCell;
-use std::collections::VecDeque;
-use std::rc::Rc;
+
+use crate::lib::{Rc, VecDeque};
 
 /// Common buffer object for the two tee halves
 #[derive(Debug)]

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -1,6 +1,6 @@
 
-use std::collections::HashMap;
-use std::collections::hash_map::{Entry};
+use crate::lib::{Entry, HashMap};
+
 use std::hash::Hash;
 use std::fmt;
 

--- a/tests/peeking_take_while.rs
+++ b/tests/peeking_take_while.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "use_std")]
 use itertools::Itertools;
 use itertools::{put_back, put_back_n};
 


### PR DESCRIPTION
I have implemented most functions to be able to use in `no_std` with `alloc` (by using optional feature `use_alloc`). Also I have included optional crate `hashbrown` (it is used while using `use_alloc`) for no_std `Hashmap`.
 Everything builds and tests are passing in both default and no default with feature `use_alloc`.
There are many changes due to cargo fmt, if this is a problem I can return them to previous formatting, however this will require some manual work.