### PR TITLE
Array combinations

### DIFF
--- a/benches/tuple_combinations.rs
+++ b/benches/tuple_combinations.rs
@@ -99,6 +99,51 @@ fn tuple_comb_c4(c: &mut Criterion) {
     });
 }
 
+
+fn array_comb_c1(c: &mut Criterion) {
+    c.bench_function("array comb c1", move |b| {
+        b.iter(|| {
+            for [i] in (0..N1).array_combinations() {
+                black_box(i);
+            }
+        })
+    });
+}
+
+
+fn array_comb_c2(c: &mut Criterion) {
+    c.bench_function("array comb c2", move |b| {
+        b.iter(|| {
+            for [i, j] in (0..N2).array_combinations() {
+                black_box(i + j);
+            }
+        })
+    });
+}
+
+
+fn array_comb_c3(c: &mut Criterion) {
+    c.bench_function("array comb c3", move |b| {
+        b.iter(|| {
+            for [i, j, k] in (0..N3).array_combinations() {
+                black_box(i + j + k);
+            }
+        })
+    });
+}
+
+
+fn array_comb_c4(c: &mut Criterion) {
+    c.bench_function("array comb c4", move |b| {
+        b.iter(|| {
+            for [i, j, k, l] in (0..N4).array_combinations() {
+                black_box(i + j + k + l);
+            }
+        })
+    });
+}
+
+
 criterion_group!(
     benches,
     tuple_comb_for1,
@@ -109,5 +154,10 @@ criterion_group!(
     tuple_comb_c2,
     tuple_comb_c3,
     tuple_comb_c4,
+    array_comb_c1,
+    array_comb_c2,
+    array_comb_c3,
+    array_comb_c4,
 );
+
 criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ pub mod structs {
         WhileSome,
         Coalesce,
         TupleCombinations,
+        ArrayCombinations,
         Positions,
         Update,
     };
@@ -1447,6 +1448,13 @@ pub trait Itertools : Iterator {
               T: adaptors::HasCombination<Self>,
     {
         adaptors::tuple_combinations(self)
+    }
+
+    fn array_combinations<const R: usize>(self) -> ArrayCombinations<Self::Item, R>
+        where Self: Sized,
+              Self::Item: Clone + std::fmt::Debug,
+    {
+        ArrayCombinations::new(self.collect())
     }
 
     /// Return an iterator adaptor that iterates over the `k`-length combinations of

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -896,6 +896,26 @@ quickcheck! {
 }
 
 quickcheck! {
+    fn equal_combinations_array(it: Iter<i16>) -> bool {
+        let values = it.clone().collect_vec();
+        if values.len() < 2 {
+            return true;
+        }
+
+        let mut cmb = it.array_combinations();
+        for i in 0..values.len() {
+            for j in i+1..values.len() {
+                let pair = [values[i], values[j]];
+                if pair != cmb.next().unwrap() {
+                    return false;
+                }
+            }
+        }
+        cmb.next() == None
+    }
+}
+
+quickcheck! {
     fn size_pad_tail(it: Iter<i8>, pad: u8) -> bool {
         correct_size_hint(it.clone().pad_using(pad as usize, |_| 0)) &&
             correct_size_hint(it.dropping(1).rev().pad_using(pad as usize, |_| 0))


### PR DESCRIPTION
An alternative to `TupleCombinations` that works in a similar fashion to the standard `Combinations` iterator. It's implemented using const generics and manages to work for >12 elements too.

I doubt I'll be able to get merged as is. Since this uses const generics, it would need to either be feature gated or we raise the MSRV from 1.32 all the way to 1.51

Benchmark results:
```
tuple comb for1         time:   [23.681 us 23.714 us 23.757 us]
tuple comb for2         time:   [27.554 us 27.584 us 27.617 us]
tuple comb for3         time:   [67.963 us 68.138 us 68.343 us]
tuple comb for4         time:   [60.098 us 60.182 us 60.280 us]

tuple comb c1           time:   [24.335 us 24.357 us 24.383 us]
tuple comb c2           time:   [43.833 us 43.876 us 43.924 us]
tuple comb c3           time:   [282.67 us 282.98 us 283.31 us]
tuple comb c4           time:   [1.2475 ms 1.2496 ms 1.2525 ms]

array comb c1           time:   [64.303 us 64.325 us 64.349 us]
array comb c2           time:   [201.38 us 201.49 us 201.61 us]
array comb c3           time:   [120.58 us 120.96 us 121.41 us]
array comb c4           time:   [176.37 us 176.58 us 176.79 us]
```

Interesting notes: c1 and c2 for this version are much higher than I would have expected but c3 and c4 are much lower than the tuple alternatives 