### PR TITLE
Add fold_mut alternative to fold

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,7 @@ harness = false
 [[bench]]
 name = "bench1"
 harness = false
+
+[[bench]]
+name = "fold_mut"
+harness = false

--- a/benches/fold_mut.rs
+++ b/benches/fold_mut.rs
@@ -1,0 +1,109 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use itertools::Itertools;
+
+fn bench_sum(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fold sum accumulator");
+
+    group.bench_function("fold", |b| {
+        b.iter(|| {
+            (0i64..1_000_000)
+                .map(black_box)
+                .fold(0, |sum, n| sum + n)
+        })
+    });
+
+    group.bench_function("fold_mut", |b| {
+        b.iter(|| {
+            (0i64..1_000_000).map(black_box).fold_mut(0, |sum, n| {
+                *sum += n;
+            })
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_vec(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fold vec accumulator");
+
+    group.bench_function("fold", |b| {
+        b.iter(|| {
+            (0i64..1_000_000)
+                .map(black_box)
+                .fold(Vec::new(), |mut v, n| {
+                    v.push(n);
+                    v
+                })
+        })
+    });
+
+    group.bench_function("fold_mut", |b| {
+        b.iter(|| {
+            (0i64..1_000_000)
+                .map(black_box)
+                .fold_mut(Vec::new(), |v, n| {
+                    v.push(n);
+                })
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_num_with_chain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fold chained iterator with num accumulator");
+
+    group.bench_function("fold", |b| {
+        b.iter(|| {
+            (0i64..1_000_000)
+                .chain(0i64..1_000_000)
+                .map(black_box)
+                .fold(0, |sum, n| sum + n)
+        })
+    });
+
+    group.bench_function("fold_mut", |b| {
+        b.iter(|| {
+            (0i64..1_000_000)
+                .chain(0i64..1_000_000)
+                .map(black_box)
+                .fold_mut(0, |sum, n| {
+                    *sum += n;
+                })
+        })
+    });
+
+    group.finish();
+}
+
+fn bench_vec_with_chain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fold chained iterator with vec accumulator");
+
+    group.bench_function("fold", |b| {
+        b.iter(|| {
+            (0i64..1_000_000)
+                .chain(0i64..1_000_000)
+                .map(black_box)
+                .fold(Vec::new(), |mut v, n| {
+                    v.push(n);
+                    v
+                })
+        })
+    });
+
+    group.bench_function("fold_mut", |b| {
+        b.iter(|| {
+            (0i64..1_000_000)
+                .chain(0i64..1_000_000)
+                .map(black_box)
+                .fold_mut(Vec::new(), |v, n| {
+                    v.push(n);
+                })
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_sum, bench_vec, bench_num_with_chain, bench_vec_with_chain);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2831,6 +2831,46 @@ pub trait Itertools : Iterator {
         self.for_each(|item| *counts.entry(item).or_default() += 1);
         counts
     }
+
+    /// An alternative to [`fold()`] - `fold_mut()` also applies a function
+    /// producing a single value. The main difference is that the closure
+    /// passed to `fold_mut()` accepts a `&mut` to the accumulator instead
+    /// of consuming the accumulator. This can simplify some closures
+    /// that might otherwise be forced to return the accumulator awkwardly:
+    /// ```
+    /// let evens = [1, 2, 3, 4, 5, 6].iter().fold(Vec::new(), |mut evens, num| {
+    ///   if num % 2 == 0 {
+    ///     evens.push(num);
+    ///   }
+    ///   evens // potentially awkward return
+    /// });
+    /// ```
+    ///
+    /// `fold_mut()` may also be more performant in situations where the
+    /// accumulator is "large" as passing it by `&mut` can be cheaper than moving it.
+    ///
+    /// # Examples
+    /// ```
+    /// # use itertools::Itertools;
+    /// let evens = [1, 2, 3, 4, 5, 6].iter().fold_mut(Vec::new(), |evens, &num| {
+    ///   if num % 2 == 0 {
+    ///     evens.push(num);
+    ///   }
+    /// });
+    ///
+    /// assert_eq!(evens, [2, 4, 6]);
+    /// ```
+    /// [`fold()`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.fold
+    #[cfg(feature = "use_std")]
+    fn fold_mut<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(&mut B, Self::Item),
+    {
+        let mut accum = init;
+        self.for_each(|item| f(&mut accum, item));
+        accum
+    }
 }
 
 impl<T: ?Sized> Itertools for T where T: Iterator { }

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -1237,3 +1237,24 @@ quickcheck! {
         TestResult::from_bool(itertools::equal(x, y))
     }
 }
+
+quickcheck! {
+    fn test_fold_mut(a: Vec<u8>) -> TestResult {
+        let with_fold_mut =
+          a.iter().fold_mut(Vec::new(), |v, &n| {
+              if n % 2 == 0 {
+                  v.push(n);
+              }
+          });
+
+        let with_fold =
+          a.iter().fold(Vec::new(), |mut v, &n| {
+              if n % 2 == 0 {
+                  v.push(n);
+              }
+              v
+          });
+
+        TestResult::from_bool(itertools::equal(with_fold_mut, with_fold))
+    }
+}


### PR DESCRIPTION
**This PR**
Adds a `fold_mut` alternative to `fold`

**Why?**
1. Sometimes the closure in a `fold` requires an awkward final line to return the accumulator as mentioned [here](https://github.com/rust-lang/rust-clippy/issues/6053).
2. Sometimes `fold_mut` can be faster. And sometimes it can be slower! See the benchmarks [here](https://github.com/rust-lang/rust/pull/76746#discussion_r490572461). TL;DR, if the accumulator is at least as big as a `&mut` to the accumulator, `fold` can be slower than `fold_mut` as moving the larger accumulator is more work than moving the `&mut`.

**Background**
A lot of the background is in [this issue](https://github.com/rust-lang/rust/issues/76725) and [this PR](https://github.com/rust-lang/rust/pull/76746). Based on the discussion there, it seemed that this wasn't warranted for the standard library so I figured I'd pitch it here!

**Benchmarks**
I ran the benchmarks like:
```
cargo bench "fold sum accumulator" \
  && cargo bench "fold vec accumulator" \
  && cargo bench "fold chained iterator with num accumulator" \
  && cargo bench "fold chained iterator with vec accumulator" \
  && open target/criterion/report/index.html
```
(not sure if there's a shorter syntax) and saw:

What | Benchmark
-|-
folding an `i64` |![num](https://user-images.githubusercontent.com/18740355/93798491-c2b98780-fc0b-11ea-80a8-6e9341c56590.png)
folding a `vec` | ![vec](https://user-images.githubusercontent.com/18740355/93798497-c77e3b80-fc0b-11ea-9890-f7d8c1254fcd.png)
folding a [`chain`ed iterator](https://github.com/rust-lang/rust/pull/76746#discussion_r490422807) into an `i64` | ![i64_chain](https://user-images.githubusercontent.com/18740355/93798507-ccdb8600-fc0b-11ea-933a-da7d43be5479.png)
folding a `chain`ed iterator into a `vec` | ![vec_chain](https://user-images.githubusercontent.com/18740355/93798528-d533c100-fc0b-11ea-9c7b-1d069d6c6a83.png)

I could also add a benchmark with like an `i8` or something to show how much faster `fold` is when folding into something much smaller than a reference if we want that! I just had a hard time coming up with an accumulator that wouldn't overflow but would still be super readable. It might be like `(0i8..10).chain(-10i8..0).cycle().take(1_000_000)` or some such.