### PR TITLE
fix compiler warning on array.into_iter()

### DIFF
--- a/src/ziptuple.rs
+++ b/src/ziptuple.rs
@@ -108,7 +108,7 @@ macro_rules! impl_zip_iter {
             #[inline]
             fn next_back(&mut self) -> Option<Self::Item> {
                 let ($(ref mut $B,)*) = self.t;
-                let size = *[$( $B.len(), )*].into_iter().min().unwrap();
+                let size = *[$( $B.len(), )*].iter().min().unwrap();
 
                 $(
                     if $B.len() != size {


### PR DESCRIPTION
Fix the compile warnings listed below by changing `into_iter()` invocation to `iter()` 
in the `impl_zip_iter` macro as recommended in https://github.com/rust-lang/rust/issues/66145.
For additional background, see also https://github.com/rust-lang/rust/pull/65819 and https://github.com/rust-lang/rust/pull/66017 (the latter is the linter change producing the warning).

```
$ cargo build
   Compiling itertools v0.9.0 (/Users/dsavints/dev/hack/github.com/rust-itertools/itertools)
warning: this method call currently resolves to `<&[T; N] as IntoIterator>::into_iter` (due to autoref coercions), but that might change in the future when `IntoIterator` impls for arrays are added.
   --> src/ziptuple.rs:111:47
    |
111 |                 let size = *[$( $B.len(), )*].into_iter().min().unwrap();
    |                                               ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
...
128 | impl_zip_iter!(A);
    | ------------------ in this macro invocation
    |
    = note: `#[warn(array_into_iter)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

warning: this method call currently resolves to `<&[T; N] as IntoIterator>::into_iter` (due to autoref coercions), but that might change in the future when `IntoIterator` impls for arrays are added.
   --> src/ziptuple.rs:111:47
    |
111 |                 let size = *[$( $B.len(), )*].into_iter().min().unwrap();
    |                                               ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
...
129 | impl_zip_iter!(A, B);
    | --------------------- in this macro invocation
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #66145 <https://github.com/rust-lang/rust/issues/66145>
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```