### PR TITLE
Add take_borrowed iterator adaptor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ pub mod structs {
         TupleCombinations,
         Positions,
         Update,
+        TakeBorrowed,
     };
     #[allow(deprecated)]
     pub use crate::adaptors::{MapResults, Step};
@@ -1653,6 +1654,34 @@ pub trait Itertools : Iterator {
               F: FnMut(&mut Self::Item),
     {
         adaptors::update(self, updater)
+    }
+
+    /// Return an iterator over the first `n` elements,
+    /// while borrowing the original iterator.
+    ///
+    /// This is similar to `take(n)`, except that is doesn't
+    /// consume the original iterator.
+    ///
+    /// The iterator must be evaluated for it to have any effect on the original iterator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// fn consume_iterator<I>(iter: I) where I: Iterator<Item = i32> {
+    ///     itertools::assert_equal(iter, vec![1, 2, 3]);
+    /// }
+    ///
+    /// let mut iter = vec![1, 2, 3, 4, 5].into_iter();
+    ///
+    /// consume_iterator(iter.take_borrowed(3));
+    ///
+    /// itertools::assert_equal(iter, vec![4, 5])
+    /// ```
+    fn take_borrowed(&mut self, n: usize) -> TakeBorrowed<Self>
+        where Self: Sized {
+        adaptors::take_borrowed(self, n)
     }
 
     // non-adaptor methods

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -1587,3 +1587,26 @@ quickcheck! {
         TestResult::from_bool(itertools::equal(x, y))
     }
 }
+
+quickcheck! {
+    fn size_take_borrowed(mut iter: Iter<u8>, n: usize) -> bool {
+        correct_size_hint(iter.take_borrowed(n))
+    }
+
+    fn size_take_borrowed_remaining(vec: Vec<u8>, n: usize) -> bool {
+        let mut iter = vec.into_iter();
+        let _: Vec<_> = iter.take_borrowed(n).collect();
+        correct_size_hint(iter)
+    }
+
+    fn test_take_borrowed_taken(iter: Iter<u8>, n: usize) -> bool {
+        itertools::equal(iter.clone().take_borrowed(n), iter.take(n))
+    }
+
+    fn test_take_borrowed_remaining(vec: Vec<u8>, n: usize) -> bool {
+        let other = vec.clone();
+        let mut iter = vec.into_iter();
+        let _: Vec<_> = iter.take_borrowed(n).collect();
+        itertools::equal(iter, other.into_iter().skip(n))
+    }
+}


### PR DESCRIPTION
This adds the `take_borrowed(n)` method to the itertools trait. This produces an iterator over the first `n` elements, similar to `take`. However, it borrows from the original iterator, leaving the remaining elements once the returned iterator has been evaluated. This provides a simple way of splitting an iterator in two.

The only doubt I have about this is what should happen if the returned iterator isn't fully evaluated. Currently, if it is only evaluated k times, then only the first k elements will be removed from the original. It might be a better idea to add a `drop` implementation to skip the remaining elements, or perhaps add that as an option. I'm not sure what would be the most logical in that situation.