### PR TITLE
Use internal iteration in more places

### DIFF
--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -102,12 +102,12 @@ impl<I, K, V> GroupingMap<I>
     {
         let mut destination_map = HashMap::new();
 
-        for (key, val) in self.iter {
+        self.iter.for_each(|(key, val)| {
             let acc = destination_map.remove(&key);
             if let Some(op_res) = operation(acc, &key, val) {
                 destination_map.insert(key, op_res);
             }
-        }
+        });
 
         destination_map
     }
@@ -208,9 +208,9 @@ impl<I, K, V> GroupingMap<I>
     {
         let mut destination_map = HashMap::new();
 
-        for (key, val) in self.iter {
+        self.iter.for_each(|(key, val)| {
             destination_map.entry(key).or_insert_with(C::default).extend(Some(val));
-        }
+        });
 
         destination_map
     }

--- a/src/k_smallest.rs
+++ b/src/k_smallest.rs
@@ -6,7 +6,7 @@ pub(crate) fn k_smallest<T: Ord, I: Iterator<Item = T>>(mut iter: I, k: usize) -
 
     let mut heap = iter.by_ref().take(k).collect::<BinaryHeap<_>>();
 
-    for i in iter {
+    iter.for_each(|i| {
         debug_assert_eq!(heap.len(), k);
         // Equivalent to heap.push(min(i, heap.pop())) but more efficient.
         // This should be done with a single `.peek_mut().unwrap()` but
@@ -14,7 +14,7 @@ pub(crate) fn k_smallest<T: Ord, I: Iterator<Item = T>>(mut iter: I, k: usize) -
         if *heap.peek().unwrap() > i {
             *heap.peek_mut().unwrap() = i;
         }
-    }
+    });
 
     heap
 }


### PR DESCRIPTION
I haven't benched it but internal iteration should always be equivalent or faster than external iteration.