### PR TITLE
Add #[track_caller] to iterators that may panic

### DIFF
--- a/src/rciter_impl.rs
+++ b/src/rciter_impl.rs
@@ -1,7 +1,6 @@
-
-use std::iter::IntoIterator;
 use alloc::rc::Rc;
 use std::cell::RefCell;
+use std::iter::IntoIterator;
 
 /// A wrapper for `Rc<RefCell<I>>`, that implements the `Iterator` trait.
 #[derive(Debug)]
@@ -45,9 +44,12 @@ pub struct RcIter<I> {
 /// `.next()`, i.e. if it somehow participates in an “iterator knot”
 /// where it is an adaptor of itself.
 pub fn rciter<I>(iterable: I) -> RcIter<I::IntoIter>
-    where I: IntoIterator
+where
+    I: IntoIterator,
 {
-    RcIter { rciter: Rc::new(RefCell::new(iterable.into_iter())) }
+    RcIter {
+        rciter: Rc::new(RefCell::new(iterable.into_iter())),
+    }
 }
 
 impl<I> Clone for RcIter<I> {
@@ -56,10 +58,12 @@ impl<I> Clone for RcIter<I> {
 }
 
 impl<A, I> Iterator for RcIter<I>
-    where I: Iterator<Item = A>
+where
+    I: Iterator<Item = A>,
 {
     type Item = A;
     #[inline]
+    #[track_caller]
     fn next(&mut self) -> Option<Self::Item> {
         self.rciter.borrow_mut().next()
     }
@@ -74,7 +78,8 @@ impl<A, I> Iterator for RcIter<I>
 }
 
 impl<I> DoubleEndedIterator for RcIter<I>
-    where I: DoubleEndedIterator
+where
+    I: DoubleEndedIterator,
 {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
@@ -84,7 +89,8 @@ impl<I> DoubleEndedIterator for RcIter<I>
 
 /// Return an iterator from `&RcIter<I>` (by simply cloning it).
 impl<'a, I> IntoIterator for &'a RcIter<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     type Item = I::Item;
     type IntoIter = RcIter<I>;

--- a/src/zip_eq_impl.rs
+++ b/src/zip_eq_impl.rs
@@ -25,8 +25,9 @@ pub struct ZipEq<I, J> {
 /// }
 /// ```
 pub fn zip_eq<I, J>(i: I, j: J) -> ZipEq<I::IntoIter, J::IntoIter>
-    where I: IntoIterator,
-          J: IntoIterator
+where
+    I: IntoIterator,
+    J: IntoIterator,
 {
     ZipEq {
         a: i.into_iter(),
@@ -35,17 +36,20 @@ pub fn zip_eq<I, J>(i: I, j: J) -> ZipEq<I::IntoIter, J::IntoIter>
 }
 
 impl<I, J> Iterator for ZipEq<I, J>
-    where I: Iterator,
-          J: Iterator
+where
+    I: Iterator,
+    J: Iterator,
 {
     type Item = (I::Item, J::Item);
 
+    #[track_caller]
     fn next(&mut self) -> Option<Self::Item> {
         match (self.a.next(), self.b.next()) {
             (None, None) => None,
             (Some(a), Some(b)) => Some((a, b)),
-            (None, Some(_)) | (Some(_), None) =>
-            panic!("itertools: .zip_eq() reached end of one iterator before the other")
+            (None, Some(_)) | (Some(_), None) => {
+                panic!("itertools: .zip_eq() reached end of one iterator before the other")
+            }
         }
     }
 
@@ -55,6 +59,8 @@ impl<I, J> Iterator for ZipEq<I, J>
 }
 
 impl<I, J> ExactSizeIterator for ZipEq<I, J>
-    where I: ExactSizeIterator,
-          J: ExactSizeIterator
-{}
+where
+    I: ExactSizeIterator,
+    J: ExactSizeIterator,
+{
+}


### PR DESCRIPTION
Adds the #[track_caller] attribute to `zip_eq` and `rc_iter`. That leads to more useful error messages in case of a panic.