### PR TITLE
Don't CI on nightly rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,6 @@ matrix:
             cargo build --verbose --features "$FEATURES" &&
             cargo test --verbose --features "$FEATURES" &&
             cargo bench --no-run --verbose --features "$FEATURES"
-    - rust: nightly
-      script:
-        - |
-            cargo build --verbose --no-default-features &&
-            cargo build --verbose --features "$FEATURES" &&
-            cargo test --verbose --features "$FEATURES" &&
-            cargo bench --no-run --verbose --features "$FEATURES"
 cache: cargo # https://docs.travis-ci.com/user/languages/rust/#dependency-management
 branches:
   only:


### PR DESCRIPTION
I don't know why our nightly CI silently broke, but I don't have the bandwidth to debug it. Running it was overkill, anyways.