### PR TITLE
Add `find_or_last` method to `Itertools` trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1738,7 +1738,7 @@ pub trait Itertools : Iterator {
     /// use itertools::Itertools;
     ///
     /// let numbers = [1, 2, 3, 4];
-    /// assert_eq!(numbers.iter().find_or_last(|x| x > 5), Some(4));
+    /// assert_eq!(numbers.iter().find_or_last(|&&x| x > 5), Some(&4));
     /// ```
 	fn find_or_last<P>(mut self, predicate: P) -> Option<Self::Item>
 		where Self: Sized,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1750,6 +1750,29 @@ pub trait Itertools : Iterator {
         self.find_map(|x| if predicate(&x) { Some(x) } else { prev = Some(x); None })
             .or(prev)
     }
+    /// Find the value of the first element satisfying a predicate or return the first element, if any.
+    ///
+    /// The iterator is not advanced past the first element found.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let numbers = [1, 2, 3, 4];
+    /// assert_eq!(numbers.iter().find_or_first(|&&x| x > 5), Some(&1));
+    /// assert_eq!(numbers.iter().find_or_first(|&&x| x > 2), Some(&3));
+    /// assert_eq!(std::iter::empty::<i32>().find_or_first(|&x| x > 5), None);
+    /// ```
+    fn find_or_first<P>(mut self, mut predicate: P) -> Option<Self::Item>
+        where Self: Sized,
+              P: FnMut(&Self::Item) -> bool,
+    {
+        let first = self.next()?;
+        Some(if predicate(&first) {
+            first
+        } else {
+            self.find(|x| predicate(&x)).unwrap_or(first)
+        })
+    }
     /// Returns `true` if the given item is present in this iterator.
     ///
     /// This method is short-circuiting. If the given item is present in this

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1742,18 +1742,13 @@ pub trait Itertools : Iterator {
     /// assert_eq!(numbers.iter().find_or_last(|&&x| x > 2), Some(&3));
     /// assert_eq!(std::iter::empty::<i32>().find_or_last(|&x| x > 5), None);
     /// ```
-    fn find_or_last<P>(mut self, predicate: P) -> Option<Self::Item>
+    fn find_or_last<P>(mut self, mut predicate: P) -> Option<Self::Item>
         where Self: Sized,
               P: FnMut(&Self::Item) -> bool,
     {
-        #[inline]
-        fn check<T>(mut predicate: impl FnMut(&T) -> bool) -> impl FnMut(Option<T>, T) -> Result<Option<T>, T> {
-            move |_, x| {
-                if predicate(&x) { Result::Err(x) } else { Result::Ok(Some(x)) }
-            }
-        }
-
-        self.try_fold(None, check(predicate)).unwrap_or_else(Some)
+        let mut prev = None;
+        self.find_map(|x| if predicate(&x) { Some(x) } else { prev = Some(x); None })
+            .or(prev)
     }
     /// Returns `true` if the given item is present in this iterator.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1739,6 +1739,8 @@ pub trait Itertools : Iterator {
     ///
     /// let numbers = [1, 2, 3, 4];
     /// assert_eq!(numbers.iter().find_or_last(|&&x| x > 5), Some(&4));
+    /// assert_eq!(numbers.iter().find_or_last(|&&x| x > 2), Some(&3));
+    /// assert_eq!(std::iter::empty::<i32>().find_or_last(|&x| x > 5), None);
     /// ```
 	fn find_or_last<P>(mut self, predicate: P) -> Option<Self::Item>
 		where Self: Sized,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1742,11 +1742,11 @@ pub trait Itertools : Iterator {
     /// assert_eq!(numbers.iter().find_or_last(|&&x| x > 2), Some(&3));
     /// assert_eq!(std::iter::empty::<i32>().find_or_last(|&x| x > 5), None);
     /// ```
-	fn find_or_last<P>(mut self, predicate: P) -> Option<Self::Item>
-		where Self: Sized,
-			  P: FnMut(&Self::Item) -> bool,
-	{
-		#[inline]
+    fn find_or_last<P>(mut self, predicate: P) -> Option<Self::Item>
+        where Self: Sized,
+              P: FnMut(&Self::Item) -> bool,
+    {
+        #[inline]
         fn check<T>(mut predicate: impl FnMut(&T) -> bool) -> impl FnMut(Option<T>, T) -> Result<Option<T>, T> {
             move |_, x| {
                 if predicate(&x) { Result::Err(x) } else { Result::Ok(Some(x)) }
@@ -1754,7 +1754,7 @@ pub trait Itertools : Iterator {
         }
 
         self.try_fold(None, check(predicate)).unwrap_or_else(Some)
-	}
+    }
     /// Returns `true` if the given item is present in this iterator.
     ///
     /// This method is short-circuiting. If the given item is present in this


### PR DESCRIPTION
[Playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=6abc43c9037445f88fb0a86991da01f2)

```rust
fn find_or_last(mut self, predicate: impl FnMut(&Self::Item) -> bool) -> Option<Self::Item>
```
- returns `None` if iterator is empty
- returns `Some(element)` when element matches the predicate
- returns `Some(last_element)` when no element matches the predicate

[Related discussion on the rust user forum](https://users.rust-lang.org/t/find-or-return-last-element-of-iterator/58171)