### PR TITLE
Fix clippy lint: match_ref_pats

### DIFF
--- a/src/permutations.rs
+++ b/src/permutations.rs
@@ -105,21 +105,21 @@ where
 
         let &mut Permutations { ref vals, ref state } = self;
 
-        match state {
-            &PermutationState::StartUnknownLen { .. } => panic!("unexpected iterator state"),
-            &PermutationState::OngoingUnknownLen { k, min_n } => {
+        match *state {
+            PermutationState::StartUnknownLen { .. } => panic!("unexpected iterator state"),
+            PermutationState::OngoingUnknownLen { k, min_n } => {
                 let latest_idx = min_n - 1;
                 let indices = (0..(k - 1)).chain(once(latest_idx));
 
                 Some(indices.map(|i| vals[i].clone()).collect())
             }
-            &PermutationState::Complete(CompleteState::Start { .. }) => None,
-            &PermutationState::Complete(CompleteState::Ongoing { ref indices, ref cycles }) => {
+            PermutationState::Complete(CompleteState::Start { .. }) => None,
+            PermutationState::Complete(CompleteState::Ongoing { ref indices, ref cycles }) => {
                 let k = cycles.len();
 
                 Some(indices[0..k].iter().map(|&i| vals[i].clone()).collect())
             },
-            &PermutationState::Empty => None
+            PermutationState::Empty => None
         }
     }
 
@@ -175,11 +175,11 @@ where
     fn advance(&mut self) {
         let &mut Permutations { ref mut vals, ref mut state } = self;
 
-        *state = match state {
-            &mut PermutationState::StartUnknownLen { k } => {
+        *state = match *state {
+            PermutationState::StartUnknownLen { k } => {
                 PermutationState::OngoingUnknownLen { k, min_n: k }
             }
-            &mut PermutationState::OngoingUnknownLen { k, min_n } => {
+            PermutationState::OngoingUnknownLen { k, min_n } => {
                 if vals.get_next() {
                     PermutationState::OngoingUnknownLen { k, min_n: min_n + 1 }
                 } else {
@@ -195,20 +195,20 @@ where
                     PermutationState::Complete(complete_state)
                 }
             }
-            &mut PermutationState::Complete(ref mut state) => {
+            PermutationState::Complete(ref mut state) => {
                 state.advance();
 
                 return;
             }
-            &mut PermutationState::Empty => { return; }
+            PermutationState::Empty => { return; }
         };
     }
 }
 
 impl CompleteState {
     fn advance(&mut self) {
-        *self = match self {
-            &mut CompleteState::Start { n, k } => {
+        *self = match *self {
+            CompleteState::Start { n, k } => {
                 let indices = (0..n).collect();
                 let cycles = ((n - k)..n).rev().collect();
 
@@ -217,7 +217,7 @@ impl CompleteState {
                     indices
                 }
             },
-            &mut CompleteState::Ongoing { ref mut indices, ref mut cycles } => {
+            CompleteState::Ongoing { ref mut indices, ref mut cycles } => {
                 let n = indices.len();
                 let k = cycles.len();
 
@@ -244,8 +244,8 @@ impl CompleteState {
     fn remaining(&self) -> CompleteStateRemaining {
         use self::CompleteStateRemaining::{Known, Overflow};
 
-        match self {
-            &CompleteState::Start { n, k } => {
+        match *self {
+            CompleteState::Start { n, k } => {
                 if n < k {
                     return Known(0);
                 }
@@ -259,7 +259,7 @@ impl CompleteState {
                     None => Overflow
                 }
             }
-            &CompleteState::Ongoing { ref indices, ref cycles } => {
+            CompleteState::Ongoing { ref indices, ref cycles } => {
                 let mut count: usize = 0;
 
                 for (i, &c) in cycles.iter().enumerate() {


### PR DESCRIPTION
This fixes a clippy lint, hoping that our minimum supported Rust version accepts this: https://rust-lang.github.io/rust-clippy/master/index.html#match_ref_pats