### PR TITLE
Simplify tuple macro

### DIFF
--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -260,7 +260,9 @@ macro_rules! rev_for_each_ident{
 }
 
 macro_rules! impl_tuple_collect {
-    ($($Y:ident),*) => (
+    ($dummy:ident,) => {}; // stop
+    ($dummy:ident, $($Y:ident,)*) => (
+        impl_tuple_collect!($($Y,)*);
         impl<A> TupleCollect for ($(ignore_ident!($Y, A),)*) {
             type Item = A;
             type Buffer = [Option<A>; count_ident!($($Y,)*) - 1];
@@ -322,16 +324,4 @@ macro_rules! impl_tuple_collect {
         }
     )
 }
-
-impl_tuple_collect!(a);
-impl_tuple_collect!(a, b);
-impl_tuple_collect!(a, b, c);
-impl_tuple_collect!(a, b, c, d);
-impl_tuple_collect!(a, b, c, d, e);
-impl_tuple_collect!(a, b, c, d, e, f);
-impl_tuple_collect!(a, b, c, d, e, f, g);
-impl_tuple_collect!(a, b, c, d, e, f, g, h);
-impl_tuple_collect!(a, b, c, d, e, f, g, h, i);
-impl_tuple_collect!(a, b, c, d, e, f, g, h, i, j);
-impl_tuple_collect!(a, b, c, d, e, f, g, h, i, j, k);
-impl_tuple_collect!(a, b, c, d, e, f, g, h, i, j, k, l);
+impl_tuple_collect!(dummy, a, b, c, d, e, f, g, h, i, j, k, l,);

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -248,10 +248,13 @@ macro_rules! count_ident{
     () => {0};
     ($i0:ident, $($i:ident,)*) => {1 + count_ident!($($i,)*)};
 }
+macro_rules! ignore_ident{
+    ($id:ident, $($t:tt)*) => {$($t)*};
+}
 
 macro_rules! impl_tuple_collect {
-    ($($X:ident),* ; $($Y:ident),* ; $($Y_rev:ident),*) => (
-        impl<A> TupleCollect for ($($X),*,) {
+    ($($Y:ident),* ; $($Y_rev:ident),*) => (
+        impl<A> TupleCollect for ($(ignore_ident!($Y, A),)*) {
             type Item = A;
             type Buffer = [Option<A>; count_ident!($($Y,)*) - 1];
 
@@ -317,22 +320,21 @@ macro_rules! impl_tuple_collect {
 //    use itertools::Itertools;
 //
 //    for i in 1..=12 {
-//        println!("impl_tuple_collect!({ty}; {idents}; {rev_idents});",
-//            ty=iter::repeat("A").take(i).join(", "),
+//        println!("impl_tuple_collect!({idents}; {rev_idents});",
 //            idents=('a'..='z').take(i).join(", "),
 //            rev_idents=('a'..='z').take(i).collect_vec().into_iter().rev().join(", ")
 //        );
 //    }
 // It could probably be replaced by a bit more macro cleverness.
-impl_tuple_collect!(A; a; a);
-impl_tuple_collect!(A, A; a, b; b, a);
-impl_tuple_collect!(A, A, A; a, b, c; c, b, a);
-impl_tuple_collect!(A, A, A, A; a, b, c, d; d, c, b, a);
-impl_tuple_collect!(A, A, A, A, A; a, b, c, d, e; e, d, c, b, a);
-impl_tuple_collect!(A, A, A, A, A, A; a, b, c, d, e, f; f, e, d, c, b, a);
-impl_tuple_collect!(A, A, A, A, A, A, A; a, b, c, d, e, f, g; g, f, e, d, c, b, a);
-impl_tuple_collect!(A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h; h, g, f, e, d, c, b, a);
-impl_tuple_collect!(A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i; i, h, g, f, e, d, c, b, a);
-impl_tuple_collect!(A, A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i, j; j, i, h, g, f, e, d, c, b, a);
-impl_tuple_collect!(A, A, A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i, j, k; k, j, i, h, g, f, e, d, c, b, a);
-impl_tuple_collect!(A, A, A, A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i, j, k, l; l, k, j, i, h, g, f, e, d, c, b, a);
+impl_tuple_collect!(a; a);
+impl_tuple_collect!(a, b; b, a);
+impl_tuple_collect!(a, b, c; c, b, a);
+impl_tuple_collect!(a, b, c, d; d, c, b, a);
+impl_tuple_collect!(a, b, c, d, e; e, d, c, b, a);
+impl_tuple_collect!(a, b, c, d, e, f; f, e, d, c, b, a);
+impl_tuple_collect!(a, b, c, d, e, f, g; g, f, e, d, c, b, a);
+impl_tuple_collect!(a, b, c, d, e, f, g, h; h, g, f, e, d, c, b, a);
+impl_tuple_collect!(a, b, c, d, e, f, g, h, i; i, h, g, f, e, d, c, b, a);
+impl_tuple_collect!(a, b, c, d, e, f, g, h, i, j; j, i, h, g, f, e, d, c, b, a);
+impl_tuple_collect!(a, b, c, d, e, f, g, h, i, j, k; k, j, i, h, g, f, e, d, c, b, a);
+impl_tuple_collect!(a, b, c, d, e, f, g, h, i, j, k, l; l, k, j, i, h, g, f, e, d, c, b, a);

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -244,11 +244,16 @@ pub trait TupleCollect: Sized {
     fn left_shift_push(&mut self, item: Self::Item);
 }
 
+macro_rules! count_ident{
+    () => {0};
+    ($i0:ident, $($i:ident,)*) => {1 + count_ident!($($i,)*)};
+}
+
 macro_rules! impl_tuple_collect {
-    ($N:expr; $A:ident ; $($X:ident),* ; $($Y:ident),* ; $($Y_rev:ident),*) => (
+    ($A:ident ; $($X:ident),* ; $($Y:ident),* ; $($Y_rev:ident),*) => (
         impl<$A> TupleCollect for ($($X),*,) {
             type Item = $A;
-            type Buffer = [Option<$A>; $N - 1];
+            type Buffer = [Option<$A>; count_ident!($($Y,)*) - 1];
 
             #[allow(unused_assignments, unused_mut)]
             fn collect_from_iter<I>(iter: I, buf: &mut Self::Buffer) -> Option<Self>
@@ -291,7 +296,7 @@ macro_rules! impl_tuple_collect {
             }
 
             fn num_items() -> usize {
-                $N
+                count_ident!($($Y,)*)
             }
 
             fn left_shift_push(&mut self, item: $A) {
@@ -312,23 +317,22 @@ macro_rules! impl_tuple_collect {
 //    use itertools::Itertools;
 //
 //    for i in 1..=12 {
-//        println!("impl_tuple_collect!({arity}; A; {ty}; {idents}; {rev_idents});",
-//            arity=i,
+//        println!("impl_tuple_collect!(A; {ty}; {idents}; {rev_idents});",
 //            ty=iter::repeat("A").take(i).join(", "),
 //            idents=('a'..='z').take(i).join(", "),
 //            rev_idents=('a'..='z').take(i).collect_vec().into_iter().rev().join(", ")
 //        );
 //    }
 // It could probably be replaced by a bit more macro cleverness.
-impl_tuple_collect!(1; A; A; a; a);
-impl_tuple_collect!(2; A; A, A; a, b; b, a);
-impl_tuple_collect!(3; A; A, A, A; a, b, c; c, b, a);
-impl_tuple_collect!(4; A; A, A, A, A; a, b, c, d; d, c, b, a);
-impl_tuple_collect!(5; A; A, A, A, A, A; a, b, c, d, e; e, d, c, b, a);
-impl_tuple_collect!(6; A; A, A, A, A, A, A; a, b, c, d, e, f; f, e, d, c, b, a);
-impl_tuple_collect!(7; A; A, A, A, A, A, A, A; a, b, c, d, e, f, g; g, f, e, d, c, b, a);
-impl_tuple_collect!(8; A; A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h; h, g, f, e, d, c, b, a);
-impl_tuple_collect!(9; A; A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i; i, h, g, f, e, d, c, b, a);
-impl_tuple_collect!(10; A; A, A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i, j; j, i, h, g, f, e, d, c, b, a);
-impl_tuple_collect!(11; A; A, A, A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i, j, k; k, j, i, h, g, f, e, d, c, b, a);
-impl_tuple_collect!(12; A; A, A, A, A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i, j, k, l; l, k, j, i, h, g, f, e, d, c, b, a);
+impl_tuple_collect!(A; A; a; a);
+impl_tuple_collect!(A; A, A; a, b; b, a);
+impl_tuple_collect!(A; A, A, A; a, b, c; c, b, a);
+impl_tuple_collect!(A; A, A, A, A; a, b, c, d; d, c, b, a);
+impl_tuple_collect!(A; A, A, A, A, A; a, b, c, d, e; e, d, c, b, a);
+impl_tuple_collect!(A; A, A, A, A, A, A; a, b, c, d, e, f; f, e, d, c, b, a);
+impl_tuple_collect!(A; A, A, A, A, A, A, A; a, b, c, d, e, f, g; g, f, e, d, c, b, a);
+impl_tuple_collect!(A; A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h; h, g, f, e, d, c, b, a);
+impl_tuple_collect!(A; A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i; i, h, g, f, e, d, c, b, a);
+impl_tuple_collect!(A; A, A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i, j; j, i, h, g, f, e, d, c, b, a);
+impl_tuple_collect!(A; A, A, A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i, j, k; k, j, i, h, g, f, e, d, c, b, a);
+impl_tuple_collect!(A; A, A, A, A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i, j, k, l; l, k, j, i, h, g, f, e, d, c, b, a);

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -250,14 +250,14 @@ macro_rules! count_ident{
 }
 
 macro_rules! impl_tuple_collect {
-    ($A:ident ; $($X:ident),* ; $($Y:ident),* ; $($Y_rev:ident),*) => (
-        impl<$A> TupleCollect for ($($X),*,) {
-            type Item = $A;
-            type Buffer = [Option<$A>; count_ident!($($Y,)*) - 1];
+    ($($X:ident),* ; $($Y:ident),* ; $($Y_rev:ident),*) => (
+        impl<A> TupleCollect for ($($X),*,) {
+            type Item = A;
+            type Buffer = [Option<A>; count_ident!($($Y,)*) - 1];
 
             #[allow(unused_assignments, unused_mut)]
             fn collect_from_iter<I>(iter: I, buf: &mut Self::Buffer) -> Option<Self>
-                where I: IntoIterator<Item = $A>
+                where I: IntoIterator<Item = A>
             {
                 let mut iter = iter.into_iter();
                 $(
@@ -286,7 +286,7 @@ macro_rules! impl_tuple_collect {
             }
 
             fn collect_from_iter_no_buf<I>(iter: I) -> Option<Self>
-                where I: IntoIterator<Item = $A>
+                where I: IntoIterator<Item = A>
             {
                 let mut iter = iter.into_iter();
 
@@ -299,7 +299,7 @@ macro_rules! impl_tuple_collect {
                 count_ident!($($Y,)*)
             }
 
-            fn left_shift_push(&mut self, item: $A) {
+            fn left_shift_push(&mut self, item: A) {
                 use std::mem::replace;
 
                 let &mut ($(ref mut $Y),*,) = self;
@@ -317,22 +317,22 @@ macro_rules! impl_tuple_collect {
 //    use itertools::Itertools;
 //
 //    for i in 1..=12 {
-//        println!("impl_tuple_collect!(A; {ty}; {idents}; {rev_idents});",
+//        println!("impl_tuple_collect!({ty}; {idents}; {rev_idents});",
 //            ty=iter::repeat("A").take(i).join(", "),
 //            idents=('a'..='z').take(i).join(", "),
 //            rev_idents=('a'..='z').take(i).collect_vec().into_iter().rev().join(", ")
 //        );
 //    }
 // It could probably be replaced by a bit more macro cleverness.
-impl_tuple_collect!(A; A; a; a);
-impl_tuple_collect!(A; A, A; a, b; b, a);
-impl_tuple_collect!(A; A, A, A; a, b, c; c, b, a);
-impl_tuple_collect!(A; A, A, A, A; a, b, c, d; d, c, b, a);
-impl_tuple_collect!(A; A, A, A, A, A; a, b, c, d, e; e, d, c, b, a);
-impl_tuple_collect!(A; A, A, A, A, A, A; a, b, c, d, e, f; f, e, d, c, b, a);
-impl_tuple_collect!(A; A, A, A, A, A, A, A; a, b, c, d, e, f, g; g, f, e, d, c, b, a);
-impl_tuple_collect!(A; A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h; h, g, f, e, d, c, b, a);
-impl_tuple_collect!(A; A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i; i, h, g, f, e, d, c, b, a);
-impl_tuple_collect!(A; A, A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i, j; j, i, h, g, f, e, d, c, b, a);
-impl_tuple_collect!(A; A, A, A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i, j, k; k, j, i, h, g, f, e, d, c, b, a);
-impl_tuple_collect!(A; A, A, A, A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i, j, k, l; l, k, j, i, h, g, f, e, d, c, b, a);
+impl_tuple_collect!(A; a; a);
+impl_tuple_collect!(A, A; a, b; b, a);
+impl_tuple_collect!(A, A, A; a, b, c; c, b, a);
+impl_tuple_collect!(A, A, A, A; a, b, c, d; d, c, b, a);
+impl_tuple_collect!(A, A, A, A, A; a, b, c, d, e; e, d, c, b, a);
+impl_tuple_collect!(A, A, A, A, A, A; a, b, c, d, e, f; f, e, d, c, b, a);
+impl_tuple_collect!(A, A, A, A, A, A, A; a, b, c, d, e, f, g; g, f, e, d, c, b, a);
+impl_tuple_collect!(A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h; h, g, f, e, d, c, b, a);
+impl_tuple_collect!(A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i; i, h, g, f, e, d, c, b, a);
+impl_tuple_collect!(A, A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i, j; j, i, h, g, f, e, d, c, b, a);
+impl_tuple_collect!(A, A, A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i, j, k; k, j, i, h, g, f, e, d, c, b, a);
+impl_tuple_collect!(A, A, A, A, A, A, A, A, A, A, A, A; a, b, c, d, e, f, g, h, i, j, k, l; l, k, j, i, h, g, f, e, d, c, b, a);


### PR DESCRIPTION
This is a follow-up to (i.e. builds upon) https://github.com/rust-itertools/itertools/pull/475, doing some of the mentioned "macro cleverness" in the comments.