### PR TITLE
Cartesian power.

### DIFF
--- a/src/cartesian_power.rs
+++ b/src/cartesian_power.rs
@@ -1,9 +1,49 @@
 use alloc::vec::Vec;
 use std::fmt;
 
-/// Pseudo-iterator owned by [`CartesianPower`],
-/// yielding underlying indices by references to itself,
-/// the [streaming iterator](https://docs.rs/streaming-iterator/latest/streaming_iterator/) way.
+/// Yield all indices combinations of size `pow` from `0..base`.
+/// This "lending" iterator only allocates once,
+/// and yields references to its internal owned slice of updated indices.
+/// See [streaming iterator](https://docs.rs/streaming-iterator/latest/streaming_iterator/).
+///
+/// The resulting iterator is "cycling",
+/// meaning that, after the last `.next()` call has yielded `None`,
+/// you can call `.next()` again to resume iteration from the start,
+/// as many times as needed.
+///
+/// This is the iterator internally used by [`CartesianPower`],
+/// ```
+/// use itertools::CartesianPowerIndices;
+///
+/// let mut it = CartesianPowerIndices::new(3, 2);
+/// assert_eq!(it.next(), Some(&[0, 0][..]));
+/// assert_eq!(it.next(), Some(&[0, 1][..]));
+/// assert_eq!(it.next(), Some(&[0, 2][..]));
+/// assert_eq!(it.next(), Some(&[1, 0][..]));
+/// assert_eq!(it.next(), Some(&[1, 1][..]));
+/// assert_eq!(it.next(), Some(&[1, 2][..]));
+/// assert_eq!(it.next(), Some(&[2, 0][..]));
+/// assert_eq!(it.next(), Some(&[2, 1][..]));
+/// assert_eq!(it.next(), Some(&[2, 2][..]));
+/// assert_eq!(it.next(), None);              // End of iteration.
+/// assert_eq!(it.next(), Some(&[0, 0][..])); // Cycle: start over.
+/// assert_eq!(it.next(), Some(&[0, 1][..]));
+/// // ...
+///
+/// let mut it = CartesianPowerIndices::new(2, 3);
+/// assert_eq!(it.next(), Some(&[0, 0, 0][..]));
+/// assert_eq!(it.next(), Some(&[0, 0, 1][..]));
+/// assert_eq!(it.next(), Some(&[0, 1, 0][..]));
+/// assert_eq!(it.next(), Some(&[0, 1, 1][..]));
+/// assert_eq!(it.next(), Some(&[1, 0, 0][..]));
+/// assert_eq!(it.next(), Some(&[1, 0, 1][..]));
+/// assert_eq!(it.next(), Some(&[1, 1, 0][..]));
+/// assert_eq!(it.next(), Some(&[1, 1, 1][..]));
+/// assert_eq!(it.next(), None);
+/// assert_eq!(it.next(), Some(&[0, 0, 0][..]));
+/// assert_eq!(it.next(), Some(&[0, 0, 1][..]));
+/// // ...
+/// ```
 #[derive(Debug, Clone)]
 pub struct Indices {
     // May be incremented by owner on first pass as long as exact value is unknown.
@@ -21,6 +61,7 @@ pub struct Indices {
 }
 
 impl Indices {
+    /// Create a new `base^pow` lending iterator.
     pub fn new(base: usize, pow: u32) -> Self {
         Self {
             base,
@@ -28,6 +69,10 @@ impl Indices {
             values: None,
         }
     }
+
+    /// Step the iterator, yielding a reference to internal updated indices,
+    /// or `None` if the iteration is exhausted.
+    #[allow(clippy::should_implement_trait)] // <- Intended `.next` name "like Iterator::next".
     pub fn next(&mut self) -> Option<&[usize]> {
         let Self { base, pow, values } = self;
 
@@ -67,6 +112,25 @@ impl Indices {
         }
     }
 
+    /// Same as [`next`][crate::CartesianPowerIndices::next],
+    /// but skip `n` steps.
+    /// Return `None` if this would lead to iterator exhaustion.  
+    /// Saturates in case of overflow:
+    /// the iterator is cycling,
+    /// but if you skip past the last iteration,
+    /// you'll obtain `None` no matter how far you skip.
+    /// Iteration will only resume on further calls to `.next()` and `.nth()`.
+    ///
+    /// ```
+    /// use itertools::CartesianPowerIndices;
+    ///
+    /// let mut it = CartesianPowerIndices::new(3, 2);
+    /// assert_eq!(it.nth(0), Some(&[0, 0][..]));
+    /// assert_eq!(it.nth(1), Some(&[0, 2][..]));
+    /// assert_eq!(it.nth(2), Some(&[1, 2][..]));
+    /// assert_eq!(it.nth(9), None); // Overshoot, but don't resume cycling yet.
+    /// assert_eq!(it.nth(2), Some(&[0, 2][..])); // Only resume cycling now.
+    /// ```
     pub fn nth(&mut self, n: usize) -> Option<&[usize]> {
         let Self { base, pow, values } = self;
         match (base, pow, values, n) {
@@ -110,7 +174,8 @@ impl Indices {
         }
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>) {
+    /// Akin to [`Iterator::size_hint`].
+    pub fn size_hint(&self) -> (usize, Option<usize>) {
         self.size_hint_with_base(self.base)
     }
 
@@ -195,11 +260,12 @@ fn inbounds_increment_by(n: usize, indices: &mut [usize], base: usize) -> bool {
     false
 }
 
-/// An adaptor iterating through all the ordered `n`-length lists of items
-/// yielded by the underlying iterator, including repetitions.
-/// Works by cloning the items into a fresh Vector on every `.next()`.
-/// If this is too much allocation for you,
-/// consider using the underlying lending [`Indices`] iterator instead.
+/// The adaptor adaptor yielded by
+/// [`.cartesian_power()`](crate::Itertools::cartesian_power).
+///
+/// This iterator is *cycling*,
+/// meaning that, once consumed after `.next()` returns `None`,
+/// you can call `.next()` again to resume iteration from the start.
 ///
 /// See [`.cartesian_power()`](crate::Itertools::cartesian_power)
 /// for more information.
@@ -217,24 +283,19 @@ where
     indices: Indices,
 }
 
-/// Create a new `CartesianPower` from an iterator of clonables.
-pub fn cartesian_power<I>(iter: I, pow: u32) -> CartesianPower<I>
-where
-    I: Iterator,
-    I::Item: Clone,
-{
-    CartesianPower {
-        iter: Some(iter),
-        items: None,
-        indices: Indices::new(0, pow),
-    }
-}
-
 impl<I> CartesianPower<I>
 where
     I: Iterator,
     I::Item: Clone,
 {
+    pub(crate) fn new(iter: I, pow: u32) -> CartesianPower<I> {
+        CartesianPower {
+            iter: Some(iter),
+            items: None,
+            indices: Indices::new(0, pow),
+        }
+    }
+
     /// Increments internal indices to advance to the next list to be yielded.
     /// This collects new items from the underlying iterator
     /// if they were not all already collected.
@@ -358,495 +419,5 @@ where
             .field("items", items)
             .field("indices", indices)
             .finish()
-    }
-}
-
-/// Use chars and string to ease testing of every yielded iterator values.
-#[cfg(test)]
-mod tests {
-
-    use crate::{cartesian_power::Indices, Itertools};
-
-    #[test]
-    fn next() {
-        fn check(origin: &str, pow: u32, expected: &[&str]) {
-            println!("================== ({origin:?}^{pow})");
-            let mut it_act = origin
-                .chars()
-                .collect::<Vec<_>>() // Collect to get exact size hint upper bound.
-                .into_iter()
-                .cartesian_power(pow);
-            // Check size_hint on the fly.
-            let e_hint = expected.len();
-            // Check thrice that it's cycling.
-            for r in 1..=3 {
-                println!("- - {r} - - - - - -");
-                let mut it_exp = expected.iter();
-                let mut i = 0;
-                let mut e_remaining = e_hint;
-                loop {
-                    // Common context to emit in case of test failure.
-                    let ctx = || {
-                        format!(
-                            "Failed iteration {} (repetition {}) for {:?}^{}.",
-                            i, r, origin, pow,
-                        )
-                    };
-                    // Check size hints.
-                    let a_remaining = it_act.size_hint();
-                    assert!(
-                        if let (la, Some(ha)) = a_remaining {
-                            la == e_remaining && ha == e_remaining
-                        } else {
-                            false
-                        },
-                        "{} Expected size hint: ({e}, Some({e})), got instead: {a:?}.",
-                        ctx(),
-                        e = e_remaining,
-                        a = a_remaining,
-                    );
-                    // Actual/expected iterators steps.
-                    let act = it_act.next();
-                    let exp = it_exp.next().map(|e| e.chars().collect::<Vec<_>>());
-                    println!(" {:?}", act);
-                    // Possible failure report.
-                    let fail = |e, a| {
-                        let f = |o| {
-                            if let Some(v) = o {
-                                format!("{v:?}")
-                            } else {
-                                "None".into()
-                            }
-                        };
-                        panic!("{} Expected {:?}, got {:?} instead.", ctx(), f(e), f(a));
-                    };
-                    // Comparison.
-                    match (exp, act) {
-                        (Some(exp), Some(act)) => {
-                            if act != exp {
-                                fail(Some(exp), Some(act));
-                            }
-                            i += 1;
-                        }
-                        (None, Some(act)) => {
-                            fail(None, Some(act));
-                        }
-                        (Some(exp), None) => {
-                            fail(Some(exp), None);
-                        }
-                        (None, None) => break,
-                    }
-                    e_remaining -= 1;
-                }
-            }
-        }
-
-        // Empty underlying iterator.
-        check("", 0, &[""]); // 0^0 = 1.
-        check("", 1, &[]);
-        check("", 2, &[]);
-        check("", 3, &[]);
-
-        // Singleton underlying iterator.
-        check("a", 0, &[""]);
-        check("a", 1, &["a"]);
-        check("a", 2, &["aa"]);
-        check("a", 3, &["aaa"]);
-
-        // Underlying pair.
-        check("ab", 0, &[""]);
-        check("ab", 1, &["a", "b"]);
-        check("ab", 2, &["aa", "ab", "ba", "bb"]);
-        check(
-            "ab",
-            3,
-            &["aaa", "aab", "aba", "abb", "baa", "bab", "bba", "bbb"],
-        );
-
-        // Underlying triplet.
-        check("abc", 0, &[""]);
-        check("abc", 1, &["a", "b", "c"]);
-        check(
-            "abc",
-            2,
-            &["aa", "ab", "ac", "ba", "bb", "bc", "ca", "cb", "cc"],
-        );
-        check(
-            "abc",
-            3,
-            &[
-                "aaa", "aab", "aac", "aba", "abb", "abc", "aca", "acb", "acc", "baa", "bab", "bac",
-                "bba", "bbb", "bbc", "bca", "bcb", "bcc", "caa", "cab", "cac", "cba", "cbb", "cbc",
-                "cca", "ccb", "ccc",
-            ],
-        );
-    }
-
-    #[test]
-    fn nth() {
-        fn check(origin: &str, pow: u32, expected: &[(usize, (Option<&str>, usize))]) {
-            println!("================== ({origin:?}^{pow})");
-            let mut it = origin
-                .chars()
-                .collect::<Vec<_>>()
-                .into_iter()
-                .cartesian_power(pow);
-            let mut total_n = Vec::new();
-            for &(n, (exp, e_hint)) in expected {
-                total_n.push(n);
-                let ctx = || {
-                    format!(
-                        "Failed nth({}) iteration for {:?}^{}.",
-                        total_n
-                            .iter()
-                            .map(ToString::to_string)
-                            .collect::<Vec<_>>()
-                            .join(", "),
-                        origin,
-                        pow,
-                    )
-                };
-                let act = it.nth(n);
-                let a_hint = it.size_hint();
-                let act = act.map(|v| v.into_iter().collect::<String>());
-                println!(
-                    " → {}",
-                    if let Some(act) = act.as_ref() {
-                        act
-                    } else {
-                        "🗙"
-                    }
-                );
-                if act.as_ref().map(String::as_str) != exp {
-                    panic!("{} Expected {:?}, got {:?} instead.", ctx(), exp, act);
-                }
-                // Check size hint after stepping.
-                assert!(
-                    if let (la, Some(ha)) = a_hint {
-                        la == e_hint && ha == e_hint
-                    } else {
-                        false
-                    },
-                    "{} Expected size hint: ({e}, Some({e})), got instead: {a:?}.",
-                    ctx(),
-                    e = e_hint,
-                    a = a_hint,
-                );
-            }
-        }
-
-        // Ease test read/write.
-        // Accept a sequence of '<n> <result>' yielded by a call to `.nth(n)`.
-        macro_rules! check {
-            ($base:expr, $pow:expr => $( $n:literal $expected:expr )+ ) => {
-                check($base, $pow, &[$(($n, $expected)),+]);
-            };
-        }
-
-        // Degenerated 0th power.
-        let o = (None, 1);
-        let e = (Some(""), 0); // "e"mpty.
-        for base in ["", "a", "ab"] {
-            check!(base, 0 => 0 e 0 o 0 e 0 o);
-            check!(base, 0 => 0 e 1 o 0 e 1 o);
-            check!(base, 0 => 0 e 2 o 1 o 0 e);
-            check!(base, 0 => 1 o 0 e 0 o 1 o);
-            check!(base, 0 => 1 o 1 o 0 e 0 o);
-            check!(base, 0 => 1 o 2 o 0 e 1 o);
-            check!(base, 0 => 2 o 0 e 1 o 0 e);
-            check!(base, 0 => 2 o 1 o 2 o 0 e);
-            check!(base, 0 => 2 o 2 o 0 e 2 o);
-        }
-
-        // Degenerated 0-base.
-        let o = (None, 0);
-        for pow in [1, 2, 3] {
-            check!("", pow => 0 o 0 o 0 o 0 o);
-            check!("", pow => 1 o 1 o 1 o 1 o);
-            check!("", pow => 2 o 2 o 2 o 2 o);
-            check!("", pow => 0 o 1 o 2 o 0 o);
-            check!("", pow => 2 o 1 o 0 o 1 o);
-        }
-
-        // Unit power.
-        let o = (None, 1);
-        let a = (Some("a"), 0);
-        check!("a", 1 => 0 a 0 o 0 a 0 o 0 a 0 o);
-        check!("a", 1 => 1 o 1 o 1 o 1 o 1 o 1 o);
-        check!("a", 1 => 2 o 2 o 2 o 2 o 2 o 2 o);
-        check!("a", 1 => 0 a 1 o 0 a 1 o 0 a 1 o);
-        check!("a", 1 => 1 o 0 a 1 o 0 a 1 o 0 a);
-        check!("a", 1 => 0 a 2 o 0 a 2 o 0 a 2 o);
-        check!("a", 1 => 2 o 0 a 2 o 0 a 2 o 0 a);
-        check!("a", 1 => 1 o 2 o 1 o 2 o 1 o 2 o);
-        check!("a", 1 => 2 o 1 o 2 o 1 o 2 o 1 o);
-        check!("a", 1 => 0 a 1 o 2 o 0 a 1 o 2 o);
-        check!("a", 1 => 0 a 2 o 1 o 0 a 2 o 1 o);
-        check!("a", 1 => 1 o 0 a 2 o 1 o 0 a 2 o);
-        check!("a", 1 => 1 o 2 o 0 a 1 o 2 o 0 a 1 o 2 o 0 a);
-        check!("a", 1 => 2 o 0 a 1 o 2 o 0 a 1 o 2 o 0 a 1 o);
-        check!("a", 1 => 2 o 1 o 0 a 2 o 1 o 0 a 2 o 1 o 0 a);
-        check!("a", 1 => 1 o 0 a 0 o 1 o 0 a 0 o 1 o 0 a 0 o);
-        check!("a", 1 => 1 o 1 o 0 a 0 o 1 o 1 o 0 a 0 o 1 o 1 o);
-
-        let o = (None, 2);
-        let a = (Some("a"), 1);
-        let b = (Some("b"), 0);
-        check!("ab", 1 => 0 a 0 b 0 o 0 a 0 b 0 o);
-        check!("ab", 1 => 1 b 1 o 1 b 1 o 1 b 1 o);
-        check!("ab", 1 => 2 o 2 o 2 o 2 o 2 o 2 o);
-        check!("ab", 1 => 0 a 1 o 0 a 1 o 0 a 1 o);
-        check!("ab", 1 => 1 b 0 o 1 b 0 o 1 b 0 o);
-        check!("ab", 1 => 0 a 2 o 0 a 2 o 0 a 2 o);
-        check!("ab", 1 => 2 o 0 a 2 o 0 a 2 o 0 a);
-        check!("ab", 1 => 1 b 2 o 1 b 2 o 1 b 2 o);
-        check!("ab", 1 => 2 o 1 b 2 o 1 b 2 o 1 b);
-        check!("ab", 1 => 0 a 1 o 2 o 0 a 1 o 2 o);
-        check!("ab", 1 => 0 a 2 o 1 b 0 o 2 o 1 b);
-        check!("ab", 1 => 1 b 0 o 2 o 1 b 0 o 2 o);
-        check!("ab", 1 => 1 b 2 o 0 a 1 o 2 o 0 a 1 o 2 o 0 a);
-        check!("ab", 1 => 2 o 0 a 1 o 2 o 0 a 1 o);
-        check!("ab", 1 => 2 o 1 b 0 o 2 o 1 b 0 o);
-        check!("ab", 1 => 1 b 0 o 0 a 1 o 0 a 0 b 1 o 0 a 0 b);
-        check!("ab", 1 => 1 b 1 o 0 a 0 b 1 o 1 b 0 o 0 a 1 o 1 b);
-
-        let o = (None, 3);
-        let a = (Some("a"), 2);
-        let b = (Some("b"), 1);
-        let c = (Some("c"), 0);
-        check!("abc", 1 => 0 a 0 b 0 c 0 o 0 a 0 b 0 c 0 o);
-        check!("abc", 1 => 1 b 1 o 1 b 1 o 1 b 1 o);
-        check!("abc", 1 => 2 c 2 o 2 c 2 o 2 c 2 o);
-        check!("abc", 1 => 0 a 1 c 0 o 1 b 0 c 1 o 0 a 1 c);
-        check!("abc", 1 => 1 b 0 c 1 o 0 a 1 c 0 o 1 b 0 c);
-        check!("abc", 1 => 0 a 2 o 0 a 2 o 0 a 2 o);
-        check!("abc", 1 => 2 c 0 o 2 c 0 o 2 c 0 o);
-        check!("abc", 1 => 1 b 2 o 1 b 2 o 1 b 2 o);
-        check!("abc", 1 => 2 c 1 o 2 c 1 o 2 c 1 o);
-        check!("abc", 1 => 0 a 1 c 2 o 0 a 1 c 2 o);
-        check!("abc", 1 => 0 a 2 o 1 b 0 c 2 o 1 b);
-        check!("abc", 1 => 1 b 0 c 2 o 1 b 0 c 2 o);
-        check!("abc", 1 => 1 b 2 o 0 a 1 c 2 o 0 a 1 c 2 o 0 a);
-        check!("abc", 1 => 2 c 0 o 1 b 2 o 0 a 1 c 2 o 0 a 1 c);
-        check!("abc", 1 => 2 c 1 o 0 a 2 o 1 b 0 c 2 o 1 b 0 c);
-        check!("abc", 1 => 1 b 0 c 0 o 1 b 0 c 0 o 1 b 0 c 0 o);
-        check!("abc", 1 => 1 b 1 o 0 a 0 b 1 o 1 b 0 c 0 o 1 b 1 o);
-
-        // Higher power.
-        let o = (None, 1);
-        let aa = (Some("aa"), 0);
-        check!("a", 2 => 0 aa 0 o 0 aa 0 o 0 aa 0 o);
-        check!("a", 2 => 1 o 1 o 1 o 1 o 1 o 1 o);
-        check!("a", 2 => 2 o 2 o 2 o 2 o 2 o 2 o);
-        check!("a", 2 => 0 aa 1 o 0 aa 1 o 0 aa 1 o);
-        check!("a", 2 => 1 o 0 aa 1 o 0 aa 1 o 0 aa 1 o);
-        check!("a", 2 => 0 aa 2 o 0 aa 2 o 0 aa 2 o);
-        check!("a", 2 => 2 o 0 aa 2 o 0 aa 2 o 0 aa);
-        check!("a", 2 => 1 o 2 o 1 o 2 o 1 o 2 o);
-        check!("a", 2 => 2 o 1 o 2 o 1 o 2 o 1 o);
-        check!("a", 2 => 0 aa 1 o 2 o 0 aa 1 o 2 o);
-        check!("a", 2 => 0 aa 2 o 1 o 0 aa 2 o 1 o);
-        check!("a", 2 => 1 o 0 aa 2 o 1 o 0 aa 2 o);
-        check!("a", 2 => 1 o 2 o 0 aa 1 o 2 o 0 aa 1 o 2 o 0 aa);
-        check!("a", 2 => 2 o 0 aa 1 o 2 o 0 aa 1 o 2 o 0 aa 1 o);
-        check!("a", 2 => 2 o 1 o 0 aa 2 o 1 o 0 aa 2 o 1 o 0 aa);
-        check!("a", 2 => 1 o 0 aa 0 o 1 o 0 aa 0 o 1 o 0 aa 0 o);
-        check!("a", 2 => 1 o 1 o 0 aa 0 o 1 o 1 o 0 aa 0 o 1 o 1 o);
-
-        let o = (None, 4);
-        let aa = (Some("aa"), 3);
-        let ab = (Some("ab"), 2);
-        let ba = (Some("ba"), 1);
-        let bb = (Some("bb"), 0);
-        check!("ab", 2 => 0 aa 0 ab 0 ba 0 bb 0 o 0 aa 0 ab);
-        check!("ab", 2 => 1 ab 1 bb 1 o 1 ab 1 bb 1 o);
-        check!("ab", 2 => 2 ba 2 o 2 ba 2 o 2 ba 2 o);
-        check!("ab", 2 => 0 aa 1 ba 0 bb 1 o 0 aa 1 ba);
-        check!("ab", 2 => 1 ab 0 ba 1 o 0 aa 1 ba 0 bb 1 o 0 aa 1 ba 0 bb);
-        check!("ab", 2 => 0 aa 2 bb 0 o 2 ba 0 bb 2 o 0 aa 2 bb);
-        check!("ab", 2 => 2 ba 0 bb 2 o 0 aa 2 bb 0 o 2 ba 0 bb);
-        check!("ab", 2 => 1 ab 2 o 1 ab 2 o 1 ab 2 o);
-        check!("ab", 2 => 2 ba 1 o 2 ba 1 o 2 ba 1 o);
-        check!("ab", 2 => 0 aa 1 ba 2 o 0 aa 1 ba 2 o);
-        check!("ab", 2 => 0 aa 2 bb 1 o 0 aa 2 bb 1 o);
-        check!("ab", 2 => 1 ab 0 ba 2 o 1 ab 0 ba 2 o);
-        check!("ab", 2 => 1 ab 2 o 0 aa 1 ba 2 o 0 aa 1 ba 2 o 0 aa);
-        check!("ab", 2 => 2 ba 0 bb 1 o 2 ba 0 bb 1 o 2 ba 0 bb 1 o);
-        check!("ab", 2 => 2 ba 1 o 0 aa 2 bb 1 o 0 aa 2 bb 1 o 0 aa);
-        check!("ab", 2 => 1 ab 0 ba 0 bb 1 o 0 aa 0 ab 1 bb 0 o 0 aa 1 ba 0 bb 0 o 1 ab 0 ba 0 bb);
-        check!("ab", 2 => 1 ab 1 bb 0 o 0 aa 1 ba 1 o 0 aa 0 ab 1 bb 1 o 0 aa 0 ab 1 bb 1 o);
-
-        let o = (None, 9);
-        let aa = (Some("aa"), 8);
-        let ab = (Some("ab"), 7);
-        let ac = (Some("ac"), 6);
-        let ba = (Some("ba"), 5);
-        let bb = (Some("bb"), 4);
-        let bc = (Some("bc"), 3);
-        let ca = (Some("ca"), 2);
-        let cb = (Some("cb"), 1);
-        let cc = (Some("cc"), 0);
-        check!("abc", 2 => 0 aa 0 ab 0 ac 0 ba 0 bb 0 bc 0 ca 0 cb 0 cc 0 o 0 aa 0 ab 0 ac 0 ba);
-        check!("abc", 2 => 1 ab 1 ba 1 bc 1 cb 1 o 1 ab 1 ba 1 bc 1 cb 1 o 1 ab 1 ba 1 bc 1 cb 1 o);
-        check!("abc", 2 => 2 ac 2 bc 2 cc 2 o 2 ac 2 bc 2 cc 2 o 2 ac 2 bc 2 cc 2 o 2 ac 2 bc 2 cc);
-        check!("abc", 2 => 0 aa 1 ac 0 ba 1 bc 0 ca 1 cc 0 o 1 ab 0 ac 1 bb 0 bc 1 cb 0 cc 1 o);
-        check!("abc", 2 => 1 ab 0 ac 1 bb 0 bc 1 cb 0 cc 1 o 0 aa 1 ac 0 ba 1 bc 0 ca 1 cc 0 o);
-        check!("abc", 2 => 0 aa 2 ba 0 bb 2 cb 0 cc 2 o 0 aa 2 ba 0 bb 2 cb 0 cc 2 o 0 aa 2 ba);
-        check!("abc", 2 => 2 ac 0 ba 2 ca 0 cb 2 o 0 aa 2 ba 0 bb 2 cb 0 cc 2 o 0 aa 2 ba 0 bb);
-        check!("abc", 2 => 1 ab 2 bb 1 ca 2 o 1 ab 2 bb 1 ca 2 o 1 ab 2 bb 1 ca 2 o 1 ab 2 bb 1 ca);
-        check!("abc", 2 => 2 ac 1 bb 2 cb 1 o 2 ac 1 bb 2 cb 1 o 2 ac 1 bb 2 cb 1 o 2 ac 1 bb 2 cb);
-        check!("abc", 2 => 0 aa 1 ac 2 bc 0 ca 1 cc 2 o 0 aa 1 ac 2 bc 0 ca 1 cc 2 o 0 aa 1 ac);
-        check!("abc", 2 => 0 aa 2 ba 1 bc 0 ca 2 o 1 ab 0 ac 2 bc 1 cb 0 cc 2 o 1 ab 0 ac 2 bc);
-        check!("abc", 2 => 1 ab 0 ac 2 bc 1 cb 0 cc 2 o 1 ab 0 ac 2 bc 1 cb 0 cc 2 o 1 ab 0 ac);
-        check!("abc", 2 => 1 ab 2 bb 0 bc 1 cb 2 o 0 aa 1 ac 2 bc 0 ca 1 cc 2 o 0 aa 1 ac 2 bc);
-        check!("abc", 2 => 2 ac 0 ba 1 bc 2 cc 0 o 1 ab 2 bb 0 bc 1 cb 2 o 0 aa 1 ac 2 bc 0 ca);
-        check!("abc", 2 => 2 ac 1 bb 0 bc 2 cc 1 o 0 aa 2 ba 1 bc 0 ca 2 o 1 ab 0 ac 2 bc 1 cb);
-        check!("abc", 2 => 1 ab 0 ac 0 ba 1 bc 0 ca 0 cb 1 o 0 aa 0 ab 1 ba 0 bb 0 bc 1 cb 0 cc);
-        check!("abc", 2 => 1 ab 1 ba 0 bb 0 bc 1 cb 1 o 0 aa 0 ab 1 ba 1 bc 0 ca 0 cb 1 o 1 ab);
-
-        let o = (None, 27);
-        let aaa = (Some("aaa"), 26);
-        let aab = (Some("aab"), 25);
-        let aac = (Some("aac"), 24);
-        let aba = (Some("aba"), 23);
-        let abb = (Some("abb"), 22);
-        let abc = (Some("abc"), 21);
-        let aca = (Some("aca"), 20);
-        let acb = (Some("acb"), 19);
-        let acc = (Some("acc"), 18);
-        let baa = (Some("baa"), 17);
-        let bab = (Some("bab"), 16);
-        let bac = (Some("bac"), 15);
-        let bba = (Some("bba"), 14);
-        let bbb = (Some("bbb"), 13);
-        let bbc = (Some("bbc"), 12);
-        let bca = (Some("bca"), 11);
-        let bcb = (Some("bcb"), 10);
-        let bcc = (Some("bcc"), 9);
-        let caa = (Some("caa"), 8);
-        let cab = (Some("cab"), 7);
-        let cac = (Some("cac"), 6);
-        let cba = (Some("cba"), 5);
-        let cbb = (Some("cbb"), 4);
-        let cbc = (Some("cbc"), 3);
-        let cca = (Some("cca"), 2);
-        let ccb = (Some("ccb"), 1);
-        let ccc = (Some("ccc"), 0);
-
-        check!(
-            "abc", 3 =>
-            0 aaa
-            0 aab
-            0 aac
-            0 aba
-            0 abb
-            0 abc
-            0 aca
-            0 acb
-            0 acc
-            0 baa
-            0 bab
-            0 bac
-            0 bba
-            0 bbb
-            0 bbc
-            0 bca
-            0 bcb
-            0 bcc
-            0 caa
-            0 cab
-            0 cac
-            0 cba
-            0 cbb
-            0 cbc
-            0 cca
-            0 ccb
-            0 ccc
-            0 o
-            0 aaa
-            0 aab
-            0 aac
-        );
-
-        check!(
-            "abc", 3 =>
-            1 aab
-            1 aba
-            1 abc
-            1 acb
-            1 baa
-            1 bac
-            1 bbb
-            1 bca
-            1 bcc
-            1 cab
-            1 cba
-            1 cbc
-            1 ccb
-            1 o
-            1 aab
-            1 aba
-        );
-
-        check!(
-            "abc", 3 =>
-            2 aac
-            2 abc
-            2 acc
-            2 bac
-            2 bbc
-            2 bcc
-            2 cac
-            2 cbc
-            2 ccc
-            2 o
-            2 aac
-            2 abc
-        );
-
-        check!(
-            "abc", 3 =>
-            3 aba 3 acb 3 bac 3 bca 3 cab 3 cbc 3 o
-            3 aba 3 acb 3 bac 3 bca 3 cab 3 cbc 3 o
-        );
-
-        check!(
-            "abc", 3 =>
-            4 abb 4 baa 4 bbc 4 cab 4 cca 4 o
-            4 abb 4 baa 4 bbc 4 cab 4 cca 4 o
-        );
-
-        check!(
-            "abc", 3 =>
-            5 abc 5 bac 5 bcc 5 cbc 5 o
-            5 abc 5 bac 5 bcc 5 cbc 5 o
-        );
-
-        check!("abc", 3 =>
-            6 aca 6 bbb 6 cac 6 o
-            6 aca 6 bbb 6 cac 6 o
-        );
-
-        check!("abc", 3 =>
-            7 acb 7 bca 7 cbc 7 o
-            7 acb 7 bca 7 cbc 7 o
-        );
-
-        check!(
-            "abc", 3 =>
-            8 acc 8 bcc 8 ccc 8 o
-            8 acc 8 bcc 8 ccc 8 o
-        );
-
-        check!("abc", 3 => 9 baa 9 cab 9 o 9 baa 9 cab 9 o);
-        check!("abc", 3 => 10 bab 10 cba 10 o 10 bab 10 cba 10 o);
-        check!("abc", 3 => 11 bac 11 cbc 11 o 11 bac 11 cbc 11 o);
-        check!("abc", 3 => 12 bba 12 ccb 12 o 12 bba 12 ccb 12 o);
-        check!("abc", 3 => 13 bbb 13 o 13 bbb 13 o);
-        check!("abc", 3 => 14 bbc 14 o 14 bbc 14 o);
-        check!("abc", 3 => 25 ccb 25 o 25 ccb 25 o);
-        check!("abc", 3 => 26 ccc 26 o 26 ccc 26 o);
-        check!("abc", 3 => 27 o 27 o 27 o 27 o);
-        check!("abc", 3 => 28 o 28 o 28 o 28 o);
     }
 }

--- a/src/cartesian_power.rs
+++ b/src/cartesian_power.rs
@@ -1,6 +1,5 @@
 use alloc::vec::Vec;
 use std::fmt;
-use std::iter::FusedIterator;
 
 /// An adaptor iterating through all the ordered `n`-length lists of items
 /// yielded by the underlying iterator, including repetitions.
@@ -15,9 +14,19 @@ where
     I::Item: Clone,
 {
     pow: usize,
-    iter: Option<I>,     // Inner iterator. Forget once consumed after 'base' iterations.
-    items: Vec<I::Item>, // Fill from iter. Clear once adaptor is exhausted. Final length is 'base'.
-    indices: Vec<usize>, // Indices just yielded. Clear once adaptor is exhausted. Length is 'pow'.
+    iter: Option<I>, // Inner iterator. Forget once consumed after 'base' iterations.
+    items: Option<Vec<I::Item>>, // Fill from iter. Final length is 'base'.
+    // None means that collection has not started yet.
+    // Some(empty) means that collection would have started but pow = 0.
+
+    // Indices just yielded. Length is 'pow'.
+    // 0 0 .. 0 0 means that the first combination has been yielded.
+    // 0 0 .. 0 1 means that the second combination has been yielded.
+    // m m .. m m means that the last combination has just been yielded (m = base - 1).
+    // b 0 .. 0 0 means that 'None' has just been yielded (b = base).
+    // The latter is a special value marking the renewal of the iterator,
+    // which can cycle again through another full round, ad libitum.
+    indices: Vec<usize>,
 }
 
 /// Create a new `CartesianPower` from an iterator of clonables.
@@ -29,7 +38,7 @@ where
     CartesianPower {
         pow,
         iter: Some(iter),
-        items: Vec::new(),
+        items: None,
         indices: Vec::new(),
     }
 }
@@ -53,37 +62,57 @@ where
             items,
             indices,
         } = self;
-        match (*pow, iter, items.len()) {
-            // Final stable state: underlying iterator and items forgotten.
-            (_, None, 0) => None,
+        println!(
+            "^{pow}: {} {indices:?}\t\t{:?}",
+            if iter.is_some() { 'S' } else { 'N' },
+            items.as_ref().map(Vec::len)
+        );
 
-            // Degenerated 0th power iteration.
-            (0, Some(_), _) => {
-                self.iter = None; // Forget without even consuming.
-                Some((indices, items))
+        // (weird 'items @' bindings circumvent NLL limitations, unneeded with polonius)
+        match (*pow, iter, &mut *items) {
+            // First iteration with degenerated 0th power.
+            (0, Some(_), items @ None) => {
+                self.iter = None; // Forget about underlying iteration immediately.
+                let empty = items.insert(Vec::new()); // Raise this value as a boolean flag.
+                Some((indices, empty)) // Yield empty list.
             }
 
-            (pow, Some(it), 0) => {
+            // Subsequent degenerated 0th power iteration.
+            // Use the Some<(empty)Vec> as a flag to alternate between yielding [] or None.
+            (0, None, items @ Some(_)) => {
+                *items = None;
+                None
+            }
+            (0, None, items @ None) => Some((indices, items.insert(Vec::new()))),
+
+            // First iteration in the general case.
+            (pow, Some(it), items @ None) => {
                 // Check whether there is at least one element in the iterator.
                 if let Some(first) = it.next() {
-                    // Allocate buffer to hold items about to be yielded.
-                    items.reserve_exact(it.size_hint().0);
-                    items.push(first);
-                    // Same for indices to be yielded.
+                    items // Collect it.
+                        .insert(Vec::with_capacity(it.size_hint().0))
+                        .push(first);
+                    // Prepare indices to be yielded.
                     indices.reserve_exact(pow);
                     for _ in 0..pow {
                         indices.push(0);
                     }
-                    return Some((indices, items));
+                    Some((indices, items.as_ref().unwrap()))
+                } else {
+                    // Degenerated iteration over an empty set:
+                    // 'base = 0', yet with non-null power.
+                    self.iter = None;
+                    None
                 }
-                // Degenerated iteration over an empty set, yet with non-null power.
-                self.iter = None;
-                None
             }
 
-            (pow, Some(it), base) => {
+            // Stable iteration in the degenerated case 'base = 0'.
+            (_, None, None) => None,
+
+            // Subsequent iteration in the general case.
+            (pow, Some(it), Some(items)) => {
                 // We are still unsure whether all items have been collected.
-                // As a consequence, 'base' is still uncertain,
+                // As a consequence, the exact value of 'base' is still uncertain,
                 // but then we know that indices haven't started wrapping around yet.
                 if let Some(next) = it.next() {
                     items.push(next);
@@ -91,32 +120,41 @@ where
                     return Some((indices, items));
                 }
 
-                // All items have just been collected.
+                // The item collected on previous call was the last one.
                 self.iter = None;
+                let base = items.len(); // Definitive 'base' value.
                 if base == 1 || pow == 1 {
-                    // End of iteration.
-                    items.clear();
-                    indices.clear();
+                    // Early end of singleton iteration.
+                    indices[0] = base; // Mark to cycle again on next iteration.
                     return None;
                 }
 
                 // First wrap around.
                 indices[pow - 1] = 0;
-                indices[pow - 2] += 1;
+                indices[pow - 2] = 1;
                 Some((indices, items))
             }
 
-            (_, None, b) => {
+            // Subsequent iteration in the general case after all items have been collected.
+            (_, None, Some(items)) => {
+                let base = items.len();
+                if indices[0] == base {
+                    // Special marker that iteration can start over for a new round.
+                    indices[0] = 0;
+                    return Some((indices, items));
+                }
                 // Keep yielding items list, incrementing indices rightmost first.
                 for index in indices.iter_mut().rev() {
                     *index += 1;
-                    if *index < b {
+                    if *index < base {
                         return Some((indices, items));
                     }
                     *index = 0; // Wrap and increment left.
                 }
-                items.clear();
-                indices.clear();
+                // Iteration is over.
+                // Mark a special index value to not fuse the iterator
+                // and make it possible to cycle through all results again.
+                indices[0] = base;
                 None
             }
         }
@@ -187,13 +225,6 @@ where
     }
 }
 
-impl<I> FusedIterator for CartesianPower<I>
-where
-    I: Iterator,
-    I::Item: Clone,
-{
-}
-
 #[cfg(test)]
 mod tests {
     //! Use chars and string to ease testing of every yielded iterator values.
@@ -202,41 +233,50 @@ mod tests {
     use crate::Itertools;
     use core::str::Chars;
 
-    fn check_fused(mut exhausted_it: CartesianPower<Chars>, context: String) {
-        for i in 0..100 {
-            let act = exhausted_it.next();
-            assert!(
-                act.is_none(),
-                "Iteration {} after expected exhaustion of {} \
-                yielded {:?} instead of None. ",
-                i,
-                context,
-                act,
-            );
-        }
-    }
-
     #[test]
     fn basic() {
         fn check(origin: &str, pow: usize, expected: &[&str]) {
-            let mut it = origin.chars().cartesian_power(pow);
-            let mut i = 0;
-            for exp in expected {
-                let act = it.next();
-                if act != Some(exp.chars().collect()) {
-                    panic!(
-                        "Failed iteration {} for {:?}^{}. \
-                         Expected {:?}, got {:?} instead.",
-                        i, origin, pow, exp, act,
-                    );
+            println!("================== ({origin:?}^{pow})");
+            let mut it_act = origin.chars().cartesian_power(pow);
+            // Check thrice that it's cycling.
+            for r in 1..=3 {
+                println!("- - {r} - - - - - -");
+                let mut it_exp = expected.iter();
+                let mut i = 0;
+                loop {
+                    match (it_exp.next(), it_act.next()) {
+                        (Some(exp), Some(act)) => {
+                            if act != exp.chars().collect::<Vec<_>>() {
+                                panic!(
+                                    "Failed iteration {} (repetition {}) for {:?}^{}. \
+                                     Expected {:?}, got {:?} instead.",
+                                    i, r, origin, pow, exp, act,
+                                );
+                            }
+                            i += 1;
+                        }
+                        (None, Some(act)) => {
+                            panic!(
+                                "Failed iteration {} (repetition {}) for {:?}^{}. \
+                                 Expected None, got {:?} instead.",
+                                i, r, origin, pow, act,
+                            );
+                        }
+                        (Some(exp), None) => {
+                            panic!(
+                                "Failed iteration {} (repetition {}) for {:?}^{}. \
+                                 Expected {:?}, got None instead.",
+                                i, r, origin, pow, exp,
+                            );
+                        }
+                        (None, None) => break,
+                    }
                 }
-                i += 1;
             }
-            check_fused(it, format!("iteration {} or {:?}^{}", i, origin, pow));
         }
 
         // Empty underlying iterator.
-        check("", 0, &[""]);
+        check("", 0, &[""]); // 0^0 = 1.
         check("", 1, &[]);
         check("", 2, &[]);
         check("", 3, &[]);
@@ -281,41 +321,29 @@ mod tests {
         fn check(origin: &str, pow: usize, expected: &[(usize, Option<&str>)]) {
             let mut it = origin.chars().cartesian_power(pow);
             let mut total_n = Vec::new();
-            for &(n, exp) in expected {
-                let act = it.nth(n);
-                total_n.push(n);
-                if act != exp.map(|s| s.chars().collect::<Vec<_>>()) {
-                    panic!(
-                        "Failed nth({}) iteration for {:?}^{}. \
-                         Expected {:?}, got {:?} instead.",
-                        total_n
-                            .iter()
-                            .map(ToString::to_string)
-                            .collect::<Vec<_>>()
-                            .join(", "),
-                        origin,
-                        pow,
-                        exp,
-                        act,
-                    );
+            for r in 1..=3 {
+                for &(n, exp) in expected {
+                    let act = it.nth(n);
+                    total_n.push(n);
+                    if act != exp.map(|s| s.chars().collect::<Vec<_>>()) {
+                        panic!(
+                            "Failed nth({}) iteration (repetition {}) for {:?}^{}. \
+                             Expected {:?}, got {:?} instead.",
+                            total_n
+                                .iter()
+                                .map(ToString::to_string)
+                                .collect::<Vec<_>>()
+                                .join(", "),
+                            r,
+                            origin,
+                            pow,
+                            exp,
+                            act
+                        );
+                    }
                 }
             }
-            check_fused(
-                it,
-                format!(
-                    "nth({}) iteration of {:?}^{}",
-                    total_n
-                        .iter()
-                        .map(ToString::to_string)
-                        .collect::<Vec<_>>()
-                        .join(", "),
-                    origin,
-                    pow
-                ),
-            );
         }
-
-        // HERE: make it work with the new implementation.
 
         // Check degenerated cases.
         check("", 0, &[(0, Some("")), (0, None)]);

--- a/src/cartesian_power.rs
+++ b/src/cartesian_power.rs
@@ -1,0 +1,356 @@
+use alloc::vec::Vec;
+use std::fmt;
+use std::iter::FusedIterator;
+
+/// An adaptor iterating through all the ordered `n`-length lists of items
+/// yielded by the underlying iterator, including repetitions.
+///
+/// See [`.cartesian_power()`](crate::Itertools::cartesian_power)
+/// for more information.
+#[derive(Clone)]
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct CartesianPower<I>
+where
+    I: Iterator,
+    I::Item: Clone,
+{
+    pow: usize,
+    iter: Option<I>,     // Inner iterator. Forget once consumed after 'base' iterations.
+    items: Vec<I::Item>, // Fill from iter. Clear once adaptor is exhausted. Final length is 'base'.
+    indices: Vec<usize>, // Indices just yielded. Clear once adaptor is exhausted. Length is 'pow'.
+}
+
+/// Create a new `CartesianPower` from an iterator of clonables.
+pub fn cartesian_power<I>(iter: I, pow: usize) -> CartesianPower<I>
+where
+    I: Iterator,
+    I::Item: Clone,
+{
+    CartesianPower {
+        pow,
+        iter: Some(iter),
+        items: Vec::new(),
+        indices: Vec::new(),
+    }
+}
+
+impl<I> CartesianPower<I>
+where
+    I: Iterator,
+    I::Item: Clone,
+{
+    /// Increments internal indices to advance to the next list to be yielded.
+    /// This collects new items from the underlying iterator
+    /// if they were not all already collected.
+    ///
+    /// Returns None if we've run out of possible lists,
+    /// otherwise return refs to the indices to yield next,
+    /// valid within the collected items slice also returned.
+    fn increment_indices(&mut self) -> Option<(&[usize], &[I::Item])> {
+        let Self {
+            pow,
+            iter,
+            items,
+            indices,
+        } = self;
+        match (*pow, iter, items.len()) {
+            // Final stable state: underlying iterator and items forgotten.
+            (_, None, 0) => None,
+
+            // Degenerated 0th power iteration.
+            (0, Some(_), _) => {
+                self.iter = None; // Forget without even consuming.
+                Some((indices, items))
+            }
+
+            (pow, Some(it), 0) => {
+                // Check whether there is at least one element in the iterator.
+                if let Some(first) = it.next() {
+                    // Allocate buffer to hold items about to be yielded.
+                    items.reserve_exact(it.size_hint().0);
+                    items.push(first);
+                    // Same for indices to be yielded.
+                    indices.reserve_exact(pow);
+                    for _ in 0..pow {
+                        indices.push(0);
+                    }
+                    return Some((indices, items));
+                }
+                // Degenerated iteration over an empty set, yet with non-null power.
+                self.iter = None;
+                None
+            }
+
+            (pow, Some(it), base) => {
+                // We are still unsure whether all items have been collected.
+                // As a consequence, 'base' is still uncertain,
+                // but then we know that indices haven't started wrapping around yet.
+                if let Some(next) = it.next() {
+                    items.push(next);
+                    indices[pow - 1] += 1;
+                    return Some((indices, items));
+                }
+
+                // All items have just been collected.
+                self.iter = None;
+                if base == 1 || pow == 1 {
+                    // End of iteration.
+                    items.clear();
+                    indices.clear();
+                    return None;
+                }
+
+                // First wrap around.
+                indices[pow - 1] = 0;
+                indices[pow - 2] += 1;
+                Some((indices, items))
+            }
+
+            (_, None, b) => {
+                // Keep yielding items list, incrementing indices rightmost first.
+                for index in indices.iter_mut().rev() {
+                    *index += 1;
+                    if *index < b {
+                        return Some((indices, items));
+                    }
+                    *index = 0; // Wrap and increment left.
+                }
+                items.clear();
+                indices.clear();
+                None
+            }
+        }
+    }
+
+    /// Same as [`increment_indices`], but does n increments at once.
+    fn increment_indices_by_n(&mut self, n: usize) -> Option<(&[usize], &[I::Item])> {
+        todo!()
+    }
+}
+
+impl<I> Iterator for CartesianPower<I>
+where
+    I: Iterator,
+    I::Item: Clone,
+{
+    type Item = Vec<I::Item>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // If anything to yield,
+        // clone the correct 'pow' instances of collected items
+        // into a freshly allocated vector.
+        self.increment_indices().map(|(indices, items)| {
+            indices
+                .iter()
+                .map(|&i| items[i].clone())
+                .collect::<Vec<_>>()
+        })
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.increment_indices_by_n(n).map(|(indices, items)| {
+            indices
+                .iter()
+                .map(|&i| items[i].clone())
+                .collect::<Vec<_>>()
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        todo!()
+    }
+
+    fn count(self) -> usize {
+        todo!()
+    }
+}
+
+// Elide underlying iterator from the debug display.
+impl<I> fmt::Debug for CartesianPower<I>
+where
+    I: Iterator + fmt::Debug,
+    I::Item: fmt::Debug + Clone,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            pow,
+            iter,
+            items,
+            indices,
+        } = self;
+        f.debug_struct("CartesianPower")
+            .field("pow", pow)
+            .field("iter", &iter.is_some())
+            .field("items", items)
+            .field("indices", indices)
+            .finish()
+    }
+}
+
+impl<I> FusedIterator for CartesianPower<I>
+where
+    I: Iterator,
+    I::Item: Clone,
+{
+}
+
+#[cfg(test)]
+mod tests {
+    //! Use chars and string to ease testing of every yielded iterator values.
+
+    use super::CartesianPower;
+    use crate::Itertools;
+    use core::str::Chars;
+
+    fn check_fused(mut exhausted_it: CartesianPower<Chars>, context: String) {
+        for i in 0..100 {
+            let act = exhausted_it.next();
+            assert!(
+                act.is_none(),
+                "Iteration {} after expected exhaustion of {} \
+                yielded {:?} instead of None. ",
+                i,
+                context,
+                act,
+            );
+        }
+    }
+
+    #[test]
+    fn basic() {
+        fn check(origin: &str, pow: usize, expected: &[&str]) {
+            let mut it = origin.chars().cartesian_power(pow);
+            let mut i = 0;
+            for exp in expected {
+                let act = it.next();
+                if act != Some(exp.chars().collect()) {
+                    panic!(
+                        "Failed iteration {} for {:?}^{}. \
+                         Expected {:?}, got {:?} instead.",
+                        i, origin, pow, exp, act,
+                    );
+                }
+                i += 1;
+            }
+            check_fused(it, format!("iteration {} or {:?}^{}", i, origin, pow));
+        }
+
+        // Empty underlying iterator.
+        check("", 0, &[""]);
+        check("", 1, &[]);
+        check("", 2, &[]);
+        check("", 3, &[]);
+
+        // Singleton underlying iterator.
+        check("a", 0, &[""]);
+        check("a", 1, &["a"]);
+        check("a", 2, &["aa"]);
+        check("a", 3, &["aaa"]);
+
+        // Underlying pair.
+        check("ab", 0, &[""]);
+        check("ab", 1, &["a", "b"]);
+        check("ab", 2, &["aa", "ab", "ba", "bb"]);
+        check(
+            "ab",
+            3,
+            &["aaa", "aab", "aba", "abb", "baa", "bab", "bba", "bbb"],
+        );
+
+        // Underlying triplet.
+        check("abc", 0, &[""]);
+        check("abc", 1, &["a", "b", "c"]);
+        check(
+            "abc",
+            2,
+            &["aa", "ab", "ac", "ba", "bb", "bc", "ca", "cb", "cc"],
+        );
+        check(
+            "abc",
+            3,
+            &[
+                "aaa", "aab", "aac", "aba", "abb", "abc", "aca", "acb", "acc", "baa", "bab", "bac",
+                "bba", "bbb", "bbc", "bca", "bcb", "bcc", "caa", "cab", "cac", "cba", "cbb", "cbc",
+                "cca", "ccb", "ccc",
+            ],
+        );
+    }
+
+    #[test]
+    fn nth() {
+        fn check(origin: &str, pow: usize, expected: &[(usize, Option<&str>)]) {
+            let mut it = origin.chars().cartesian_power(pow);
+            let mut total_n = Vec::new();
+            for &(n, exp) in expected {
+                let act = it.nth(n);
+                total_n.push(n);
+                if act != exp.map(|s| s.chars().collect::<Vec<_>>()) {
+                    panic!(
+                        "Failed nth({}) iteration for {:?}^{}. \
+                         Expected {:?}, got {:?} instead.",
+                        total_n
+                            .iter()
+                            .map(ToString::to_string)
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                        origin,
+                        pow,
+                        exp,
+                        act,
+                    );
+                }
+            }
+            check_fused(
+                it,
+                format!(
+                    "nth({}) iteration of {:?}^{}",
+                    total_n
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    origin,
+                    pow
+                ),
+            );
+        }
+
+        // HERE: make it work with the new implementation.
+
+        // Check degenerated cases.
+        check("", 0, &[(0, Some("")), (0, None)]);
+        check("", 0, &[(0, Some("")), (1, None)]);
+        check("", 0, &[(0, Some("")), (2, None)]);
+        check("", 0, &[(1, None), (0, None)]);
+        check("", 0, &[(1, None), (1, None)]);
+        check("", 0, &[(1, None), (2, None)]);
+        check("", 0, &[(2, None), (0, None)]);
+        check("", 0, &[(2, None), (1, None)]);
+        check("", 0, &[(2, None), (2, None)]);
+
+        check("a", 0, &[(0, Some("")), (0, None)]);
+        check("a", 0, &[(0, Some("")), (1, None)]);
+        check("a", 0, &[(0, Some("")), (2, None)]);
+        check("a", 0, &[(1, None), (0, None)]);
+        check("a", 0, &[(1, None), (1, None)]);
+        check("a", 0, &[(1, None), (2, None)]);
+        check("a", 0, &[(2, None), (0, None)]);
+        check("a", 0, &[(2, None), (1, None)]);
+        check("a", 0, &[(2, None), (2, None)]);
+
+        // Unit power.
+        check("a", 1, &[(0, Some("a")), (0, None)]);
+        check("a", 1, &[(0, Some("a")), (1, None)]);
+        check("a", 1, &[(0, Some("a")), (2, None)]);
+        check("a", 1, &[(1, None), (0, None)]);
+        check("a", 1, &[(1, None), (1, None)]);
+        check("a", 1, &[(1, None), (2, None)]);
+        check("a", 1, &[(2, None), (0, None)]);
+        check("a", 1, &[(2, None), (1, None)]);
+        check("a", 1, &[(2, None), (2, None)]);
+
+        check("ab", 1, &[(0, Some("a")), (0, Some("b")), (0, None)]);
+        check("ab", 1, &[(1, Some("b")), (0, None), (0, None)]);
+        check("ab", 1, &[(2, None), (0, None), (0, None)]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ extern crate alloc;
 #[cfg(feature = "use_alloc")]
 use alloc::{collections::VecDeque, string::String, vec::Vec};
 
+use cartesian_power::CartesianPower;
 pub use either::Either;
 
 use core::borrow::Borrow;
@@ -177,6 +178,8 @@ pub use crate::either_or_both::EitherOrBoth;
 pub mod free;
 #[doc(inline)]
 pub use crate::free::*;
+#[cfg(feature = "use_alloc")]
+mod cartesian_power;
 #[cfg(feature = "use_alloc")]
 mod combinations;
 #[cfg(feature = "use_alloc")]
@@ -1790,6 +1793,23 @@ pub trait Itertools: Iterator {
         Self::Item: Clone,
     {
         combinations_with_replacement::combinations_with_replacement(self, k)
+    }
+
+    /// Returns an iterator yielding the successive elements
+    /// of the cartesian power of the set described by the original iterator.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// TODO: illustrative example.
+    /// ```
+    #[cfg(feature = "use_alloc")]
+    fn cartesian_power(self, pow: usize) -> CartesianPower<Self>
+    where
+        Self: Sized,
+        Self::Item: Clone,
+    {
+        cartesian_power::cartesian_power(self, pow)
     }
 
     /// Return an iterator adaptor that iterates over all k-permutations of the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1804,7 +1804,7 @@ pub trait Itertools: Iterator {
     /// TODO: illustrative example.
     /// ```
     #[cfg(feature = "use_alloc")]
-    fn cartesian_power(self, pow: usize) -> CartesianPower<Self>
+    fn cartesian_power(self, pow: u32) -> CartesianPower<Self>
     where
         Self: Sized,
         Self::Item: Clone,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,6 @@ extern crate alloc;
 #[cfg(feature = "use_alloc")]
 use alloc::{collections::VecDeque, string::String, vec::Vec};
 
-use cartesian_power::CartesianPower;
 pub use either::Either;
 
 use core::borrow::Borrow;
@@ -91,7 +90,10 @@ pub use std::iter as __std_iter;
 /// The concrete iterator types.
 pub mod structs {
     #[cfg(feature = "use_alloc")]
-    pub use crate::adaptors::MultiProduct;
+    pub use crate::{
+        cartesian_power::{CartesianPower, Indices as CartesianPowerIndices},
+        adaptors::MultiProduct
+    };
     pub use crate::adaptors::{
         Batching, Coalesce, Dedup, DedupBy, DedupByWithCount, DedupWithCount, FilterMapOk,
         FilterOk, Interleave, InterleaveShortest, MapInto, MapOk, Positions, Product, PutBack,
@@ -1215,6 +1217,66 @@ pub trait Itertools: Iterator {
         adaptors::cartesian_product(self, other.into_iter())
     }
 
+    /// Return an iterator adaptor that iterates over the given cartesian power of
+    /// the element yielded by `self`.
+    ///
+    /// Iterator element type is a collection `Vec<Self::Item>` of size `pow`.
+    /// The collection is a fresh vector
+    /// allocated on every `.next()` call
+    /// and populated with `Self::Item::clone`
+    /// until the cartesian power is exhausted.
+    /// The underlying iterator is only consumed once,
+    /// and all its yielded items are stored within the adaptor for future cloning.
+    ///
+    /// If this is too much allocation for you,
+    /// you may try the underlying streaming
+    /// [`CartesianPowerIndices`] instead.
+    ///
+    /// The resulting iterator is "cycling",
+    /// meaning that, after the last `.next()` call has yielded `None`,
+    /// you can call `.next()` again to resume iteration from the start,
+    /// as many times as needed.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let mut it = "abc".chars().cartesian_power(2);
+    /// assert_eq!(it.next(), Some(vec!['a', 'a']));
+    /// assert_eq!(it.next(), Some(vec!['a', 'b']));
+    /// assert_eq!(it.next(), Some(vec!['a', 'c'])); // Underlying a"abc".chars()` consumed.
+    /// assert_eq!(it.next(), Some(vec!['b', 'a']));
+    /// assert_eq!(it.next(), Some(vec!['b', 'b']));
+    /// assert_eq!(it.next(), Some(vec!['b', 'c']));
+    /// assert_eq!(it.next(), Some(vec!['c', 'a']));
+    /// assert_eq!(it.next(), Some(vec!['c', 'b']));
+    /// assert_eq!(it.next(), Some(vec!['c', 'c']));
+    /// assert_eq!(it.next(), None);                 // Cartesian product exhausted.
+    /// assert_eq!(it.next(), Some(vec!['a', 'a'])); // Cycle: start over, *ad libitum*.
+    /// assert_eq!(it.next(), Some(vec!['a', 'b']));
+    /// // ...
+    ///
+    /// let mut it = "ab".chars().cartesian_power(3);
+    /// assert_eq!(it.next(), Some(vec!['a', 'a', 'a']));
+    /// assert_eq!(it.next(), Some(vec!['a', 'a', 'b']));
+    /// assert_eq!(it.next(), Some(vec!['a', 'b', 'a']));
+    /// assert_eq!(it.next(), Some(vec!['a', 'b', 'b']));
+    /// assert_eq!(it.next(), Some(vec!['b', 'a', 'a']));
+    /// assert_eq!(it.next(), Some(vec!['b', 'a', 'b']));
+    /// assert_eq!(it.next(), Some(vec!['b', 'b', 'a']));
+    /// assert_eq!(it.next(), Some(vec!['b', 'b', 'b']));
+    /// assert_eq!(it.next(), None);
+    /// assert_eq!(it.next(), Some(vec!['a', 'a', 'a']));
+    /// assert_eq!(it.next(), Some(vec!['a', 'a', 'b']));
+    /// // ...
+    /// ```
+    fn cartesian_power(self, pow: u32) -> CartesianPower<Self>
+    where
+        Self: Sized,
+        Self::Item: Clone,
+    {
+        CartesianPower::new(self, pow)
+    }
+
     /// Return an iterator adaptor that iterates over the cartesian product of
     /// all subiterators returned by meta-iterator `self`.
     ///
@@ -1793,23 +1855,6 @@ pub trait Itertools: Iterator {
         Self::Item: Clone,
     {
         combinations_with_replacement::combinations_with_replacement(self, k)
-    }
-
-    /// Returns an iterator yielding the successive elements
-    /// of the cartesian power of the set described by the original iterator.
-    ///
-    /// ```
-    /// use itertools::Itertools;
-    ///
-    /// TODO: illustrative example.
-    /// ```
-    #[cfg(feature = "use_alloc")]
-    fn cartesian_power(self, pow: u32) -> CartesianPower<Self>
-    where
-        Self: Sized,
-        Self::Item: Clone,
-    {
-        cartesian_power::cartesian_power(self, pow)
     }
 
     /// Return an iterator adaptor that iterates over all k-permutations of the

--- a/tests/cartesian_power.rs
+++ b/tests/cartesian_power.rs
@@ -1,0 +1,486 @@
+//! Use chars and string to ease testing of every yielded iterator values.
+use itertools::Itertools;
+
+#[test]
+fn next() {
+    fn check(origin: &str, pow: u32, expected: &[&str]) {
+        println!("================== ({origin:?}^{pow})");
+        let mut it_act = origin
+            .chars()
+            .collect::<Vec<_>>() // Collect to get exact size hint upper bound.
+            .into_iter()
+            .cartesian_power(pow);
+        // Check size_hint on the fly.
+        let e_hint = expected.len();
+        // Check thrice that it's cycling.
+        for r in 1..=3 {
+            println!("- - {r} - - - - - -");
+            let mut it_exp = expected.iter();
+            let mut i = 0;
+            let mut e_remaining = e_hint;
+            loop {
+                // Common context to emit in case of test failure.
+                let ctx =
+                    || format!("Failed iteration {i} (repetition {r}) for {origin:?}^{pow}.",);
+                // Check size hints.
+                let a_remaining = it_act.size_hint();
+                assert!(
+                    if let (la, Some(ha)) = a_remaining {
+                        la == e_remaining && ha == e_remaining
+                    } else {
+                        false
+                    },
+                    "{} Expected size hint: ({e}, Some({e})), got instead: {a:?}.",
+                    ctx(),
+                    e = e_remaining,
+                    a = a_remaining,
+                );
+                // Actual/expected iterators steps.
+                let act = it_act.next();
+                let exp = it_exp.next().map(|e| e.chars().collect::<Vec<_>>());
+                println!(" {act:?}");
+                // Possible failure report.
+                let fail = |e, a| {
+                    let f = |o| {
+                        if let Some(v) = o {
+                            format!("{v:?}")
+                        } else {
+                            "None".into()
+                        }
+                    };
+                    panic!("{} Expected {:?}, got {:?} instead.", ctx(), f(e), f(a));
+                };
+                // Comparison.
+                match (exp, act) {
+                    (Some(exp), Some(act)) => {
+                        if act != exp {
+                            fail(Some(exp), Some(act));
+                        }
+                        i += 1;
+                    }
+                    (None, Some(act)) => {
+                        fail(None, Some(act));
+                    }
+                    (Some(exp), None) => {
+                        fail(Some(exp), None);
+                    }
+                    (None, None) => break,
+                }
+                e_remaining -= 1;
+            }
+        }
+    }
+
+    // Empty underlying iterator.
+    check("", 0, &[""]); // 0^0 = 1.
+    check("", 1, &[]);
+    check("", 2, &[]);
+    check("", 3, &[]);
+
+    // Singleton underlying iterator.
+    check("a", 0, &[""]);
+    check("a", 1, &["a"]);
+    check("a", 2, &["aa"]);
+    check("a", 3, &["aaa"]);
+
+    // Underlying pair.
+    check("ab", 0, &[""]);
+    check("ab", 1, &["a", "b"]);
+    check("ab", 2, &["aa", "ab", "ba", "bb"]);
+    check(
+        "ab",
+        3,
+        &["aaa", "aab", "aba", "abb", "baa", "bab", "bba", "bbb"],
+    );
+
+    // Underlying triplet.
+    check("abc", 0, &[""]);
+    check("abc", 1, &["a", "b", "c"]);
+    check(
+        "abc",
+        2,
+        &["aa", "ab", "ac", "ba", "bb", "bc", "ca", "cb", "cc"],
+    );
+    check(
+        "abc",
+        3,
+        &[
+            "aaa", "aab", "aac", "aba", "abb", "abc", "aca", "acb", "acc", "baa", "bab", "bac",
+            "bba", "bbb", "bbc", "bca", "bcb", "bcc", "caa", "cab", "cac", "cba", "cbb", "cbc",
+            "cca", "ccb", "ccc",
+        ],
+    );
+}
+
+#[test]
+#[allow(clippy::too_many_lines)] // Numerous detailed tests, especially corner-cases.
+#[allow(clippy::similar_names)] // On-purpose `aab`, `aba`, `aac`, etc.
+#[allow(clippy::many_single_char_names)] // On-purpose short `o`, `e`, `a`: ease test readability.
+fn nth() {
+    fn check(origin: &str, pow: u32, expected: &[(usize, (Option<&str>, usize))]) {
+        println!("================== ({origin:?}^{pow})");
+        let mut it = origin
+            .chars()
+            .collect::<Vec<_>>()
+            .into_iter()
+            .cartesian_power(pow);
+        let mut total_n = Vec::new();
+        for &(n, (exp, e_hint)) in expected {
+            total_n.push(n);
+            let ctx = || {
+                format!(
+                    "Failed nth({}) iteration for {:?}^{}.",
+                    total_n
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    origin,
+                    pow,
+                )
+            };
+            let act = it.nth(n);
+            let a_hint = it.size_hint();
+            let act = act.map(|v| v.into_iter().collect::<String>());
+            println!(
+                " → {}",
+                if let Some(act) = act.as_ref() {
+                    act
+                } else {
+                    "🗙"
+                }
+            );
+            assert!(
+                act.as_deref() == exp,
+                "{} Expected {exp:?}, got {act:?} instead.",
+                ctx(),
+            );
+            // Check size hint after stepping.
+            assert!(
+                if let (la, Some(ha)) = a_hint {
+                    la == e_hint && ha == e_hint
+                } else {
+                    false
+                },
+                "{} Expected size hint: ({e}, Some({e})), got instead: {a:?}.",
+                ctx(),
+                e = e_hint,
+                a = a_hint,
+            );
+        }
+    }
+
+    // Ease test read/write.
+    // Accept a sequence of '<n> <result>' yielded by a call to `.nth(n)`.
+    macro_rules! check {
+            ($base:expr, $pow:expr => $( $n:literal $expected:expr )+ ) => {
+                check($base, $pow, &[$(($n, $expected)),+]);
+            };
+        }
+
+    // Degenerated 0th power.
+    let o = (None, 1);
+    let e = (Some(""), 0); // "e"mpty.
+    for base in ["", "a", "ab"] {
+        check!(base, 0 => 0 e 0 o 0 e 0 o);
+        check!(base, 0 => 0 e 1 o 0 e 1 o);
+        check!(base, 0 => 0 e 2 o 1 o 0 e);
+        check!(base, 0 => 1 o 0 e 0 o 1 o);
+        check!(base, 0 => 1 o 1 o 0 e 0 o);
+        check!(base, 0 => 1 o 2 o 0 e 1 o);
+        check!(base, 0 => 2 o 0 e 1 o 0 e);
+        check!(base, 0 => 2 o 1 o 2 o 0 e);
+        check!(base, 0 => 2 o 2 o 0 e 2 o);
+    }
+
+    // Degenerated 0-base.
+    let o = (None, 0);
+    for pow in [1, 2, 3] {
+        check!("", pow => 0 o 0 o 0 o 0 o);
+        check!("", pow => 1 o 1 o 1 o 1 o);
+        check!("", pow => 2 o 2 o 2 o 2 o);
+        check!("", pow => 0 o 1 o 2 o 0 o);
+        check!("", pow => 2 o 1 o 0 o 1 o);
+    }
+
+    // Unit power.
+    let o = (None, 1);
+    let a = (Some("a"), 0);
+    check!("a", 1 => 0 a 0 o 0 a 0 o 0 a 0 o);
+    check!("a", 1 => 1 o 1 o 1 o 1 o 1 o 1 o);
+    check!("a", 1 => 2 o 2 o 2 o 2 o 2 o 2 o);
+    check!("a", 1 => 0 a 1 o 0 a 1 o 0 a 1 o);
+    check!("a", 1 => 1 o 0 a 1 o 0 a 1 o 0 a);
+    check!("a", 1 => 0 a 2 o 0 a 2 o 0 a 2 o);
+    check!("a", 1 => 2 o 0 a 2 o 0 a 2 o 0 a);
+    check!("a", 1 => 1 o 2 o 1 o 2 o 1 o 2 o);
+    check!("a", 1 => 2 o 1 o 2 o 1 o 2 o 1 o);
+    check!("a", 1 => 0 a 1 o 2 o 0 a 1 o 2 o);
+    check!("a", 1 => 0 a 2 o 1 o 0 a 2 o 1 o);
+    check!("a", 1 => 1 o 0 a 2 o 1 o 0 a 2 o);
+    check!("a", 1 => 1 o 2 o 0 a 1 o 2 o 0 a 1 o 2 o 0 a);
+    check!("a", 1 => 2 o 0 a 1 o 2 o 0 a 1 o 2 o 0 a 1 o);
+    check!("a", 1 => 2 o 1 o 0 a 2 o 1 o 0 a 2 o 1 o 0 a);
+    check!("a", 1 => 1 o 0 a 0 o 1 o 0 a 0 o 1 o 0 a 0 o);
+    check!("a", 1 => 1 o 1 o 0 a 0 o 1 o 1 o 0 a 0 o 1 o 1 o);
+
+    let o = (None, 2);
+    let a = (Some("a"), 1);
+    let b = (Some("b"), 0);
+    check!("ab", 1 => 0 a 0 b 0 o 0 a 0 b 0 o);
+    check!("ab", 1 => 1 b 1 o 1 b 1 o 1 b 1 o);
+    check!("ab", 1 => 2 o 2 o 2 o 2 o 2 o 2 o);
+    check!("ab", 1 => 0 a 1 o 0 a 1 o 0 a 1 o);
+    check!("ab", 1 => 1 b 0 o 1 b 0 o 1 b 0 o);
+    check!("ab", 1 => 0 a 2 o 0 a 2 o 0 a 2 o);
+    check!("ab", 1 => 2 o 0 a 2 o 0 a 2 o 0 a);
+    check!("ab", 1 => 1 b 2 o 1 b 2 o 1 b 2 o);
+    check!("ab", 1 => 2 o 1 b 2 o 1 b 2 o 1 b);
+    check!("ab", 1 => 0 a 1 o 2 o 0 a 1 o 2 o);
+    check!("ab", 1 => 0 a 2 o 1 b 0 o 2 o 1 b);
+    check!("ab", 1 => 1 b 0 o 2 o 1 b 0 o 2 o);
+    check!("ab", 1 => 1 b 2 o 0 a 1 o 2 o 0 a 1 o 2 o 0 a);
+    check!("ab", 1 => 2 o 0 a 1 o 2 o 0 a 1 o);
+    check!("ab", 1 => 2 o 1 b 0 o 2 o 1 b 0 o);
+    check!("ab", 1 => 1 b 0 o 0 a 1 o 0 a 0 b 1 o 0 a 0 b);
+    check!("ab", 1 => 1 b 1 o 0 a 0 b 1 o 1 b 0 o 0 a 1 o 1 b);
+
+    let o = (None, 3);
+    let a = (Some("a"), 2);
+    let b = (Some("b"), 1);
+    let c = (Some("c"), 0);
+    check!("abc", 1 => 0 a 0 b 0 c 0 o 0 a 0 b 0 c 0 o);
+    check!("abc", 1 => 1 b 1 o 1 b 1 o 1 b 1 o);
+    check!("abc", 1 => 2 c 2 o 2 c 2 o 2 c 2 o);
+    check!("abc", 1 => 0 a 1 c 0 o 1 b 0 c 1 o 0 a 1 c);
+    check!("abc", 1 => 1 b 0 c 1 o 0 a 1 c 0 o 1 b 0 c);
+    check!("abc", 1 => 0 a 2 o 0 a 2 o 0 a 2 o);
+    check!("abc", 1 => 2 c 0 o 2 c 0 o 2 c 0 o);
+    check!("abc", 1 => 1 b 2 o 1 b 2 o 1 b 2 o);
+    check!("abc", 1 => 2 c 1 o 2 c 1 o 2 c 1 o);
+    check!("abc", 1 => 0 a 1 c 2 o 0 a 1 c 2 o);
+    check!("abc", 1 => 0 a 2 o 1 b 0 c 2 o 1 b);
+    check!("abc", 1 => 1 b 0 c 2 o 1 b 0 c 2 o);
+    check!("abc", 1 => 1 b 2 o 0 a 1 c 2 o 0 a 1 c 2 o 0 a);
+    check!("abc", 1 => 2 c 0 o 1 b 2 o 0 a 1 c 2 o 0 a 1 c);
+    check!("abc", 1 => 2 c 1 o 0 a 2 o 1 b 0 c 2 o 1 b 0 c);
+    check!("abc", 1 => 1 b 0 c 0 o 1 b 0 c 0 o 1 b 0 c 0 o);
+    check!("abc", 1 => 1 b 1 o 0 a 0 b 1 o 1 b 0 c 0 o 1 b 1 o);
+
+    // Higher power.
+    let o = (None, 1);
+    let aa = (Some("aa"), 0);
+    check!("a", 2 => 0 aa 0 o 0 aa 0 o 0 aa 0 o);
+    check!("a", 2 => 1 o 1 o 1 o 1 o 1 o 1 o);
+    check!("a", 2 => 2 o 2 o 2 o 2 o 2 o 2 o);
+    check!("a", 2 => 0 aa 1 o 0 aa 1 o 0 aa 1 o);
+    check!("a", 2 => 1 o 0 aa 1 o 0 aa 1 o 0 aa 1 o);
+    check!("a", 2 => 0 aa 2 o 0 aa 2 o 0 aa 2 o);
+    check!("a", 2 => 2 o 0 aa 2 o 0 aa 2 o 0 aa);
+    check!("a", 2 => 1 o 2 o 1 o 2 o 1 o 2 o);
+    check!("a", 2 => 2 o 1 o 2 o 1 o 2 o 1 o);
+    check!("a", 2 => 0 aa 1 o 2 o 0 aa 1 o 2 o);
+    check!("a", 2 => 0 aa 2 o 1 o 0 aa 2 o 1 o);
+    check!("a", 2 => 1 o 0 aa 2 o 1 o 0 aa 2 o);
+    check!("a", 2 => 1 o 2 o 0 aa 1 o 2 o 0 aa 1 o 2 o 0 aa);
+    check!("a", 2 => 2 o 0 aa 1 o 2 o 0 aa 1 o 2 o 0 aa 1 o);
+    check!("a", 2 => 2 o 1 o 0 aa 2 o 1 o 0 aa 2 o 1 o 0 aa);
+    check!("a", 2 => 1 o 0 aa 0 o 1 o 0 aa 0 o 1 o 0 aa 0 o);
+    check!("a", 2 => 1 o 1 o 0 aa 0 o 1 o 1 o 0 aa 0 o 1 o 1 o);
+
+    let o = (None, 4);
+    let aa = (Some("aa"), 3);
+    let ab = (Some("ab"), 2);
+    let ba = (Some("ba"), 1);
+    let bb = (Some("bb"), 0);
+    check!("ab", 2 => 0 aa 0 ab 0 ba 0 bb 0 o 0 aa 0 ab);
+    check!("ab", 2 => 1 ab 1 bb 1 o 1 ab 1 bb 1 o);
+    check!("ab", 2 => 2 ba 2 o 2 ba 2 o 2 ba 2 o);
+    check!("ab", 2 => 0 aa 1 ba 0 bb 1 o 0 aa 1 ba);
+    check!("ab", 2 => 1 ab 0 ba 1 o 0 aa 1 ba 0 bb 1 o 0 aa 1 ba 0 bb);
+    check!("ab", 2 => 0 aa 2 bb 0 o 2 ba 0 bb 2 o 0 aa 2 bb);
+    check!("ab", 2 => 2 ba 0 bb 2 o 0 aa 2 bb 0 o 2 ba 0 bb);
+    check!("ab", 2 => 1 ab 2 o 1 ab 2 o 1 ab 2 o);
+    check!("ab", 2 => 2 ba 1 o 2 ba 1 o 2 ba 1 o);
+    check!("ab", 2 => 0 aa 1 ba 2 o 0 aa 1 ba 2 o);
+    check!("ab", 2 => 0 aa 2 bb 1 o 0 aa 2 bb 1 o);
+    check!("ab", 2 => 1 ab 0 ba 2 o 1 ab 0 ba 2 o);
+    check!("ab", 2 => 1 ab 2 o 0 aa 1 ba 2 o 0 aa 1 ba 2 o 0 aa);
+    check!("ab", 2 => 2 ba 0 bb 1 o 2 ba 0 bb 1 o 2 ba 0 bb 1 o);
+    check!("ab", 2 => 2 ba 1 o 0 aa 2 bb 1 o 0 aa 2 bb 1 o 0 aa);
+    check!("ab", 2 => 1 ab 0 ba 0 bb 1 o 0 aa 0 ab 1 bb 0 o 0 aa 1 ba 0 bb 0 o 1 ab 0 ba 0 bb);
+    check!("ab", 2 => 1 ab 1 bb 0 o 0 aa 1 ba 1 o 0 aa 0 ab 1 bb 1 o 0 aa 0 ab 1 bb 1 o);
+
+    let o = (None, 9);
+    let aa = (Some("aa"), 8);
+    let ab = (Some("ab"), 7);
+    let ac = (Some("ac"), 6);
+    let ba = (Some("ba"), 5);
+    let bb = (Some("bb"), 4);
+    let bc = (Some("bc"), 3);
+    let ca = (Some("ca"), 2);
+    let cb = (Some("cb"), 1);
+    let cc = (Some("cc"), 0);
+    check!("abc", 2 => 0 aa 0 ab 0 ac 0 ba 0 bb 0 bc 0 ca 0 cb 0 cc 0 o 0 aa 0 ab 0 ac 0 ba);
+    check!("abc", 2 => 1 ab 1 ba 1 bc 1 cb 1 o 1 ab 1 ba 1 bc 1 cb 1 o 1 ab 1 ba 1 bc 1 cb 1 o);
+    check!("abc", 2 => 2 ac 2 bc 2 cc 2 o 2 ac 2 bc 2 cc 2 o 2 ac 2 bc 2 cc 2 o 2 ac 2 bc 2 cc);
+    check!("abc", 2 => 0 aa 1 ac 0 ba 1 bc 0 ca 1 cc 0 o 1 ab 0 ac 1 bb 0 bc 1 cb 0 cc 1 o);
+    check!("abc", 2 => 1 ab 0 ac 1 bb 0 bc 1 cb 0 cc 1 o 0 aa 1 ac 0 ba 1 bc 0 ca 1 cc 0 o);
+    check!("abc", 2 => 0 aa 2 ba 0 bb 2 cb 0 cc 2 o 0 aa 2 ba 0 bb 2 cb 0 cc 2 o 0 aa 2 ba);
+    check!("abc", 2 => 2 ac 0 ba 2 ca 0 cb 2 o 0 aa 2 ba 0 bb 2 cb 0 cc 2 o 0 aa 2 ba 0 bb);
+    check!("abc", 2 => 1 ab 2 bb 1 ca 2 o 1 ab 2 bb 1 ca 2 o 1 ab 2 bb 1 ca 2 o 1 ab 2 bb 1 ca);
+    check!("abc", 2 => 2 ac 1 bb 2 cb 1 o 2 ac 1 bb 2 cb 1 o 2 ac 1 bb 2 cb 1 o 2 ac 1 bb 2 cb);
+    check!("abc", 2 => 0 aa 1 ac 2 bc 0 ca 1 cc 2 o 0 aa 1 ac 2 bc 0 ca 1 cc 2 o 0 aa 1 ac);
+    check!("abc", 2 => 0 aa 2 ba 1 bc 0 ca 2 o 1 ab 0 ac 2 bc 1 cb 0 cc 2 o 1 ab 0 ac 2 bc);
+    check!("abc", 2 => 1 ab 0 ac 2 bc 1 cb 0 cc 2 o 1 ab 0 ac 2 bc 1 cb 0 cc 2 o 1 ab 0 ac);
+    check!("abc", 2 => 1 ab 2 bb 0 bc 1 cb 2 o 0 aa 1 ac 2 bc 0 ca 1 cc 2 o 0 aa 1 ac 2 bc);
+    check!("abc", 2 => 2 ac 0 ba 1 bc 2 cc 0 o 1 ab 2 bb 0 bc 1 cb 2 o 0 aa 1 ac 2 bc 0 ca);
+    check!("abc", 2 => 2 ac 1 bb 0 bc 2 cc 1 o 0 aa 2 ba 1 bc 0 ca 2 o 1 ab 0 ac 2 bc 1 cb);
+    check!("abc", 2 => 1 ab 0 ac 0 ba 1 bc 0 ca 0 cb 1 o 0 aa 0 ab 1 ba 0 bb 0 bc 1 cb 0 cc);
+    check!("abc", 2 => 1 ab 1 ba 0 bb 0 bc 1 cb 1 o 0 aa 0 ab 1 ba 1 bc 0 ca 0 cb 1 o 1 ab);
+
+    let o = (None, 27);
+    let aaa = (Some("aaa"), 26);
+    let aab = (Some("aab"), 25);
+    let aac = (Some("aac"), 24);
+    let aba = (Some("aba"), 23);
+    let abb = (Some("abb"), 22);
+    let abc = (Some("abc"), 21);
+    let aca = (Some("aca"), 20);
+    let acb = (Some("acb"), 19);
+    let acc = (Some("acc"), 18);
+    let baa = (Some("baa"), 17);
+    let bab = (Some("bab"), 16);
+    let bac = (Some("bac"), 15);
+    let bba = (Some("bba"), 14);
+    let bbb = (Some("bbb"), 13);
+    let bbc = (Some("bbc"), 12);
+    let bca = (Some("bca"), 11);
+    let bcb = (Some("bcb"), 10);
+    let bcc = (Some("bcc"), 9);
+    let caa = (Some("caa"), 8);
+    let cab = (Some("cab"), 7);
+    let cac = (Some("cac"), 6);
+    let cba = (Some("cba"), 5);
+    let cbb = (Some("cbb"), 4);
+    let cbc = (Some("cbc"), 3);
+    let cca = (Some("cca"), 2);
+    let ccb = (Some("ccb"), 1);
+    let ccc = (Some("ccc"), 0);
+
+    check!(
+        "abc", 3 =>
+        0 aaa
+        0 aab
+        0 aac
+        0 aba
+        0 abb
+        0 abc
+        0 aca
+        0 acb
+        0 acc
+        0 baa
+        0 bab
+        0 bac
+        0 bba
+        0 bbb
+        0 bbc
+        0 bca
+        0 bcb
+        0 bcc
+        0 caa
+        0 cab
+        0 cac
+        0 cba
+        0 cbb
+        0 cbc
+        0 cca
+        0 ccb
+        0 ccc
+        0 o
+        0 aaa
+        0 aab
+        0 aac
+    );
+
+    check!(
+        "abc", 3 =>
+        1 aab
+        1 aba
+        1 abc
+        1 acb
+        1 baa
+        1 bac
+        1 bbb
+        1 bca
+        1 bcc
+        1 cab
+        1 cba
+        1 cbc
+        1 ccb
+        1 o
+        1 aab
+        1 aba
+    );
+
+    check!(
+        "abc", 3 =>
+        2 aac
+        2 abc
+        2 acc
+        2 bac
+        2 bbc
+        2 bcc
+        2 cac
+        2 cbc
+        2 ccc
+        2 o
+        2 aac
+        2 abc
+    );
+
+    check!(
+        "abc", 3 =>
+        3 aba 3 acb 3 bac 3 bca 3 cab 3 cbc 3 o
+        3 aba 3 acb 3 bac 3 bca 3 cab 3 cbc 3 o
+    );
+
+    check!(
+        "abc", 3 =>
+        4 abb 4 baa 4 bbc 4 cab 4 cca 4 o
+        4 abb 4 baa 4 bbc 4 cab 4 cca 4 o
+    );
+
+    check!(
+        "abc", 3 =>
+        5 abc 5 bac 5 bcc 5 cbc 5 o
+        5 abc 5 bac 5 bcc 5 cbc 5 o
+    );
+
+    check!("abc", 3 =>
+        6 aca 6 bbb 6 cac 6 o
+        6 aca 6 bbb 6 cac 6 o
+    );
+
+    check!("abc", 3 =>
+        7 acb 7 bca 7 cbc 7 o
+        7 acb 7 bca 7 cbc 7 o
+    );
+
+    check!(
+        "abc", 3 =>
+        8 acc 8 bcc 8 ccc 8 o
+        8 acc 8 bcc 8 ccc 8 o
+    );
+
+    check!("abc", 3 => 9 baa 9 cab 9 o 9 baa 9 cab 9 o);
+    check!("abc", 3 => 10 bab 10 cba 10 o 10 bab 10 cba 10 o);
+    check!("abc", 3 => 11 bac 11 cbc 11 o 11 bac 11 cbc 11 o);
+    check!("abc", 3 => 12 bba 12 ccb 12 o 12 bba 12 ccb 12 o);
+    check!("abc", 3 => 13 bbb 13 o 13 bbb 13 o);
+    check!("abc", 3 => 14 bbc 14 o 14 bbc 14 o);
+    check!("abc", 3 => 25 ccb 25 o 25 ccb 25 o);
+    check!("abc", 3 => 26 ccc 26 o 26 ccc 26 o);
+    check!("abc", 3 => 27 o 27 o 27 o 27 o);
+    check!("abc", 3 => 28 o 28 o 28 o 28 o);
+}


### PR DESCRIPTION
Hello, this is my first contribution to a rust library, can somebody guide me a little out here?

The idea is to complete the `cartesian_product` logic with a `cartesian_power` adaptor. It scrolls the cartesian product of an iterator with itself `pow` times. For instance with the set `abc` and `pow=4`, it yields:
```
aaaa (0)
aaab (1)
aaac (2)
aaba (3)
aabb (4)
aabc (5)
aaca (6)
aacb (7)
aacc (8)
abaa (9)
...
cccc (80 = 3^4 - 1)
```
Put it another way, it's supposedly equivalent to `iproduct!("abc", "abc", "abc", "abc")` except for the technical types quirks.

I have a few unresolved questions, which I need help with:

- Dummy stuff first: the diff is big because I thought it was okay to hit the `rustfmt` button, was I wrong? Should I reverse formatting?

- I cannot get the `size_hint` test to pass because it just.. times out, although I'm unsure why. How am I supposed to correctly test it?

- What am I supposed to add in the `bench` files?

- Deepest questions last:
How could the `Self::Item` type be more generic in this case? I have chosen `Vec` to start with, but the problem is that the expected returned length actually depends on the `pow` argument.
    - Should I leave it as-is and wait for generic consts to be available?
    - Can I improve it by making the returned collection type (here `Vec`) a type parameter? If yes, how?

This is it, thank you for your patience, I'd be happy to read your feedback :)