### PR TITLE
Added the `or_default`  method to `EitherOrBoth`

### DIFF
--- a/src/either_or_both.rs
+++ b/src/either_or_both.rs
@@ -163,6 +163,21 @@ impl<A, B> EitherOrBoth<A, B> {
             Right(b) | Both(_, b) => f(b),
         }
     }
+
+    /// Returns a tuple consisting of the `l` and `r` in `Both(l, r)`, if present.
+    /// Otherwise, returns the wrapped value for the present element, and the [`default`](Default::default)
+    /// for the other.
+    pub fn or_default(self) -> (A, B)
+    where
+        A: Default,
+        B: Default,
+    {
+        match self {
+            EitherOrBoth::Left(l) => (l, B::default()),
+            EitherOrBoth::Right(r) => (A::default(), r),
+            EitherOrBoth::Both(l, r) => (l, r),
+        }
+    }
 }
 
 impl<T> EitherOrBoth<T, T> {
@@ -185,19 +200,6 @@ impl<A, B> Into<Option<Either<A, B>>> for EitherOrBoth<A, B> {
             EitherOrBoth::Left(l) => Some(Either::Left(l)),
             EitherOrBoth::Right(r) => Some(Either::Right(r)),
             _ => None,
-        }
-    }
-}
-
-impl<A: Default, B: Default> EitherOrBoth<A,B> {
-    /// Returns a tuple consisting of the `l` and `r` in `Both(l, r)`, if present.
-    /// Otherwise, returns the wrapped value for the present element, and the [`default`](Default::default)
-    /// for the other.
-    pub fn or_default(self) -> (A, B) {
-        match self {
-            EitherOrBoth::Left(l) => (l, B::default()),
-            EitherOrBoth::Right(r) => (A::default(), r),
-            EitherOrBoth::Both(l, r) => (l, r),
         }
     }
 }

--- a/src/either_or_both.rs
+++ b/src/either_or_both.rs
@@ -188,3 +188,16 @@ impl<A, B> Into<Option<Either<A, B>>> for EitherOrBoth<A, B> {
         }
     }
 }
+
+impl<A: Default, B: Default> EitherOrBoth<A,B> {
+    /// Returns a tuple consisting of the `l` and `r` in `Both(l, r)`, if present.
+    /// Otherwise, returns the wrapped value for the present element, and the [`default`](Default::default)
+    /// for the other.
+    pub fn or_default(self) -> (A, B) {
+        match self {
+            EitherOrBoth::Left(l) => (l, B::default()),
+            EitherOrBoth::Right(r) => (A::default(), r),
+            EitherOrBoth::Both(l, r) => (l, r),
+        }
+    }
+}


### PR DESCRIPTION
This commit is motivated by the context explained in issue #537 

Allows for doing things like padding out an iterator with a default value while the other one is consumed.