### PR TITLE
Simplify CombinationsWithReplacement

### DIFF
--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -13,8 +13,6 @@ where
     I::Item: Clone,
 {
     indices: Vec<usize>,
-    // The current known max index value. This increases as pool grows.
-    max_index: usize,
     pool: LazyBuffer<I>,
     first: bool,
 }
@@ -24,7 +22,7 @@ where
     I: Iterator + fmt::Debug,
     I::Item: fmt::Debug + Clone,
 {
-    debug_fmt_fields!(Combinations, indices, max_index, pool, first);
+    debug_fmt_fields!(Combinations, indices, pool, first);
 }
 
 impl<I> CombinationsWithReplacement<I>
@@ -49,7 +47,6 @@ where
 
     CombinationsWithReplacement {
         indices,
-        max_index: 0,
         pool,
         first: true,
     }
@@ -76,14 +73,12 @@ where
 
         // Check if we need to consume more from the iterator
         // This will run while we increment our first index digit
-        if self.pool.get_next() {
-            self.max_index = self.pool.len() - 1;
-        }
+        self.pool.get_next();
 
         // Work out where we need to update our indices
         let mut increment: Option<(usize, usize)> = None;
         for (i, indices_int) in self.indices.iter().enumerate().rev() {
-            if indices_int < &self.max_index {
+            if *indices_int < self.pool.len()-1 {
                 increment = Some((i, indices_int + 1));
                 break;
             }

--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -12,7 +12,6 @@ where
     I: Iterator,
     I::Item: Clone,
 {
-    k: usize,
     indices: Vec<usize>,
     // The current known max index value. This increases as pool grows.
     max_index: usize,
@@ -25,7 +24,7 @@ where
     I: Iterator + fmt::Debug,
     I::Item: fmt::Debug + Clone,
 {
-    debug_fmt_fields!(Combinations, k, indices, max_index, pool, first);
+    debug_fmt_fields!(Combinations, indices, max_index, pool, first);
 }
 
 impl<I> CombinationsWithReplacement<I>
@@ -49,7 +48,6 @@ where
     let pool: LazyBuffer<I> = LazyBuffer::new(iter);
 
     CombinationsWithReplacement {
-        k,
         indices,
         max_index: 0,
         pool,
@@ -67,7 +65,7 @@ where
         // If this is the first iteration, return early
         if self.first {
             // In empty edge cases, stop iterating immediately
-            return if self.k != 0 && !self.pool.get_next() {
+            return if self.indices.len() != 0 && !self.pool.get_next() {
                 None
             // Otherwise, yield the initial state
             } else {


### PR DESCRIPTION
* Eliminate `k`: It can be obtained via `indices.len`.
* Eliminate `max_index`: It can be obtained via `pool.len()-1`.