### PR TITLE
Don't cache travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ matrix:
             cargo build --verbose --features "$FEATURES" &&
             cargo test --verbose --features "$FEATURES" &&
             cargo bench --no-run --verbose --features "$FEATURES"
-cache: cargo # https://docs.travis-ci.com/user/languages/rust/#dependency-management
 branches:
   only:
     - master


### PR DESCRIPTION
Reverts #429.

The CI is hanging at setting up the cache. A proper solution would be nice, but in the meantime, we'll just disable caching altogether.