### PR TITLE
Support owned iterators for GroupBy and IntoChunks `into_iter()`

### DIFF
--- a/src/groupbylazy.rs
+++ b/src/groupbylazy.rs
@@ -117,7 +117,8 @@ where
         if elt.is_none() && client == self.oldest_buffered_group {
             // FIXME: VecDeque is unfortunately not zero allocation when empty,
             // so we do this job manually.
-            // `bottom_group..oldest_buffered_group` is unused, and if it's large enough, erase it.
+            // `bottom_group..oldest_buffered_group` is unused, and if it's large enough,
+            // erase it.
             self.oldest_buffered_group += 1;
             // skip forward further empty queues too
             while self
@@ -202,7 +203,8 @@ where
     }
 
     fn push_next_group(&mut self, group: Vec<I::Item>) {
-        // When we add a new buffered group, fill up slots between oldest_buffered_group and top_group
+        // When we add a new buffered group, fill up slots between oldest_buffered_group
+        // and top_group
         while self.top_group - self.bottom_group > self.buffer.len() {
             if self.buffer.is_empty() {
                 self.bottom_group += 1;

--- a/src/groupbylazy.rs
+++ b/src/groupbylazy.rs
@@ -1,7 +1,7 @@
 use alloc::vec::{self, Vec};
 use std::cell::{Cell, RefCell};
 use std::ops::Deref;
-use std::rc::Rc;
+use alloc::rc::Rc;
 
 /// A trait to unify `FnMut` for `ChunkBy` with the chunk key in `IntoChunks`
 trait KeyFunction<A> {

--- a/src/groupbylazy.rs
+++ b/src/groupbylazy.rs
@@ -397,7 +397,7 @@ where
     /// references in the underlying iterators instead of reference counts,
     /// resulting in one less allocation. You may however hit lifetime
     /// errors if you require full ownership.
-    pub fn borrowed_iter<'a>(&'a self) -> <&'a Self as IntoIterator>::IntoIter {
+    pub fn borrowed_iter(&self) -> <&Self as IntoIterator>::IntoIter {
         self.into_iter()
     }
 }
@@ -589,7 +589,7 @@ where
     /// references in the underlying iterators instead of reference counts,
     /// resulting in one less allocation. You may however hit lifetime
     /// errors if you require full ownership.
-    pub fn borrowed_iter<'a>(&'a self) -> <&'a Self as IntoIterator>::IntoIter {
+    pub fn borrowed_iter(&self) -> <&Self as IntoIterator>::IntoIter {
         self.into_iter()
     }
 }

--- a/src/groupbylazy.rs
+++ b/src/groupbylazy.rs
@@ -1,7 +1,7 @@
-use alloc::vec::{self, Vec};
-use std::cell::{Cell, RefCell};
-use std::ops::Deref;
 use alloc::rc::Rc;
+use alloc::vec::{self, Vec};
+use core::cell::{Cell, RefCell};
+use core::ops::Deref;
 
 /// A trait to unify `FnMut` for `ChunkBy` with the chunk key in `IntoChunks`
 trait KeyFunction<A> {

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -8,8 +8,7 @@
 use itertools::free::{
     cloned, enumerate, multipeek, peek_nth, put_back, put_back_n, rciter, zip, zip_eq,
 };
-use itertools::Itertools;
-use itertools::{iproduct, izip, multizip, EitherOrBoth};
+use itertools::{iproduct, izip, multizip, EitherOrBoth, Itertools};
 use quickcheck as qc;
 use std::cmp::{max, min, Ordering};
 use std::collections::{HashMap, HashSet};
@@ -1049,8 +1048,8 @@ quickcheck! {
 quickcheck! {
     fn fuzz_chunk_by_lazy_duo(data: Vec<u8>, order: Vec<(bool, bool)>) -> bool {
         let grouper = data.iter().chunk_by(|k| *k / 3);
-        let mut chunks1 = grouper.into_iter();
-        let mut chunks2 = grouper.into_iter();
+        let mut chunks1 = grouper.borrowed_iter();
+        let mut chunks2 = grouper.borrowed_iter();
         let mut elts = Vec::<&u8>::new();
         let mut old_chunks = Vec::new();
 


### PR DESCRIPTION
Resolves #499