### PR TITLE
Refine intra-doc links

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -35,7 +35,7 @@ pub struct Interleave<I, J> {
 
 /// Create an iterator that interleaves elements in `i` and `j`.
 ///
-/// `IntoIterator` enabled version of `i.interleave(j)`.
+/// [`IntoIterator`] enabled version of `i.interleave(j)`.
 ///
 /// See [`.interleave()`](crate::Itertools::interleave) for more information.
 pub fn interleave<I, J>(i: I, j: J) -> Interleave<<I as IntoIterator>::IntoIter, <J as IntoIterator>::IntoIter>
@@ -481,7 +481,7 @@ pub type Merge<I, J> = MergeBy<I, J, MergeLte>;
 
 /// Create an iterator that merges elements in `i` and `j`.
 ///
-/// `IntoIterator` enabled version of `i.merge(j)`.
+/// [`IntoIterator`] enabled version of `i.merge(j)`.
 ///
 /// ```
 /// use itertools::merge;

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -481,7 +481,7 @@ pub type Merge<I, J> = MergeBy<I, J, MergeLte>;
 
 /// Create an iterator that merges elements in `i` and `j`.
 ///
-/// [`IntoIterator`] enabled version of `i.merge(j)`.
+/// [`IntoIterator`] enabled version of [`Itertools::merge`](crate::Itertools::merge).
 ///
 /// ```
 /// use itertools::merge;

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -47,9 +47,7 @@ impl<I: Iterator> Combinations<I> {
     pub fn k(&self) -> usize { self.indices.len() }
 
     /// Returns the (current) length of the pool from which combination elements are
-    /// selected. This value can change between invocations of [`next`].
-    ///
-    /// [`next`]: #method.next
+    /// selected. This value can change between invocations of [`next`](Combinations::next).
     #[inline]
     pub fn n(&self) -> usize { self.pool.len() }
 

--- a/src/concat_impl.rs
+++ b/src/concat_impl.rs
@@ -2,7 +2,7 @@ use crate::Itertools;
 
 /// Combine all an iterator's elements into one element by using [`Extend`].
 ///
-/// [`IntoIterator`]-enabled version of `.concat()`
+/// [`IntoIterator`]-enabled version of [`Itertools::concat`].
 ///
 /// This combinator will extend the first item with each of the rest of the
 /// items of the iterator. If the iterator is empty, the default value of

--- a/src/concat_impl.rs
+++ b/src/concat_impl.rs
@@ -1,8 +1,8 @@
 use crate::Itertools;
 
-/// Combine all an iterator's elements into one element by using `Extend`.
+/// Combine all an iterator's elements into one element by using [`Extend`].
 ///
-/// `IntoIterator`-enabled version of `.concat()`
+/// [`IntoIterator`]-enabled version of `.concat()`
 ///
 /// This combinator will extend the first item with each of the rest of the
 /// items of the iterator. If the iterator is empty, the default value of

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -26,7 +26,7 @@ pub enum Diff<I, J>
 }
 
 /// Compares every element yielded by both `i` and `j` with the given function in lock-step and
-/// returns a `Diff` which describes how `j` differs from `i`.
+/// returns a [`Diff`] which describes how `j` differs from `i`.
 ///
 /// If the number of elements yielded by `j` is less than the number of elements yielded by `i`,
 /// the number of `j` elements yielded will be returned along with `i`'s remaining elements as

--- a/src/duplicates_impl.rs
+++ b/src/duplicates_impl.rs
@@ -176,7 +176,7 @@ mod private {
 
 /// An iterator adapter to filter for duplicate elements.
 ///
-/// See [`.duplicates_by()`](../trait.Itertools.html#method.duplicates_by) for more information.
+/// See [`.duplicates_by()`](crate::Itertools::duplicates_by) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub type DuplicatesBy<I, V, F> = private::DuplicatesBy<I, V, private::ByFn<F>>;
 
@@ -192,7 +192,7 @@ where
 
 /// An iterator adapter to filter out duplicate elements.
 ///
-/// See [`.duplicates()`](../trait.Itertools.html#method.duplicates) for more information.
+/// See [`.duplicates()`](crate::Itertools::duplicates) for more information.
 pub type Duplicates<I> = private::DuplicatesBy<I, <I as Iterator>::Item, private::ById>;
 
 /// Create a new `Duplicates` iterator.

--- a/src/either_or_both.rs
+++ b/src/either_or_both.rs
@@ -25,7 +25,7 @@ impl<A, B> EitherOrBoth<A, B> {
     }
 
     /// If Left, return true otherwise, return false.
-    /// Exclusive version of [`has_left`](Self::has_left).
+    /// Exclusive version of [`has_left`](EitherOrBoth::has_left).
     pub fn is_left(&self) -> bool {
         match *self {
             Left(_) => true,
@@ -34,7 +34,7 @@ impl<A, B> EitherOrBoth<A, B> {
     }
 
     /// If Right, return true otherwise, return false.
-    /// Exclusive version of [`has_right`](Self::has_right).
+    /// Exclusive version of [`has_right`](EitherOrBoth::has_right).
     pub fn is_right(&self) -> bool {
         match *self {
             Right(_) => true,

--- a/src/free.rs
+++ b/src/free.rs
@@ -223,9 +223,7 @@ pub fn join<I>(iterable: I, sep: &str) -> String
 
 /// Sort all iterator elements into a new iterator in ascending order.
 ///
-/// [`IntoIterator`] enabled version of [`iterable.sorted()`][1].
-///
-/// [1]: crate::Itertools::sorted
+/// [`IntoIterator`] enabled version of [`Itertools::sorted`].
 ///
 /// ```
 /// use itertools::sorted;

--- a/src/free.rs
+++ b/src/free.rs
@@ -37,7 +37,7 @@ pub use crate::rciter_impl::rciter;
 
 /// Iterate `iterable` with a running index.
 ///
-/// [`IntoIterator`] enabled version of `.enumerate()`.
+/// [`IntoIterator`] enabled version of [`Iterator::enumerate`].
 ///
 /// ```
 /// use itertools::enumerate;
@@ -54,7 +54,7 @@ pub fn enumerate<I>(iterable: I) -> iter::Enumerate<I::IntoIter>
 
 /// Iterate `iterable` in reverse.
 ///
-/// [`IntoIterator`] enabled version of `.rev()`.
+/// [`IntoIterator`] enabled version of [`Iterator::rev`].
 ///
 /// ```
 /// use itertools::rev;
@@ -72,7 +72,7 @@ pub fn rev<I>(iterable: I) -> iter::Rev<I::IntoIter>
 
 /// Iterate `i` and `j` in lock step.
 ///
-/// [`IntoIterator`] enabled version of `i.zip(j)`.
+/// [`IntoIterator`] enabled version of [`Iterator::zip`].
 ///
 /// ```
 /// use itertools::zip;
@@ -91,7 +91,7 @@ pub fn zip<I, J>(i: I, j: J) -> Zip<I::IntoIter, J::IntoIter>
 
 /// Create an iterator that first iterates `i` and then `j`.
 ///
-/// `IntoIterator` enabled version of `i.chain(j)`.
+/// [`IntoIterator`] enabled version of [`Iterator::chain`].
 ///
 /// ```
 /// use itertools::chain;
@@ -109,7 +109,7 @@ pub fn chain<I, J>(i: I, j: J) -> iter::Chain<<I as IntoIterator>::IntoIter, <J 
 
 /// Create an iterator that clones each element from &T to T
 ///
-/// [`IntoIterator`] enabled version of `i.cloned()`.
+/// [`IntoIterator`] enabled version of [`Iterator::cloned`].
 ///
 /// ```
 /// use itertools::cloned;
@@ -125,7 +125,7 @@ pub fn cloned<'a, I, T: 'a>(iterable: I) -> iter::Cloned<I::IntoIter>
 
 /// Perform a fold operation over the iterable.
 ///
-/// [`IntoIterator`] enabled version of `i.fold(init, f)`
+/// [`IntoIterator`] enabled version of [`Iterator::fold`].
 ///
 /// ```
 /// use itertools::fold;
@@ -141,7 +141,7 @@ pub fn fold<I, B, F>(iterable: I, init: B, f: F) -> B
 
 /// Test whether the predicate holds for all elements in the iterable.
 ///
-/// [`IntoIterator`] enabled version of `i.all(f)`
+/// [`IntoIterator`] enabled version of [`Iterator::all`].
 ///
 /// ```
 /// use itertools::all;
@@ -157,7 +157,7 @@ pub fn all<I, F>(iterable: I, f: F) -> bool
 
 /// Test whether the predicate holds for any elements in the iterable.
 ///
-/// [`IntoIterator`] enabled version of `i.any(f)`
+/// [`IntoIterator`] enabled version of [`Iterator::any`].
 ///
 /// ```
 /// use itertools::any;
@@ -173,7 +173,7 @@ pub fn any<I, F>(iterable: I, f: F) -> bool
 
 /// Return the maximum value of the iterable.
 ///
-/// [`IntoIterator`] enabled version of `i.max()`.
+/// [`IntoIterator`] enabled version of [`Iterator::max`].
 ///
 /// ```
 /// use itertools::max;
@@ -189,7 +189,7 @@ pub fn max<I>(iterable: I) -> Option<I::Item>
 
 /// Return the minimum value of the iterable.
 ///
-/// [`IntoIterator`] enabled version of `i.min()`.
+/// [`IntoIterator`] enabled version of [`Iterator::min`].
 ///
 /// ```
 /// use itertools::min;
@@ -206,7 +206,7 @@ pub fn min<I>(iterable: I) -> Option<I::Item>
 
 /// Combine all iterator elements into one String, seperated by `sep`.
 ///
-/// [`IntoIterator`] enabled version of `iterable.join(sep)`.
+/// [`IntoIterator`] enabled version of [`Itertools::join`].
 ///
 /// ```
 /// use itertools::join;

--- a/src/free.rs
+++ b/src/free.rs
@@ -1,6 +1,6 @@
 //! Free functions that create iterator adaptors or call iterator methods.
 //!
-//! The benefit of free functions is that they accept any `IntoIterator` as
+//! The benefit of free functions is that they accept any [`IntoIterator`] as
 //! argument, so the resulting code may be easier to read.
 
 #[cfg(feature = "use_alloc")]
@@ -37,7 +37,7 @@ pub use crate::rciter_impl::rciter;
 
 /// Iterate `iterable` with a running index.
 ///
-/// `IntoIterator` enabled version of `.enumerate()`.
+/// [`IntoIterator`] enabled version of `.enumerate()`.
 ///
 /// ```
 /// use itertools::enumerate;
@@ -54,7 +54,7 @@ pub fn enumerate<I>(iterable: I) -> iter::Enumerate<I::IntoIter>
 
 /// Iterate `iterable` in reverse.
 ///
-/// `IntoIterator` enabled version of `.rev()`.
+/// [`IntoIterator`] enabled version of `.rev()`.
 ///
 /// ```
 /// use itertools::rev;
@@ -72,7 +72,7 @@ pub fn rev<I>(iterable: I) -> iter::Rev<I::IntoIter>
 
 /// Iterate `i` and `j` in lock step.
 ///
-/// `IntoIterator` enabled version of `i.zip(j)`.
+/// [`IntoIterator`] enabled version of `i.zip(j)`.
 ///
 /// ```
 /// use itertools::zip;
@@ -109,7 +109,7 @@ pub fn chain<I, J>(i: I, j: J) -> iter::Chain<<I as IntoIterator>::IntoIter, <J 
 
 /// Create an iterator that clones each element from &T to T
 ///
-/// `IntoIterator` enabled version of `i.cloned()`.
+/// [`IntoIterator`] enabled version of `i.cloned()`.
 ///
 /// ```
 /// use itertools::cloned;
@@ -125,7 +125,7 @@ pub fn cloned<'a, I, T: 'a>(iterable: I) -> iter::Cloned<I::IntoIter>
 
 /// Perform a fold operation over the iterable.
 ///
-/// `IntoIterator` enabled version of `i.fold(init, f)`
+/// [`IntoIterator`] enabled version of `i.fold(init, f)`
 ///
 /// ```
 /// use itertools::fold;
@@ -141,7 +141,7 @@ pub fn fold<I, B, F>(iterable: I, init: B, f: F) -> B
 
 /// Test whether the predicate holds for all elements in the iterable.
 ///
-/// `IntoIterator` enabled version of `i.all(f)`
+/// [`IntoIterator`] enabled version of `i.all(f)`
 ///
 /// ```
 /// use itertools::all;
@@ -157,7 +157,7 @@ pub fn all<I, F>(iterable: I, f: F) -> bool
 
 /// Test whether the predicate holds for any elements in the iterable.
 ///
-/// `IntoIterator` enabled version of `i.any(f)`
+/// [`IntoIterator`] enabled version of `i.any(f)`
 ///
 /// ```
 /// use itertools::any;
@@ -173,7 +173,7 @@ pub fn any<I, F>(iterable: I, f: F) -> bool
 
 /// Return the maximum value of the iterable.
 ///
-/// `IntoIterator` enabled version of `i.max()`.
+/// [`IntoIterator`] enabled version of `i.max()`.
 ///
 /// ```
 /// use itertools::max;
@@ -189,7 +189,7 @@ pub fn max<I>(iterable: I) -> Option<I::Item>
 
 /// Return the minimum value of the iterable.
 ///
-/// `IntoIterator` enabled version of `i.min()`.
+/// [`IntoIterator`] enabled version of `i.min()`.
 ///
 /// ```
 /// use itertools::min;
@@ -206,7 +206,7 @@ pub fn min<I>(iterable: I) -> Option<I::Item>
 
 /// Combine all iterator elements into one String, seperated by `sep`.
 ///
-/// `IntoIterator` enabled version of `iterable.join(sep)`.
+/// [`IntoIterator`] enabled version of `iterable.join(sep)`.
 ///
 /// ```
 /// use itertools::join;
@@ -223,7 +223,7 @@ pub fn join<I>(iterable: I, sep: &str) -> String
 
 /// Sort all iterator elements into a new iterator in ascending order.
 ///
-/// `IntoIterator` enabled version of [`iterable.sorted()`][1].
+/// [`IntoIterator`] enabled version of [`iterable.sorted()`][1].
 ///
 /// [1]: crate::Itertools::sorted
 ///

--- a/src/groupbylazy.rs
+++ b/src/groupbylazy.rs
@@ -279,7 +279,7 @@ impl<K, I, F> GroupInner<K, I, F>
 /// no allocations. It needs allocations only if several group iterators
 /// are alive at the same time.
 ///
-/// This type implements `IntoIterator` (it is **not** an iterator
+/// This type implements [`IntoIterator`] (it is **not** an iterator
 /// itself), because the group iterators need to borrow from this
 /// value. It should be stored in a local variable or temporary and
 /// iterated.
@@ -453,7 +453,7 @@ pub fn new_chunks<J>(iter: J, size: usize) -> IntoChunks<J::IntoIter>
 /// `IntoChunks` behaves just like `GroupBy`: it is iterable, and
 /// it only buffers if several chunk iterators are alive at the same time.
 ///
-/// This type implements `IntoIterator` (it is **not** an iterator
+/// This type implements [`IntoIterator`] (it is **not** an iterator
 /// itself), because the chunk iterators need to borrow from this
 /// value. It should be stored in a local variable or temporary and
 /// iterated.

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -7,7 +7,7 @@ use std::hash::Hash;
 use std::iter::Iterator;
 use std::ops::{Add, Mul};
 
-/// A wrapper to allow for an easy [`into_grouping_map_by`](../trait.Itertools.html#method.into_grouping_map_by)
+/// A wrapper to allow for an easy [`into_grouping_map_by`](crate::Itertools::into_grouping_map_by)
 #[derive(Clone, Debug)]
 pub struct MapForGrouping<I, F>(I, F);
 
@@ -38,7 +38,7 @@ pub fn new<I, K, V>(iter: I) -> GroupingMap<I>
 
 /// `GroupingMapBy` is an intermediate struct for efficient group-and-fold operations.
 /// 
-/// See [`GroupingMap`](./struct.GroupingMap.html) for more informations.
+/// See [`GroupingMap`] for more informations.
 #[must_use = "GroupingMapBy is lazy and do nothing unless consumed"]
 pub type GroupingMapBy<I, F> = GroupingMap<MapForGrouping<I, F>>;
 
@@ -377,7 +377,7 @@ impl<I, K, V> GroupingMap<I>
     /// If several elements are equally maximum, the last element is picked.
     /// If several elements are equally minimum, the first element is picked.
     /// 
-    /// See [.minmax()](../trait.Itertools.html#method.minmax) for the non-grouping version.
+    /// See [.minmax()](crate::Itertools::minmax) for the non-grouping version.
     /// 
     /// Differences from the non grouping version:
     /// - It never produces a `MinMaxResult::NoElements`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3371,7 +3371,7 @@ impl<T: ?Sized> Itertools for T where T: Iterator { }
 /// `false` otherwise.
 ///
 /// This is an [`IntoIterator`] enabled function that is similar to the standard
-/// library method `Iterator::eq`.
+/// library method [`Iterator::eq`].
 ///
 /// ```
 /// assert!(itertools::equal(vec![1, 2, 3], 1..4));
@@ -3396,7 +3396,7 @@ pub fn equal<I, J>(a: I, b: J) -> bool
 }
 
 /// Assert that two iterables produce equal sequences, with the same
-/// semantics as *equal(a, b)*.
+/// semantics as [`equal(a, b)`](equal).
 ///
 /// **Panics** on assertion failure with a message that shows the
 /// two iteration elements.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,23 +354,20 @@ macro_rules! izip {
 /// The comma-separated arguments must implement [`IntoIterator`].
 /// The final argument may be followed by a trailing comma.
 ///
-/// [`chain`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.chain
-/// [`IntoIterator`]: https://doc.rust-lang.org/std/iter/trait.IntoIterator.html
+/// [`chain`]: Iterator::chain
 ///
 /// # Examples
 ///
-/// [`iter::empty`]: https://doc.rust-lang.org/std/iter/fn.empty.html
-///
-/// Empty invocations of `chain!` expand to an invocation of [`iter::empty`]:
+/// Empty invocations of `chain!` expand to an invocation of [`std::iter::empty`]:
 /// ```
-/// # use std::iter;
+/// use std::iter;
 /// use itertools::chain;
 ///
 /// let _: iter::Empty<()> = chain!();
 /// let _: iter::Empty<i8> = chain!();
 /// ```
 ///
-/// Invocations of `chain!` with one argument expand to [`arg.into_iter()`][`IntoIterator`]:
+/// Invocations of `chain!` with one argument expand to [`arg.into_iter()`](IntoIterator):
 /// ```
 /// use std::{ops::Range, slice};
 /// use itertools::chain;
@@ -378,7 +375,7 @@ macro_rules! izip {
 /// let _:     <&[_] as IntoIterator>::IntoIter = chain!(&[2, 3, 4]);
 /// ```
 ///
-/// Invocations of `chain!` with multiple arguments [`.into_iter()`][`IntoIterator`] each
+/// Invocations of `chain!` with multiple arguments [`.into_iter()`](IntoIterator) each
 /// argument, and then [`chain`] them together:
 /// ```
 /// use std::{iter::*, ops::Range, slice};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! Extra iterator adaptors, functions and macros.
 //!
 //! To extend [`Iterator`] with methods in this crate, import
-//! the [`Itertools` trait](Itertools):
+//! the [`Itertools`] trait:
 //!
 //! ```
 //! use itertools::Itertools;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,11 +421,11 @@ macro_rules! chain {
 ///
 /// * *Adaptors* take an iterator and parameter as input, and return
 /// a new iterator value. These are listed first in the trait. An example
-/// of an adaptor is [`.interleave()`](#method.interleave)
+/// of an adaptor is [`.interleave()`](Itertools::interleave)
 ///
 /// * *Regular methods* are those that don't return iterators and instead
 /// return a regular value of some other kind.
-/// [`.next_tuple()`](#method.next_tuple) is an example and the first regular
+/// [`.next_tuple()`](Itertools::next_tuple) is an example and the first regular
 /// method in the list.
 pub trait Itertools : Iterator {
     // adaptors
@@ -740,7 +740,7 @@ pub trait Itertools : Iterator {
     /// Return an iterator that groups the items in tuples of a specific size
     /// (up to 4).
     ///
-    /// See also the method [`.next_tuple()`](#method.next_tuple).
+    /// See also the method [`.next_tuple()`](Itertools::next_tuple).
     ///
     /// ```
     /// use itertools::Itertools;
@@ -838,7 +838,7 @@ pub trait Itertools : Iterator {
         adaptors::map_into(self)
     }
 
-    /// See [`.map_ok()`](#method.map_ok).
+    /// See [`.map_ok()`](Itertools::map_ok).
     #[deprecated(note="Use .map_ok() instead", since="0.10.0")]
     fn map_results<F, T, U, E>(self, f: F) -> MapOk<Self, F>
         where Self: Iterator<Item = Result<T, E>> + Sized,
@@ -1354,7 +1354,7 @@ pub trait Itertools : Iterator {
     /// `peeking_take_while` is done.
     ///
     ///
-    /// See also [`.take_while_ref()`](#method.take_while_ref)
+    /// See also [`.take_while_ref()`](Itertools::take_while_ref)
     /// which is a similar adaptor.
     fn peeking_take_while<F>(&mut self, accept: F) -> PeekingTakeWhile<Self, F>
         where Self: Sized + PeekingNext,
@@ -2094,7 +2094,7 @@ pub trait Itertools : Iterator {
         format::new_format(self, sep, format)
     }
 
-    /// See [`.fold_ok()`](#method.fold_ok).
+    /// See [`.fold_ok()`](Itertools::fold_ok).
     #[deprecated(note="Use .fold_ok() instead", since="0.10.0")]
     fn fold_results<A, E, B, F>(&mut self, start: B, f: F) -> Result<B, E>
         where Self: Iterator<Item = Result<A, E>>,
@@ -2794,7 +2794,7 @@ pub trait Itertools : Iterator {
     /// value of type `K` will be used as key to identify the groups and the
     /// value of type `V` as value for the folding operation.
     /// 
-    /// See [`GroupingMap`](./structs/struct.GroupingMap.html) for more informations
+    /// See [`GroupingMap`] for more informations
     /// on what operations are available.
     #[cfg(feature = "use_std")]
     fn into_grouping_map<K, V>(self) -> GroupingMap<Self>
@@ -2810,7 +2810,7 @@ pub trait Itertools : Iterator {
     /// The values from this iterator will be used as values for the folding operation
     /// while the keys will be obtained from the values by calling `key_mapper`.
     /// 
-    /// See [`GroupingMap`](./structs/struct.GroupingMap.html) for more informations
+    /// See [`GroupingMap`] for more informations
     /// on what operations are available.
     #[cfg(feature = "use_std")]
     fn into_grouping_map_by<K, V, F>(self, key_mapper: F) -> GroupingMapBy<Self, F>
@@ -3471,9 +3471,9 @@ pub fn partition<'a, A: 'a, I, F>(iter: I, mut pred: F) -> usize
     split_index
 }
 
-/// An enum used for controlling the execution of `.fold_while()`.
+/// An enum used for controlling the execution of `fold_while`.
 ///
-/// See [`.fold_while()`](crate::Itertools::fold_while) for more information.
+/// See [`.fold_while()`](Itertools::fold_while) for more information.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum FoldWhile<T> {
     /// Continue folding with this value

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -948,7 +948,7 @@ pub trait Itertools : Iterator {
     }
 
     /// Return an iterator adaptor that merges the two base iterators in order.
-    /// This is much like `.merge()` but allows for a custom ordering.
+    /// This is much like [`.merge()`](Itertools::merge) but allows for a custom ordering.
     ///
     /// This can be especially useful for sequences of tuples.
     ///
@@ -1935,7 +1935,7 @@ pub trait Itertools : Iterator {
         concat(self)
     }
 
-    /// `.collect_vec()` is simply a type specialization of `.collect()`,
+    /// `.collect_vec()` is simply a type specialization of [`Iterator::collect`],
     /// for convenience.
     #[cfg(feature = "use_alloc")]
     fn collect_vec(self) -> Vec<Self::Item>
@@ -2057,7 +2057,7 @@ pub trait Itertools : Iterator {
 
     /// Format all iterator elements, separated by `sep`.
     ///
-    /// This is a customizable version of `.format()`.
+    /// This is a customizable version of [`.format()`](Itertools::format).
     ///
     /// The supplied closure `format` is called once per iterator element,
     /// with two arguments: the element and a callback that takes a
@@ -2164,7 +2164,7 @@ pub trait Itertools : Iterator {
     /// value is returned inside `Some`. Otherwise, the operation terminates
     /// and returns `None`. No iterator elements are consumed after the `None`.
     ///
-    /// This is the `Option` equivalent to `fold_ok`.
+    /// This is the `Option` equivalent to [`fold_ok`](Itertools::fold_ok).
     ///
     /// ```
     /// use std::ops::Add;
@@ -2318,7 +2318,7 @@ pub trait Itertools : Iterator {
 
     /// An iterator method that applies a function, producing a single, final value.
     ///
-    /// `fold_while()` is basically equivalent to `fold()` but with additional support for
+    /// `fold_while()` is basically equivalent to [`Iterator::fold`] but with additional support for
     /// early exit via short-circuiting.
     ///
     /// ```
@@ -2437,7 +2437,7 @@ pub trait Itertools : Iterator {
     /// Sort all iterator elements into a new iterator in ascending order.
     ///
     /// **Note:** This consumes the entire iterator, uses the
-    /// `slice::sort_unstable()` method and returns the result as a new
+    /// [`slice::sort_unstable`] method and returns the result as a new
     /// iterator that owns its elements.
     ///
     /// The sorted iterator, if directly collected to a `Vec`, is converted
@@ -2466,7 +2466,7 @@ pub trait Itertools : Iterator {
     /// Sort all iterator elements into a new iterator in ascending order.
     ///
     /// **Note:** This consumes the entire iterator, uses the
-    /// `slice::sort_unstable_by()` method and returns the result as a new
+    /// [`slice::sort_unstable_by`] method and returns the result as a new
     /// iterator that owns its elements.
     ///
     /// The sorted iterator, if directly collected to a `Vec`, is converted
@@ -2499,7 +2499,7 @@ pub trait Itertools : Iterator {
     /// Sort all iterator elements into a new iterator in ascending order.
     ///
     /// **Note:** This consumes the entire iterator, uses the
-    /// `slice::sort_unstable_by_key()` method and returns the result as a new
+    /// [`slice::sort_unstable_by_key`] method and returns the result as a new
     /// iterator that owns its elements.
     ///
     /// The sorted iterator, if directly collected to a `Vec`, is converted
@@ -2533,7 +2533,7 @@ pub trait Itertools : Iterator {
     /// Sort all iterator elements into a new iterator in ascending order.
     ///
     /// **Note:** This consumes the entire iterator, uses the
-    /// `slice::sort()` method and returns the result as a new
+    /// [`slice::sort`] method and returns the result as a new
     /// iterator that owns its elements.
     ///
     /// The sorted iterator, if directly collected to a `Vec`, is converted
@@ -2562,7 +2562,7 @@ pub trait Itertools : Iterator {
     /// Sort all iterator elements into a new iterator in ascending order.
     ///
     /// **Note:** This consumes the entire iterator, uses the
-    /// `slice::sort_by()` method and returns the result as a new
+    /// [`slice::sort_by`] method and returns the result as a new
     /// iterator that owns its elements.
     ///
     /// The sorted iterator, if directly collected to a `Vec`, is converted
@@ -2595,7 +2595,7 @@ pub trait Itertools : Iterator {
     /// Sort all iterator elements into a new iterator in ascending order.
     ///
     /// **Note:** This consumes the entire iterator, uses the
-    /// `slice::sort_by_key()` method and returns the result as a new
+    /// [`slice::sort_by_key`] method and returns the result as a new
     /// iterator that owns its elements.
     ///
     /// The sorted iterator, if directly collected to a `Vec`, is converted
@@ -2664,7 +2664,7 @@ pub trait Itertools : Iterator {
     }
 
     /// Collect all iterator elements into one of two
-    /// partitions. Unlike `Iterator::partition`, each partition may
+    /// partitions. Unlike [`Iterator::partition`], each partition may
     /// have a distinct type.
     ///
     /// ```
@@ -2865,11 +2865,11 @@ pub trait Itertools : Iterator {
     /// Return the minimum and maximum element of an iterator, as determined by
     /// the specified function.
     ///
-    /// The return value is a variant of [`MinMaxResult`] like for `minmax()`.
+    /// The return value is a variant of [`MinMaxResult`] like for [`.minmax()`](Itertools::minmax).
     ///
     /// For the minimum, the first minimal element is returned.  For the maximum,
     /// the last maximal element wins.  This matches the behavior of the standard
-    /// `Iterator::min()` and `Iterator::max()` methods.
+    /// [`Iterator::min`] and [`Iterator::max`] methods.
     ///
     /// The keys can be floats but no particular result is guaranteed
     /// if a key is NaN.
@@ -2882,11 +2882,11 @@ pub trait Itertools : Iterator {
     /// Return the minimum and maximum element of an iterator, as determined by
     /// the specified comparison function.
     ///
-    /// The return value is a variant of [`MinMaxResult`] like for `minmax()`.
+    /// The return value is a variant of [`MinMaxResult`] like for [`.minmax()`](Itertools::minmax).
     ///
     /// For the minimum, the first minimal element is returned.  For the maximum,
     /// the last maximal element wins.  This matches the behavior of the standard
-    /// `Iterator::min()` and `Iterator::max()` methods.
+    /// [`Iterator::min`] and [`Iterator::max`] methods.
     fn minmax_by<F>(self, mut compare: F) -> MinMaxResult<Self::Item>
         where Self: Sized, F: FnMut(&Self::Item, &Self::Item) -> Ordering
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -595,7 +595,7 @@ pub trait Itertools : Iterator {
     /// allocations.  It needs allocations only if several group iterators
     /// are alive at the same time.
     ///
-    /// This type implements `IntoIterator` (it is **not** an iterator
+    /// This type implements [`IntoIterator`] (it is **not** an iterator
     /// itself), because the group iterators need to borrow from this
     /// value. It should be stored in a local variable or temporary and
     /// iterated.
@@ -824,7 +824,7 @@ pub trait Itertools : Iterator {
         adaptors::step(self, n)
     }
 
-    /// Convert each item of the iterator using the `Into` trait.
+    /// Convert each item of the iterator using the [`Into`] trait.
     ///
     /// ```rust
     /// use itertools::Itertools;
@@ -1915,7 +1915,7 @@ pub trait Itertools : Iterator {
         self.for_each(f)
     }
 
-    /// Combine all an iterator's elements into one element by using `Extend`.
+    /// Combine all an iterator's elements into one element by using [`Extend`].
     ///
     /// This combinator will extend the first item with each of the rest of the
     /// items of the iterator. If the iterator is empty, the default value of
@@ -2865,7 +2865,7 @@ pub trait Itertools : Iterator {
     /// Return the minimum and maximum element of an iterator, as determined by
     /// the specified function.
     ///
-    /// The return value is a variant of `MinMaxResult` like for `minmax()`.
+    /// The return value is a variant of [`MinMaxResult`] like for `minmax()`.
     ///
     /// For the minimum, the first minimal element is returned.  For the maximum,
     /// the last maximal element wins.  This matches the behavior of the standard
@@ -2882,7 +2882,7 @@ pub trait Itertools : Iterator {
     /// Return the minimum and maximum element of an iterator, as determined by
     /// the specified comparison function.
     ///
-    /// The return value is a variant of `MinMaxResult` like for `minmax()`.
+    /// The return value is a variant of [`MinMaxResult`] like for `minmax()`.
     ///
     /// For the minimum, the first minimal element is returned.  For the maximum,
     /// the last maximal element wins.  This matches the behavior of the standard
@@ -3370,7 +3370,7 @@ impl<T: ?Sized> Itertools for T where T: Iterator { }
 /// (elements pairwise equal and sequences of the same length),
 /// `false` otherwise.
 ///
-/// This is an `IntoIterator` enabled function that is similar to the standard
+/// This is an [`IntoIterator`] enabled function that is similar to the standard
 /// library method `Iterator::eq`.
 ///
 /// ```

--- a/src/minmax.rs
+++ b/src/minmax.rs
@@ -1,6 +1,7 @@
 
-/// `MinMaxResult` is an enum returned by `minmax`. See `Itertools::minmax()` for
-/// more detail.
+/// `MinMaxResult` is an enum returned by `minmax`.
+///
+/// See [`.minmax()`](crate::Itertools::minmax) for more detail.
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum MinMaxResult<T> {
     /// Empty iterator

--- a/src/peek_nth.rs
+++ b/src/peek_nth.rs
@@ -13,7 +13,7 @@ where
     buf: VecDeque<I::Item>,
 }
 
-/// A drop-in replacement for `std::iter::Peekable` which adds a `peek_nth`
+/// A drop-in replacement for [`std::iter::Peekable`] which adds a `peek_nth`
 /// method allowing the user to `peek` at a value several iterations forward
 /// without advancing the base iterator.
 ///

--- a/src/powerset.rs
+++ b/src/powerset.rs
@@ -7,7 +7,7 @@ use super::size_hint;
 
 /// An iterator to iterate through the powerset of the elements from an iterator.
 ///
-/// See [`.powerset()`](../trait.Itertools.html#method.powerset) for more
+/// See [`.powerset()`](crate::Itertools::powerset) for more
 /// information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Powerset<I: Iterator> {

--- a/src/process_results_impl.rs
+++ b/src/process_results_impl.rs
@@ -2,7 +2,7 @@
 /// An iterator that produces only the `T` values as long as the
 /// inner iterator produces `Ok(T)`.
 ///
-/// Used by [`process_results`](../fn.process_results.html), see its docs
+/// Used by [`process_results`](crate::process_results), see its docs
 /// for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug)]

--- a/src/repeatn.rs
+++ b/src/repeatn.rs
@@ -1,7 +1,7 @@
 
 /// An iterator that produces *n* repetitions of an element.
 ///
-/// See [`repeat_n()`](../fn.repeat_n.html) for more information.
+/// See [`repeat_n()`](crate::repeat_n) for more information.
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Clone, Debug)]
 pub struct RepeatN<A> {

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -5,7 +5,7 @@
 use std::fmt;
 use std::mem;
 
-/// See [`repeat_call`](../fn.repeat_call.html) for more information.
+/// See [`repeat_call`](crate::repeat_call) for more information.
 #[derive(Clone)]
 #[deprecated(note="Use std repeat_with() instead", since="0.8.0")]
 pub struct RepeatCall<F> {
@@ -112,7 +112,7 @@ impl<St, F> fmt::Debug for Unfold<St, F>
     debug_fmt_fields!(Unfold, state);
 }
 
-/// See [`unfold`](../fn.unfold.html) for more information.
+/// See [`unfold`](crate::unfold) for more information.
 #[derive(Clone)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct Unfold<St, F> {
@@ -134,9 +134,8 @@ impl<A, St, F> Iterator for Unfold<St, F>
 
 /// An iterator that infinitely applies function to value and yields results.
 ///
-/// This `struct` is created by the [`iterate()`] function. See its documentation for more.
-///
-/// [`iterate()`]: ../fn.iterate.html
+/// This `struct` is created by the [`iterate()`](crate::iterate) function.
+/// See its documentation for more.
 #[derive(Clone)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct Iterate<St, F> {

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -67,7 +67,7 @@ impl<A, F> Iterator for RepeatCall<F>
 /// `unfold` is a general iterator builder: it has a mutable state value,
 /// and a closure with access to the state that produces the next value.
 ///
-/// This more or less equivalent to a regular struct with an `Iterator`
+/// This more or less equivalent to a regular struct with an [`Iterator`]
 /// implementation, and is useful for one-off iterators.
 ///
 /// ```

--- a/src/zip_eq_impl.rs
+++ b/src/zip_eq_impl.rs
@@ -14,7 +14,7 @@ pub struct ZipEq<I, J> {
 ///
 /// **Panics** if the iterators are not of the same length.
 ///
-/// `IntoIterator` enabled version of `i.zip_eq(j)`.
+/// [`IntoIterator`] enabled version of `i.zip_eq(j)`.
 ///
 /// ```
 /// use itertools::zip_eq;

--- a/src/zip_eq_impl.rs
+++ b/src/zip_eq_impl.rs
@@ -14,7 +14,7 @@ pub struct ZipEq<I, J> {
 ///
 /// **Panics** if the iterators are not of the same length.
 ///
-/// [`IntoIterator`] enabled version of `i.zip_eq(j)`.
+/// [`IntoIterator`] enabled version of [`Itertools::zip_eq`](crate::Itertools::zip_eq).
 ///
 /// ```
 /// use itertools::zip_eq;

--- a/src/ziptuple.rs
+++ b/src/ziptuple.rs
@@ -10,7 +10,7 @@ pub struct Zip<T> {
 /// An iterator that generalizes *.zip()* and allows running multiple iterators in lockstep.
 ///
 /// The iterator `Zip<(I, J, ..., M)>` is formed from a tuple of iterators (or values that
-/// implement `IntoIterator`) and yields elements
+/// implement [`IntoIterator`]) and yields elements
 /// until any of the subiterators yields `None`.
 ///
 /// The iterator element type is a tuple like like `(A, B, ..., E)` where `A` to `E` are the


### PR DESCRIPTION
A few changes to make documenting code with links simpler and more uniform.

Highlights:

- Make some common stdlib traits into links, e.g. `IntoIterator`
- Add links to docs for free functions
- Use module paths uniformly in links (instead of html paths)
- Link to `slice::sort*` methods in docs for sorting functions