### PR TITLE
Use `for_each`

### DIFF
--- a/src/group_map.rs
+++ b/src/group_map.rs
@@ -14,9 +14,9 @@ pub fn into_group_map<I, K, V>(iter: I) -> HashMap<K, Vec<V>>
 {
     let mut lookup = HashMap::new();
 
-    for (key, val) in iter {
+    iter.for_each(|(key, val)| {
         lookup.entry(key).or_insert_with(Vec::new).push(val);
-    }
+    });
 
     lookup
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1778,10 +1778,10 @@ pub trait Itertools : Iterator {
                 let (lower, _) = self.size_hint();
                 let mut result = String::with_capacity(sep.len() * lower);
                 write!(&mut result, "{}", first_elt).unwrap();
-                for elt in self {
+                self.for_each(|elt| {
                     result.push_str(sep);
                     write!(&mut result, "{}", elt).unwrap();
-                }
+                });
                 result
             }
         }


### PR DESCRIPTION
I went through the code and looked for places where we simply traverse generic iterators. For these cases, `for_each` may be more efficient than a plain `for`.