### PR TITLE
feat: remove unneeded trait bound

### DIFF
--- a/benches/tuple_combinations.rs
+++ b/benches/tuple_combinations.rs
@@ -99,6 +99,51 @@ fn tuple_comb_c4(c: &mut Criterion) {
     });
 }
 
+
+fn array_comb_c1(c: &mut Criterion) {
+    c.bench_function("array comb c1", move |b| {
+        b.iter(|| {
+            for [i] in (0..N1).array_combinations() {
+                black_box(i);
+            }
+        })
+    });
+}
+
+
+fn array_comb_c2(c: &mut Criterion) {
+    c.bench_function("array comb c2", move |b| {
+        b.iter(|| {
+            for [i, j] in (0..N2).array_combinations() {
+                black_box(i + j);
+            }
+        })
+    });
+}
+
+
+fn array_comb_c3(c: &mut Criterion) {
+    c.bench_function("array comb c3", move |b| {
+        b.iter(|| {
+            for [i, j, k] in (0..N3).array_combinations() {
+                black_box(i + j + k);
+            }
+        })
+    });
+}
+
+
+fn array_comb_c4(c: &mut Criterion) {
+    c.bench_function("array comb c4", move |b| {
+        b.iter(|| {
+            for [i, j, k, l] in (0..N4).array_combinations() {
+                black_box(i + j + k + l);
+            }
+        })
+    });
+}
+
+
 criterion_group!(
     benches,
     tuple_comb_for1,
@@ -109,5 +154,10 @@ criterion_group!(
     tuple_comb_c2,
     tuple_comb_c3,
     tuple_comb_c4,
+    array_comb_c1,
+    array_comb_c2,
+    array_comb_c3,
+    array_comb_c4,
 );
+
 criterion_main!(benches);

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -690,7 +690,7 @@ pub trait HasCombination<I>: Sized {
 
 /// Create a new `TupleCombinations` from a clonable iterator.
 pub fn tuple_combinations<T, I>(iter: I) -> TupleCombinations<I, T>
-    where I: Iterator + Clone,
+    where I: Iterator,
           I::Item: Clone,
           T: HasCombination<I>,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1442,7 +1442,7 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![(1, 2, 3), (1, 2, 4), (1, 3, 4), (2, 3, 4)]);
     /// ```
     fn tuple_combinations<T>(self) -> TupleCombinations<Self, T>
-        where Self: Sized + Clone,
+        where Self: Sized,
               Self::Item: Clone,
               T: adaptors::HasCombination<Self>,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ pub mod structs {
         WhileSome,
         Coalesce,
         TupleCombinations,
+        ArrayCombinations,
         Positions,
         Update,
     };
@@ -1447,6 +1448,13 @@ pub trait Itertools : Iterator {
               T: adaptors::HasCombination<Self>,
     {
         adaptors::tuple_combinations(self)
+    }
+
+    fn array_combinations<const R: usize>(self) -> ArrayCombinations<Self::Item, R>
+        where Self: Sized,
+              Self::Item: Clone + std::fmt::Debug,
+    {
+        ArrayCombinations::new(self.collect())
     }
 
     /// Return an iterator adaptor that iterates over the `k`-length combinations of

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -896,6 +896,26 @@ quickcheck! {
 }
 
 quickcheck! {
+    fn equal_combinations_array(it: Iter<i16>) -> bool {
+        let values = it.clone().collect_vec();
+        if values.len() < 2 {
+            return true;
+        }
+
+        let mut cmb = it.array_combinations();
+        for i in 0..values.len() {
+            for j in i+1..values.len() {
+                let pair = [values[i], values[j]];
+                if pair != cmb.next().unwrap() {
+                    return false;
+                }
+            }
+        }
+        cmb.next() == None
+    }
+}
+
+quickcheck! {
     fn size_pad_tail(it: Iter<i8>, pad: u8) -> bool {
         correct_size_hint(it.clone().pad_using(pad as usize, |_| 0)) &&
             correct_size_hint(it.dropping(1).rev().pad_using(pad as usize, |_| 0))


### PR DESCRIPTION
tuple_combinations has an unnecessary trait bound.

This blocks certain iterators being able to use the extension. For instance, `Drain` does not implement Clone, since it takes a mutable reference of the Vec.