### PR TITLE
Add Itertools.contains

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1616,8 +1616,6 @@ pub trait Itertools : Iterator {
     /// iterator will be exhausted.
     ///
     /// ```
-    /// use itertools::Itertools;
-    ///
     /// #[derive(PartialEq, Debug)]
     /// enum Enum { A, B, C, D, E, }
     /// 
@@ -1633,12 +1631,13 @@ pub trait Itertools : Iterator {
     /// // `E` wasn't found, so `iter` is now exhausted
     /// assert_eq!(iter.next(), None);
     /// ```
-    fn contains<Q>(&mut self, query: Q) -> bool
+    fn contains<Q>(&mut self, query: &Q) -> bool
     where
         Self: Sized,
-        Self::Item: PartialEq<Q>,
+        Self::Item: Borrow<Q>,
+        Q: PartialEq,
     {
-        self.any(|x| x == query)
+        self.any(|x| x.borrow() == query)
     }
 
     /// Check whether all elements compare equal.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1608,6 +1608,53 @@ pub trait Itertools : Iterator {
         None
     }
 
+    /// Check whether the iterator contains an item.
+    ///
+    /// If the iterator contains the item prior to its end,
+    /// this method will short-circuit and only partially
+    /// exhaust the iterator.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let data = vec![
+    ///      "foo".to_owned(),
+    ///      "bar".to_owned(),
+    ///      "baz".to_owned(),
+    /// ];
+    /// // this could get expensive:
+    /// assert!(data.contains(&"foo".to_owned()));
+    /// // this, less so:
+    /// assert!(data.iter().contains("foo"));
+    ///
+    /// // now the not-as-motivating tests involving Copy data:
+    ///
+    /// let data = vec![4usize, 5, 1, 3, 0, 2];
+    /// assert!(data.iter().contains(&4));
+    /// assert!(!data.iter().contains(&6));
+    /// for x in (0..50) {
+    ///     assert_eq!(data.contains(&x), data.iter().contains(&x));
+    /// }
+    ///
+    /// let mut it = data.iter();
+    /// assert!(!it.contains(&6));
+    /// assert_eq!(it.next(), None);
+    ///
+    /// let mut it = data.iter();
+    /// assert!(it.contains(&3));
+    /// assert_eq!(it.next(), Some(&0));
+    ///
+    /// let data : Option<usize> = None;
+    /// assert!(!data.into_iter().contains(0));
+    /// ```
+    fn contains<Q>(&mut self, query: Q) -> bool
+    where
+        Self: Sized,
+        Self::Item: PartialEq<Q>,
+    {
+        self.any(|x| x == query)
+    }
+
     /// Check whether all elements compare equal.
     ///
     /// Empty iterators are considered to have equal elements:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1618,18 +1618,20 @@ pub trait Itertools : Iterator {
     /// iterator will be exhausted.
     ///
     /// ```
+    /// use itertools::Itertools;
+    ///
     /// #[derive(PartialEq, Debug)]
     /// enum Enum { A, B, C, D, E, }
     /// 
     /// let mut iter = vec![Enum::A, Enum::B, Enum::C, Enum::D].into_iter();
     /// 
     /// // search `iter` for `B`
-    /// assert_eq!(iter.contains(Enum::B), true);
+    /// assert_eq!(iter.contains(&Enum::B), true);
     /// // `B` was found, so the iterator now rests at the item after `B` (i.e, `C`).
     /// assert_eq!(iter.next(), Some(Enum::C));
     /// 
     /// // search `iter` for `E`
-    /// assert_eq!(iter.contains(Enum::E), false);
+    /// assert_eq!(iter.contains(&Enum::E), false);
     /// // `E` wasn't found, so `iter` is now exhausted
     /// assert_eq!(iter.next(), None);
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,8 +59,7 @@ use alloc::{
 
 pub use either::Either;
 
-#[cfg(feature = "use_std")]
-use std::borrow::Borrow;
+use core::borrow:Borrow;
 #[cfg(feature = "use_std")]
 use std::collections::HashMap;
 use std::iter::{IntoIterator, once};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1611,7 +1611,7 @@ pub trait Itertools : Iterator {
     /// Returns `true` if the given item is present in this iterator.
     ///
     /// This method is short-circuiting. If the given item is present in this
-    /// iterator, the this method will consume the iterator up-to-and-including
+    /// iterator, this method will consume the iterator up-to-and-including
     /// the item. If the given item is not present in this iterator, the
     /// iterator will be exhausted.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ use alloc::{
 
 pub use either::Either;
 
-use core::borrow:Borrow;
+use core::borrow::Borrow;
 #[cfg(feature = "use_std")]
 use std::collections::HashMap;
 use std::iter::{IntoIterator, once};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1618,35 +1618,20 @@ pub trait Itertools : Iterator {
     /// ```
     /// use itertools::Itertools;
     ///
-    /// let data = vec![
-    ///      "foo".to_owned(),
-    ///      "bar".to_owned(),
-    ///      "baz".to_owned(),
-    /// ];
-    /// // this could get expensive:
-    /// assert!(data.contains(&"foo".to_owned()));
-    /// // this, less so:
-    /// assert!(data.iter().contains("foo"));
-    ///
-    /// // now the not-as-motivating tests involving Copy data:
-    ///
-    /// let data = vec![4usize, 5, 1, 3, 0, 2];
-    /// assert!(data.iter().contains(&4));
-    /// assert!(!data.iter().contains(&6));
-    /// for x in (0..50) {
-    ///     assert_eq!(data.contains(&x), data.iter().contains(&x));
-    /// }
-    ///
-    /// let mut it = data.iter();
-    /// assert!(!it.contains(&6));
-    /// assert_eq!(it.next(), None);
-    ///
-    /// let mut it = data.iter();
-    /// assert!(it.contains(&3));
-    /// assert_eq!(it.next(), Some(&0));
-    ///
-    /// let data : Option<usize> = None;
-    /// assert!(!data.into_iter().contains(0));
+    /// #[derive(PartialEq, Debug)]
+    /// enum Enum { A, B, C, D, E, }
+    /// 
+    /// let mut iter = vec![Enum::A, Enum::B, Enum::C, Enum::D].into_iter();
+    /// 
+    /// // search `iter` for `B`
+    /// assert_eq!(iter.contains(Enum::B), true);
+    /// // `B` was found, so the iterator now rests at the item after `B` (i.e, `C`).
+    /// assert_eq!(iter.next(), Some(Enum::C));
+    /// 
+    /// // search `iter` for `E`
+    /// assert_eq!(iter.contains(Enum::E), false);
+    /// // `E` wasn't found, so `iter` is now exhausted
+    /// assert_eq!(iter.next(), None);
     /// ```
     fn contains<Q>(&mut self, query: Q) -> bool
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,8 @@ use alloc::{
 pub use either::Either;
 
 #[cfg(feature = "use_std")]
+use std::borrow::Borrow;
+#[cfg(feature = "use_std")]
 use std::collections::HashMap;
 use std::iter::{IntoIterator, once};
 use std::cmp::Ordering;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1608,11 +1608,12 @@ pub trait Itertools : Iterator {
         None
     }
 
-    /// Check whether the iterator contains an item.
+    /// Returns `true` if the given item is present in this iterator.
     ///
-    /// If the iterator contains the item prior to its end,
-    /// this method will short-circuit and only partially
-    /// exhaust the iterator.
+    /// This method is short-circuiting. If the given item is present in this
+    /// iterator, the this method will consume the iterator up-to-and-including
+    /// the item. If the given item is not present in this iterator, the
+    /// iterator will be exhausted.
     ///
     /// ```
     /// use itertools::Itertools;


### PR DESCRIPTION
This is an extremely trivial shorthand for the code-pattern suggested by the docs for [slice::contains](https://doc.rust-lang.org/std/primitive.slice.html#method.contains) in the case when one has a slice of owned data to be queried using borrowed data.