### PR TITLE
Add a chain! macro.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,6 +346,43 @@ macro_rules! izip {
     };
 }
 
+#[macro_export]
+/// Create an iterator running multiple iterators sequentially.
+///
+/// This is a version of the standard ``.chain()`` that's supporting more than
+/// two iterators. `chain!` takes `IntoIterator` arguments.
+/// Alternatively, this is an alternative to the standard ``.flatten()`` for a
+/// fixed number of iterators of distinct sizes.
+///
+/// **Note:** The result of this macro is in the general case an iterator
+/// composed of repeated `.chain()`.
+/// The special case of one arguments produce $a.into_iter().
+///
+///
+/// ```
+/// # use itertools::chain;
+/// #
+/// # fn main() {
+///
+/// // chain three sequences
+/// let chained: Vec<i32> = chain!(0..=3, 4..6, vec![6, 7]).collect();
+/// assert_eq!(chained, (0..=7).collect::<Vec<i32>>());
+/// # }
+/// ```
+macro_rules! chain {
+    () => {
+        core::iter::empty()
+    };
+    ( $first:expr $(, $rest:expr )* $(,)*) => {
+        core::iter::IntoIterator::into_iter($first)
+            $(
+                .chain(
+                    core::iter::IntoIterator::into_iter($rest)
+                )
+            )*
+    };
+}
+
 /// An [`Iterator`] blanket implementation that provides extra adaptors and
 /// methods.
 ///

--- a/tests/test_core.rs
+++ b/tests/test_core.rs
@@ -13,6 +13,7 @@ use crate::it::multizip;
 use crate::it::free::put_back;
 use crate::it::iproduct;
 use crate::it::izip;
+use crate::it::chain;
 
 #[test]
 fn product2() {
@@ -85,6 +86,28 @@ fn multizip3() {
     for (_, _, _, _, _) in multizip((0..3, 0..2, xs.iter(), &xs, xs.to_vec())) {
         /* test compiles */
     }
+}
+
+#[test]
+fn chain_macro() {
+    let mut chain = chain!(2..3);
+    assert!(chain.next() == Some(2));
+    assert!(chain.next().is_none());
+
+    let mut chain = chain!(0..2, 2..3, 3..5i8);
+    for i in 0..5i8 {
+        assert_eq!(Some(i), chain.next());
+    }
+    assert!(chain.next().is_none());
+
+    let mut chain = chain!();
+    assert_eq!(chain.next(), Option::<()>::None);
+}
+
+#[test]
+fn chain2() {
+    let _ = chain!(1.., 2..);
+    let _ = chain!(1.., 2.., );
 }
 
 #[test]


### PR DESCRIPTION
This is proposal to add a `chain!` macro which creates an iterator running multiple iterators sequentially.

It basically calls multiple times the standard `.chain()`. This macro is useful to avoid rightwards shift of the code when chaining many iterators.

For the implementation and tests, I took inspiration on the `izip!` macro.