### PR TITLE
Intra-doc links

### DIFF
--- a/src/adaptors/coalesce.rs
+++ b/src/adaptors/coalesce.rs
@@ -84,7 +84,7 @@ impl<I: Iterator, F: CoalescePredicate<I::Item, T>, T> FusedIterator for Coalesc
 
 /// An iterator adaptor that may join together adjacent elements.
 ///
-/// See [`.coalesce()`](../trait.Itertools.html#method.coalesce) for more information.
+/// See [`.coalesce()`](crate::Itertools::coalesce) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub type Coalesce<I, F> = CoalesceBy<I, F, <I as Iterator>::Item>;
 
@@ -111,7 +111,7 @@ where
 
 /// An iterator adaptor that removes repeated duplicates, determining equality using a comparison function.
 ///
-/// See [`.dedup_by()`](../trait.Itertools.html#method.dedup_by) or [`.dedup()`](../trait.Itertools.html#method.dedup) for more information.
+/// See [`.dedup_by()`](crate::Itertools::dedup_by) or [`.dedup()`](crate::Itertools::dedup) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub type DedupBy<I, Pred> = CoalesceBy<I, DedupPred2CoalescePred<Pred>, <I as Iterator>::Item>;
 
@@ -165,7 +165,7 @@ where
 
 /// An iterator adaptor that removes repeated duplicates.
 ///
-/// See [`.dedup()`](../trait.Itertools.html#method.dedup) for more information.
+/// See [`.dedup()`](crate::Itertools::dedup) for more information.
 pub type Dedup<I> = DedupBy<I, DedupEq>;
 
 /// Create a new `Dedup`.
@@ -179,8 +179,8 @@ where
 /// An iterator adaptor that removes repeated duplicates, while keeping a count of how many
 /// repeated elements were present. This will determine equality using a comparison function.
 ///
-/// See [`.dedup_by_with_count()`](../trait.Itertools.html#method.dedup_by_with_count) or
-/// [`.dedup_with_count()`](../trait.Itertools.html#method.dedup_with_count) for more information.
+/// See [`.dedup_by_with_count()`](crate::Itertools::dedup_by_with_count) or
+/// [`.dedup_with_count()`](crate::Itertools::dedup_with_count) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub type DedupByWithCount<I, Pred> =
     CoalesceBy<I, DedupPredWithCount2CoalescePred<Pred>, (usize, <I as Iterator>::Item)>;
@@ -208,7 +208,7 @@ where
 /// An iterator adaptor that removes repeated duplicates, while keeping a count of how many
 /// repeated elements were present.
 ///
-/// See [`.dedup_with_count()`](../trait.Itertools.html#method.dedup_with_count) for more information.
+/// See [`.dedup_with_count()`](crate::Itertools::dedup_with_count) for more information.
 pub type DedupWithCount<I> = DedupByWithCount<I, DedupEq>;
 
 /// Create a new `DedupByWithCount`.

--- a/src/adaptors/map.rs
+++ b/src/adaptors/map.rs
@@ -64,10 +64,10 @@ where
 
 /// An iterator adapter to apply a transformation within a nested `Result::Ok`.
 ///
-/// See [`.map_ok()`](../trait.Itertools.html#method.map_ok) for more information.
+/// See [`.map_ok()`](crate::Itertools::map_ok) for more information.
 pub type MapOk<I, F> = MapSpecialCase<I, MapSpecialCaseFnOk<F>>;
 
-/// See [`MapOk`](struct.MapOk.html).
+/// See [`MapOk`].
 #[deprecated(note = "Use MapOk instead", since = "0.10.0")]
 pub type MapResults<I, F> = MapOk<I, F>;
 
@@ -98,7 +98,7 @@ where
 
 /// An iterator adapter to apply `Into` conversion to each element.
 ///
-/// See [`.map_into()`](../trait.Itertools.html#method.map_into) for more information.
+/// See [`.map_into()`](crate::Itertools::map_into) for more information.
 pub type MapInto<I, R> = MapSpecialCase<I, MapSpecialCaseFnInto<R>>;
 
 impl<T: Into<U>, U> MapSpecialCaseFn<T> for MapSpecialCaseFnInto<U> {
@@ -111,7 +111,7 @@ impl<T: Into<U>, U> MapSpecialCaseFn<T> for MapSpecialCaseFnInto<U> {
 #[derive(Clone)]
 pub struct MapSpecialCaseFnInto<U>(PhantomData<U>);
 
-/// Create a new [`MapInto`](struct.MapInto.html) iterator.
+/// Create a new [`MapInto`] iterator.
 pub fn map_into<I, R>(iter: I) -> MapInto<I, R> {
     MapSpecialCase {
         iter,

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -1,6 +1,6 @@
 //! Licensed under the Apache License, Version 2.0
-//! http://www.apache.org/licenses/LICENSE-2.0 or the MIT license
-//! http://opensource.org/licenses/MIT, at your
+//! <http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+//! <http://opensource.org/licenses/MIT>, at your
 //! option. This file may not be copied, modified, or distributed
 //! except according to those terms.
 
@@ -24,7 +24,7 @@ use crate::size_hint;
 ///
 /// This iterator is *fused*.
 ///
-/// See [`.interleave()`](../trait.Itertools.html#method.interleave) for more information.
+/// See [`.interleave()`](crate::Itertools::interleave) for more information.
 #[derive(Clone, Debug)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Interleave<I, J> {
@@ -37,7 +37,7 @@ pub struct Interleave<I, J> {
 ///
 /// `IntoIterator` enabled version of `i.interleave(j)`.
 ///
-/// See [`.interleave()`](trait.Itertools.html#method.interleave) for more information.
+/// See [`.interleave()`](crate::Itertools::interleave) for more information.
 pub fn interleave<I, J>(i: I, j: J) -> Interleave<<I as IntoIterator>::IntoIter, <J as IntoIterator>::IntoIter>
     where I: IntoIterator,
           J: IntoIterator<Item = I::Item>
@@ -80,7 +80,7 @@ impl<I, J> Iterator for Interleave<I, J>
 ///
 /// This iterator is *fused*.
 ///
-/// See [`.interleave_shortest()`](../trait.Itertools.html#method.interleave_shortest)
+/// See [`.interleave_shortest()`](crate::Itertools::interleave_shortest)
 /// for more information.
 #[derive(Clone, Debug)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
@@ -271,7 +271,7 @@ impl<I> Iterator for PutBack<I>
 ///
 /// Iterator element type is `(I::Item, J::Item)`.
 ///
-/// See [`.cartesian_product()`](../trait.Itertools.html#method.cartesian_product) for more information.
+/// See [`.cartesian_product()`](crate::Itertools::cartesian_product) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Product<I, J>
     where I: Iterator
@@ -366,7 +366,7 @@ impl<I, J> Iterator for Product<I, J>
 ///
 /// Iterator element type is *X*, if the return type of `F` is *Option\<X\>*.
 ///
-/// See [`.batching()`](../trait.Itertools.html#method.batching) for more information.
+/// See [`.batching()`](crate::Itertools::batching) for more information.
 #[derive(Clone)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Batching<I, F> {
@@ -400,7 +400,7 @@ impl<B, F, I> Iterator for Batching<I, F>
 /// The iterator steps by yielding the next element from the base iterator,
 /// then skipping forward *n-1* elements.
 ///
-/// See [`.step()`](../trait.Itertools.html#method.step) for more information.
+/// See [`.step()`](crate::Itertools::step) for more information.
 #[deprecated(note="Use std .step_by() instead", since="0.8.0")]
 #[allow(deprecated)]
 #[derive(Clone, Debug)]
@@ -475,7 +475,7 @@ impl<T: PartialOrd> MergePredicate<T> for MergeLte {
 ///
 /// Iterator element type is `I::Item`.
 ///
-/// See [`.merge()`](../trait.Itertools.html#method.merge_by) for more information.
+/// See [`.merge()`](crate::Itertools::merge_by) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub type Merge<I, J> = MergeBy<I, J, MergeLte>;
 
@@ -503,7 +503,7 @@ pub fn merge<I, J>(i: I, j: J) -> Merge<<I as IntoIterator>::IntoIter, <J as Int
 ///
 /// Iterator element type is `I::Item`.
 ///
-/// See [`.merge_by()`](../trait.Itertools.html#method.merge_by) for more information.
+/// See [`.merge_by()`](crate::Itertools::merge_by) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct MergeBy<I, J, F>
     where I: Iterator,
@@ -591,7 +591,7 @@ impl<I, J, F> Iterator for MergeBy<I, J, F>
 /// An iterator adaptor that borrows from a `Clone`-able iterator
 /// to only pick off elements while the predicate returns `true`.
 ///
-/// See [`.take_while_ref()`](../trait.Itertools.html#method.take_while_ref) for more information.
+/// See [`.take_while_ref()`](crate::Itertools::take_while_ref) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct TakeWhileRef<'a, I: 'a, F> {
     iter: &'a mut I,
@@ -640,7 +640,7 @@ impl<'a, I, F> Iterator for TakeWhileRef<'a, I, F>
 /// An iterator adaptor that filters `Option<A>` iterator elements
 /// and produces `A`. Stops on the first `None` encountered.
 ///
-/// See [`.while_some()`](../trait.Itertools.html#method.while_some) for more information.
+/// See [`.while_some()`](crate::Itertools::while_some) for more information.
 #[derive(Clone, Debug)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct WhileSome<I> {
@@ -672,7 +672,7 @@ impl<I, A> Iterator for WhileSome<I>
 /// An iterator to iterate through all combinations in a `Clone`-able iterator that produces tuples
 /// of a specific size.
 ///
-/// See [`.tuple_combinations()`](../trait.Itertools.html#method.tuple_combinations) for more
+/// See [`.tuple_combinations()`](crate::Itertools::tuple_combinations) for more
 /// information.
 #[derive(Clone, Debug)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
@@ -822,7 +822,7 @@ impl_tuple_combination!(Tuple12Combination Tuple11Combination; A, A, A, A, A, A,
 
 /// An iterator adapter to filter values within a nested `Result::Ok`.
 ///
-/// See [`.filter_ok()`](../trait.Itertools.html#method.filter_ok) for more information.
+/// See [`.filter_ok()`](crate::Itertools::filter_ok) for more information.
 #[derive(Clone)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct FilterOk<I, F> {
@@ -886,7 +886,7 @@ impl<I, F, T, E> Iterator for FilterOk<I, F>
 
 /// An iterator adapter to filter and apply a transformation on values within a nested `Result::Ok`.
 ///
-/// See [`.filter_map_ok()`](../trait.Itertools.html#method.filter_map_ok) for more information.
+/// See [`.filter_map_ok()`](crate::Itertools::filter_map_ok) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct FilterMapOk<I, F> {
     iter: I,
@@ -957,7 +957,7 @@ impl<I, F, T, U, E> Iterator for FilterMapOk<I, F>
 
 /// An iterator adapter to get the positions of each element that matches a predicate.
 ///
-/// See [`.positions()`](../trait.Itertools.html#method.positions) for more information.
+/// See [`.positions()`](crate::Itertools::positions) for more information.
 #[derive(Clone)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Positions<I, F> {
@@ -1016,7 +1016,7 @@ impl<I, F> DoubleEndedIterator for Positions<I, F>
 
 /// An iterator adapter to apply a mutating function to each element before yielding it.
 ///
-/// See [`.update()`](../trait.Itertools.html#method.update) for more information.
+/// See [`.update()`](crate::Itertools::update) for more information.
 #[derive(Clone)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Update<I, F> {

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -11,7 +11,7 @@ use alloc::vec::Vec;
 ///
 /// An iterator element type is `Vec<I>`.
 ///
-/// See [`.multi_cartesian_product()`](../trait.Itertools.html#method.multi_cartesian_product)
+/// See [`.multi_cartesian_product()`](crate::Itertools::multi_cartesian_product)
 /// for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct MultiProduct<I>(Vec<MultiProductIter<I>>)

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 
 /// An iterator to iterate through all the `k`-length combinations in an iterator.
 ///
-/// See [`.combinations()`](../trait.Itertools.html#method.combinations) for more information.
+/// See [`.combinations()`](crate::Itertools::combinations) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Combinations<I: Iterator> {
     indices: Vec<usize>,

--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -5,7 +5,8 @@ use super::lazy_buffer::LazyBuffer;
 
 /// An iterator to iterate through all the `n`-length combinations in an iterator, with replacement.
 ///
-/// See [`.combinations_with_replacement()`](../trait.Itertools.html#method.combinations_with_replacement) for more information.
+/// See [`.combinations_with_replacement()`](crate::Itertools::combinations_with_replacement)
+/// for more information.
 #[derive(Clone)]
 pub struct CombinationsWithReplacement<I>
 where

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,14 +1,14 @@
 //! "Diff"ing iterators for caching elements to sequential collections without requiring the new
 //! elements' iterator to be `Clone`.
 //!
-//! - [**Diff**](./enum.Diff.html) (produced by the [**diff_with**](./fn.diff_with.html) function)
+//! - [`Diff`] (produced by the [`diff_with`] function)
 //! describes the difference between two non-`Clone` iterators `I` and `J` after breaking ASAP from
 //! a lock-step comparison.
 
 use crate::free::put_back;
 use crate::structs::PutBack;
 
-/// A type returned by the [`diff_with`](./fn.diff_with.html) function.
+/// A type returned by the [`diff_with`] function.
 ///
 /// `Diff` represents the way in which the elements yielded by the iterator `I` differ to some
 /// iterator `J`.

--- a/src/either_or_both.rs
+++ b/src/either_or_both.rs
@@ -25,7 +25,7 @@ impl<A, B> EitherOrBoth<A, B> {
     }
 
     /// If Left, return true otherwise, return false.
-    /// Exclusive version of [`has_left`].
+    /// Exclusive version of [`has_left`](Self::has_left).
     pub fn is_left(&self) -> bool {
         match *self {
             Left(_) => true,
@@ -34,7 +34,7 @@ impl<A, B> EitherOrBoth<A, B> {
     }
 
     /// If Right, return true otherwise, return false.
-    /// Exclusive version of [`has_right`].
+    /// Exclusive version of [`has_right`](Self::has_right).
     pub fn is_right(&self) -> bool {
         match *self {
             Right(_) => true,

--- a/src/format.rs
+++ b/src/format.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 /// The format value can only be formatted once, after that the iterator is
 /// exhausted.
 ///
-/// See [`.format_with()`](../trait.Itertools.html#method.format_with) for more information.
+/// See [`.format_with()`](crate::Itertools::format_with) for more information.
 #[derive(Clone)]
 pub struct FormatWith<'a, I, F> {
     sep: &'a str,
@@ -19,7 +19,7 @@ pub struct FormatWith<'a, I, F> {
 /// The format value can only be formatted once, after that the iterator is
 /// exhausted.
 ///
-/// See [`.format()`](../trait.Itertools.html#method.format)
+/// See [`.format()`](crate::Itertools::format)
 /// for more information.
 #[derive(Clone)]
 pub struct Format<'a, I> {

--- a/src/free.rs
+++ b/src/free.rs
@@ -225,7 +225,7 @@ pub fn join<I>(iterable: I, sep: &str) -> String
 ///
 /// `IntoIterator` enabled version of [`iterable.sorted()`][1].
 ///
-/// [1]: trait.Itertools.html#method.sorted
+/// [1]: crate::Itertools::sorted
 ///
 /// ```
 /// use itertools::sorted;

--- a/src/group_map.rs
+++ b/src/group_map.rs
@@ -6,7 +6,7 @@ use std::iter::Iterator;
 
 /// Return a `HashMap` of keys mapped to a list of their corresponding values.
 ///
-/// See [`.into_group_map()`](../trait.Itertools.html#method.into_group_map)
+/// See [`.into_group_map()`](crate::Itertools::into_group_map)
 /// for more information.
 pub fn into_group_map<I, K, V>(iter: I) -> HashMap<K, Vec<V>>
     where I: Iterator<Item=(K, V)>,

--- a/src/groupbylazy.rs
+++ b/src/groupbylazy.rs
@@ -284,7 +284,7 @@ impl<K, I, F> GroupInner<K, I, F>
 /// value. It should be stored in a local variable or temporary and
 /// iterated.
 ///
-/// See [`.group_by()`](../trait.Itertools.html#method.group_by) for more information.
+/// See [`.group_by()`](crate::Itertools::group_by) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct GroupBy<K, I, F>
     where I: Iterator,
@@ -354,7 +354,7 @@ impl<'a, K, I, F> IntoIterator for &'a GroupBy<K, I, F>
 /// Iterator element type is `(K, Group)`:
 /// the group's key `K` and the group's iterator.
 ///
-/// See [`.group_by()`](../trait.Itertools.html#method.group_by) for more information.
+/// See [`.group_by()`](crate::Itertools::group_by) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Groups<'a, K: 'a, I: 'a, F: 'a>
     where I: Iterator,
@@ -460,7 +460,7 @@ pub fn new_chunks<J>(iter: J, size: usize) -> IntoChunks<J::IntoIter>
 ///
 /// Iterator element type is `Chunk`, each chunk's iterator.
 ///
-/// See [`.chunks()`](../trait.Itertools.html#method.chunks) for more information.
+/// See [`.chunks()`](crate::Itertools::chunks) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct IntoChunks<I>
     where I: Iterator,
@@ -505,7 +505,7 @@ impl<'a, I> IntoIterator for &'a IntoChunks<I>
 ///
 /// Iterator element type is `Chunk`.
 ///
-/// See [`.chunks()`](../trait.Itertools.html#method.chunks) for more information.
+/// See [`.chunks()`](crate::Itertools::chunks) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Chunks<'a, I: 'a>
     where I: Iterator,

--- a/src/intersperse.rs
+++ b/src/intersperse.rs
@@ -21,7 +21,7 @@ impl<Item: Clone> IntersperseElement<Item> for IntersperseElementSimple<Item> {
 ///
 /// This iterator is *fused*.
 ///
-/// See [`.intersperse()`](../trait.Itertools.html#method.intersperse) for more information.
+/// See [`.intersperse()`](crate::Itertools::intersperse) for more information.
 pub type Intersperse<I> = IntersperseWith<I, IntersperseElementSimple<<I as Iterator>::Item>>;
 
 /// Create a new Intersperse iterator
@@ -44,7 +44,7 @@ impl<Item, F: FnMut()->Item> IntersperseElement<Item> for F {
 ///
 /// This iterator is *fused*.
 ///
-/// See [`.intersperse_with()`](../trait.Itertools.html#method.intersperse_with) for more information.
+/// See [`.intersperse_with()`](crate::Itertools::intersperse_with) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone, Debug)]
 pub struct IntersperseWith<I, ElemF>

--- a/src/kmerge_impl.rs
+++ b/src/kmerge_impl.rs
@@ -98,7 +98,7 @@ fn sift_down<T, S>(heap: &mut [T], index: usize, mut less_than: S)
 ///
 /// Iterator element type is `I::Item`.
 ///
-/// See [`.kmerge()`](../trait.Itertools.html#method.kmerge) for more information.
+/// See [`.kmerge()`](crate::Itertools::kmerge) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub type KMerge<I> = KMergeBy<I, KMergeByLt>;
 
@@ -146,7 +146,7 @@ pub fn kmerge<I>(iterable: I) -> KMerge<<I::Item as IntoIterator>::IntoIter>
 ///
 /// Iterator element type is `I::Item`.
 ///
-/// See [`.kmerge_by()`](../trait.Itertools.html#method.kmerge_by) for more
+/// See [`.kmerge_by()`](crate::Itertools::kmerge_by) for more
 /// information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct KMergeBy<I, F>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,13 +5,13 @@
 //! Extra iterator adaptors, functions and macros.
 //!
 //! To extend [`Iterator`] with methods in this crate, import
-//! the [`Itertools` trait](./trait.Itertools.html):
+//! the [`Itertools` trait](Itertools):
 //!
 //! ```
 //! use itertools::Itertools;
 //! ```
 //!
-//! Now, new methods like [`interleave`](./trait.Itertools.html#method.interleave)
+//! Now, new methods like [`interleave`](Itertools::interleave)
 //! are available on all iterators:
 //!
 //! ```
@@ -43,8 +43,6 @@
 //! ## Rust Version
 //!
 //! This version of itertools requires Rust 1.32 or later.
-//!
-//! [`Iterator`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html
 #![doc(html_root_url="https://docs.rs/itertools/0.8/")]
 
 #[cfg(not(feature = "use_std"))]
@@ -279,8 +277,6 @@ macro_rules! iproduct {
 /// Prefer this macro `izip!()` over [`multizip`] for the performance benefits
 /// of using the standard library `.zip()`.
 ///
-/// [`multizip`]: fn.multizip.html
-///
 /// ```
 /// # use itertools::izip;
 /// #
@@ -346,8 +342,6 @@ macro_rules! izip {
 /// return a regular value of some other kind.
 /// [`.next_tuple()`](#method.next_tuple) is an example and the first regular
 /// method in the list.
-///
-/// [`Iterator`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html
 pub trait Itertools : Iterator {
     // adaptors
 
@@ -446,7 +440,7 @@ pub trait Itertools : Iterator {
     /// will return `None`.
     ///
     /// Iterator element type is
-    /// [`EitherOrBoth<Self::Item, J::Item>`](enum.EitherOrBoth.html).
+    /// [`EitherOrBoth<Self::Item, J::Item>`](EitherOrBoth).
     ///
     /// ```rust
     /// use itertools::EitherOrBoth::{Both, Right};
@@ -688,7 +682,7 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![(1, 2, 3), (4, 5, 6)]);
     /// ```
     ///
-    /// See also [`Tuples::into_buffer`](structs/struct.Tuples.html#method.into_buffer).
+    /// See also [`Tuples::into_buffer`].
     fn tuples<T>(self) -> Tuples<Self, T>
         where Self: Sized + Iterator<Item = T::Item>,
               T: traits::HomogeneousTuple
@@ -985,7 +979,7 @@ pub trait Itertools : Iterator {
     ///
     /// All provided iterators must yield the same `Item` type. To generate
     /// the product of iterators yielding multiple types, use the
-    /// [`iproduct`](macro.iproduct.html) macro instead.
+    /// [`iproduct`] macro instead.
     ///
     ///
     /// The iterator element type is `Vec<T>`, where `T` is the iterator element
@@ -1434,7 +1428,7 @@ pub trait Itertools : Iterator {
     /// ease special-case handling of the first or last elements.
     ///
     /// Iterator element type is
-    /// [`Position<Self::Item>`](enum.Position.html)
+    /// [`Position<Self::Item>`](Position)
     ///
     /// ```
     /// use itertools::{Itertools, Position};
@@ -2759,8 +2753,6 @@ pub trait Itertools : Iterator {
     /// let a = [1, 1, -1, -1];
     /// assert_eq!(a.iter().position_minmax(), MinMax(2, 1));
     /// ```
-    ///
-    /// [`MinMaxResult`]: enum.MinMaxResult.html
     fn position_minmax(self) -> MinMaxResult<usize>
         where Self: Sized, Self::Item: PartialOrd
     {
@@ -2805,8 +2797,7 @@ pub trait Itertools : Iterator {
     /// assert_eq!(a.iter().position_minmax_by_key(|x| x.abs()), MinMax(0, 3));
     /// ```
     ///
-    /// [`MinMaxResult`]: enum.MinMaxResult.html
-    /// [`position_minmax`]: #method.position_minmax
+    /// [`position_minmax`]: Self::position_minmax
     fn position_minmax_by_key<K, F>(self, mut key: F) -> MinMaxResult<usize>
         where Self: Sized, K: PartialOrd, F: FnMut(&Self::Item) -> K
     {
@@ -2848,8 +2839,7 @@ pub trait Itertools : Iterator {
     /// assert_eq!(a.iter().position_minmax_by(|x, y| x.cmp(y)), MinMax(2, 1));
     /// ```
     ///
-    /// [`MinMaxResult`]: enum.MinMaxResult.html
-    /// [`position_minmax`]: #method.position_minmax
+    /// [`position_minmax`]: Self::position_minmax
     fn position_minmax_by<F>(self, mut compare: F) -> MinMaxResult<usize>
         where Self: Sized, F: FnMut(&Self::Item, &Self::Item) -> Ordering
     {
@@ -3053,7 +3043,7 @@ pub fn partition<'a, A: 'a, I, F>(iter: I, mut pred: F) -> usize
 
 /// An enum used for controlling the execution of `.fold_while()`.
 ///
-/// See [`.fold_while()`](trait.Itertools.html#method.fold_while) for more information.
+/// See [`.fold_while()`](crate::Itertools::fold_while) for more information.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum FoldWhile<T> {
     /// Continue folding with this value

--- a/src/merge_join.rs
+++ b/src/merge_join.rs
@@ -7,7 +7,7 @@ use crate::either_or_both::EitherOrBoth;
 
 /// Return an iterator adaptor that merge-joins items from the two base iterators in ascending order.
 ///
-/// See [`.merge_join_by()`](trait.Itertools.html#method.merge_join_by) for more information.
+/// See [`.merge_join_by()`](crate::Itertools::merge_join_by) for more information.
 pub fn merge_join_by<I, J, F>(left: I, right: J, cmp_fn: F)
     -> MergeJoinBy<I::IntoIter, J::IntoIter, F>
     where I: IntoIterator,
@@ -23,7 +23,7 @@ pub fn merge_join_by<I, J, F>(left: I, right: J, cmp_fn: F)
 
 /// An iterator adaptor that merge-joins items from the two base iterators in ascending order.
 ///
-/// See [`.merge_join_by()`](../trait.Itertools.html#method.merge_join_by) for more information.
+/// See [`.merge_join_by()`](crate::Itertools::merge_join_by) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct MergeJoinBy<I: Iterator, J: Iterator, F> {
     left: PutBack<Fuse<I>>,

--- a/src/multipeek_impl.rs
+++ b/src/multipeek_impl.rs
@@ -3,7 +3,7 @@ use alloc::collections::VecDeque;
 use crate::size_hint;
 use crate::PeekingNext;
 
-/// See [`multipeek()`](../fn.multipeek.html) for more information.
+/// See [`multipeek()`] for more information.
 #[derive(Clone, Debug)]
 pub struct MultiPeek<I>
     where I: Iterator

--- a/src/pad_tail.rs
+++ b/src/pad_tail.rs
@@ -6,7 +6,7 @@ use crate::size_hint;
 ///
 /// Iterator element type is `I::Item`.
 ///
-/// See [`.pad_using()`](../trait.Itertools.html#method.pad_using) for more information.
+/// See [`.pad_using()`](crate::Itertools::pad_using) for more information.
 #[derive(Clone)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct PadUsing<I, F> {

--- a/src/peek_nth.rs
+++ b/src/peek_nth.rs
@@ -3,7 +3,7 @@ use crate::PeekingNext;
 use alloc::collections::VecDeque;
 use std::iter::Fuse;
 
-/// See [`peek_nth()`](../fn.peek_nth.html) for more information.
+/// See [`peek_nth()`] for more information.
 #[derive(Clone, Debug)]
 pub struct PeekNth<I>
 where

--- a/src/peeking_take_while.rs
+++ b/src/peeking_take_while.rs
@@ -5,7 +5,7 @@ use crate::PutBackN;
 
 /// An iterator that allows peeking at an element before deciding to accept it.
 ///
-/// See [`.peeking_take_while()`](trait.Itertools.html#method.peeking_take_while)
+/// See [`.peeking_take_while()`](crate::Itertools::peeking_take_while)
 /// for more information.
 ///
 /// This is implemented by peeking adaptors like peekable and put back,
@@ -73,7 +73,7 @@ impl<I> PeekingNext for PutBackN<I>
 
 /// An iterator adaptor that takes items while a closure returns `true`.
 ///
-/// See [`.peeking_take_while()`](../trait.Itertools.html#method.peeking_take_while)
+/// See [`.peeking_take_while()`](crate::Itertools::peeking_take_while)
 /// for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct PeekingTakeWhile<'a, I: 'a, F>

--- a/src/permutations.rs
+++ b/src/permutations.rs
@@ -7,7 +7,7 @@ use super::lazy_buffer::LazyBuffer;
 /// An iterator adaptor that iterates through all the `k`-permutations of the
 /// elements from an iterator.
 ///
-/// See [`.permutations()`](../trait.Itertools.html#method.permutations) for
+/// See [`.permutations()`](crate::Itertools::permutations) for
 /// more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Permutations<I: Iterator> {

--- a/src/tee.rs
+++ b/src/tee.rs
@@ -15,7 +15,7 @@ struct TeeBuffer<A, I> {
 
 /// One half of an iterator pair where both return the same elements.
 ///
-/// See [`.tee()`](../trait.Itertools.html#method.tee) for more information.
+/// See [`.tee()`](crate::Itertools::tee) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug)]
 pub struct Tee<I>

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -19,8 +19,8 @@ impl<T: TupleCollect> HomogeneousTuple for T {}
 
 /// An iterator over a incomplete tuple.
 ///
-/// See [`.tuples()`](../trait.Itertools.html#method.tuples) and
-/// [`Tuples::into_buffer()`](struct.Tuples.html#method.into_buffer).
+/// See [`.tuples()`](crate::Itertools::tuples) and
+/// [`Tuples::into_buffer()`].
 #[derive(Clone, Debug)]
 pub struct TupleBuffer<T>
     where T: HomogeneousTuple
@@ -75,7 +75,7 @@ impl<T> ExactSizeIterator for TupleBuffer<T>
 
 /// An iterator that groups the items in tuples of a specific size.
 ///
-/// See [`.tuples()`](../trait.Itertools.html#method.tuples) for more information.
+/// See [`.tuples()`](crate::Itertools::tuples) for more information.
 #[derive(Clone)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Tuples<I, T>
@@ -130,7 +130,7 @@ impl<I, T> Tuples<I, T>
 
 /// An iterator over all contiguous windows that produces tuples of a specific size.
 ///
-/// See [`.tuple_windows()`](../trait.Itertools.html#method.tuple_windows) for more
+/// See [`.tuple_windows()`](crate::Itertools::tuple_windows) for more
 /// information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone, Debug)]
@@ -191,7 +191,7 @@ impl<I, T> Iterator for TupleWindows<I, T>
 /// window would otherwise exceed the length of the iterator, producing tuples
 /// of a specific size.
 ///
-/// See [`.circular_tuple_windows()`](../trait.Itertools.html#method.circular_tuple_windows) for more
+/// See [`.circular_tuple_windows()`](crate::Itertools::circular_tuple_windows) for more
 /// information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug)]

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -6,7 +6,7 @@ use std::fmt;
 
 /// An iterator adapter to filter out duplicate elements.
 ///
-/// See [`.unique_by()`](../trait.Itertools.html#method.unique) for more information.
+/// See [`.unique_by()`](crate::Itertools::unique) for more information.
 #[derive(Clone)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct UniqueBy<I: Iterator, V, F> {
@@ -138,7 +138,7 @@ impl<I> DoubleEndedIterator for Unique<I>
 
 /// An iterator adapter to filter out duplicate elements.
 ///
-/// See [`.unique()`](../trait.Itertools.html#method.unique) for more information.
+/// See [`.unique()`](crate::Itertools::unique) for more information.
 #[derive(Clone)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Unique<I: Iterator> {

--- a/src/with_position.rs
+++ b/src/with_position.rs
@@ -1,10 +1,10 @@
 use std::iter::{Fuse,Peekable};
 
-/// An iterator adaptor that wraps each element in an [`Position`](../enum.Position.html).
+/// An iterator adaptor that wraps each element in an [`Position`].
 ///
 /// Iterator element type is `Position<I::Item>`.
 ///
-/// See [`.with_position()`](../trait.Itertools.html#method.with_position) for more information.
+/// See [`.with_position()`](crate::Itertools::with_position) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct WithPosition<I>
     where I: Iterator,
@@ -33,7 +33,7 @@ pub fn with_position<I>(iter: I) -> WithPosition<I>
 /// A value yielded by `WithPosition`.
 /// Indicates the position of this element in the iterator results.
 ///
-/// See [`.with_position()`](trait.Itertools.html#method.with_position) for more information.
+/// See [`.with_position()`](crate::Itertools::with_position) for more information.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Position<T> {
     /// This is the first element.

--- a/src/zip_eq_impl.rs
+++ b/src/zip_eq_impl.rs
@@ -2,7 +2,7 @@ use super::size_hint;
 
 /// An iterator which iterates two other iterators simultaneously
 ///
-/// See [`.zip_eq()`](../trait.Itertools.html#method.zip_eq) for more information.
+/// See [`.zip_eq()`](crate::Itertools::zip_eq) for more information.
 #[derive(Clone, Debug)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct ZipEq<I, J> {

--- a/src/zip_longest.rs
+++ b/src/zip_longest.rs
@@ -11,7 +11,7 @@ use crate::either_or_both::EitherOrBoth;
 ///
 /// This iterator is *fused*.
 ///
-/// See [`.zip_longest()`](../trait.Itertools.html#method.zip_longest) for more information.
+/// See [`.zip_longest()`](crate::Itertools::zip_longest) for more information.
 #[derive(Clone, Debug)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct ZipLongest<T, U> {
@@ -20,7 +20,7 @@ pub struct ZipLongest<T, U> {
 }
 
 /// Create a new `ZipLongest` iterator.
-pub fn zip_longest<T, U>(a: T, b: U) -> ZipLongest<T, U> 
+pub fn zip_longest<T, U>(a: T, b: U) -> ZipLongest<T, U>
     where T: Iterator,
           U: Iterator
 {

--- a/src/ziptuple.rs
+++ b/src/ziptuple.rs
@@ -1,6 +1,6 @@
 use super::size_hint;
 
-/// See [`multizip`](../fn.multizip.html) for more information.
+/// See [`multizip`] for more information.
 #[derive(Clone, Debug)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Zip<T> {
@@ -22,8 +22,6 @@ pub struct Zip<T> {
 ///
 /// Prefer [`izip!()`] over `multizip` for the performance benefits of using the
 /// standard library `.zip()`. Prefer `multizip` if a nameable type is needed.
-///
-/// [`izip!()`]: macro.izip.html
 ///
 /// ```
 /// use itertools::multizip;


### PR DESCRIPTION
This commit changes all the documentation to use intra-doc links, which
were stabilized in rust 1.48. This helps to avoid broken links in crates
that depend on this one.

fixes #496