### PR TITLE
Add FusedIterator for which it is commented fused.

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -15,7 +15,7 @@ pub use self::map::MapResults;
 pub use self::multi_product::*;
 
 use std::fmt;
-use std::iter::{Fuse, Peekable, FromIterator};
+use std::iter::{Fuse, Peekable, FromIterator, FusedIterator};
 use std::marker::PhantomData;
 use crate::size_hint;
 
@@ -74,6 +74,11 @@ impl<I, J> Iterator for Interleave<I, J>
         size_hint::add(self.a.size_hint(), self.b.size_hint())
     }
 }
+
+impl<I, J> FusedIterator for Interleave<I, J>
+    where I: Iterator,
+          J: Iterator<Item = I::Item>
+{}
 
 /// An iterator adaptor that alternates elements from the two iterators until
 /// one of them runs out.

--- a/src/intersperse.rs
+++ b/src/intersperse.rs
@@ -1,4 +1,4 @@
-use std::iter::Fuse;
+use std::iter::{Fuse, FusedIterator};
 use super::size_hint;
 
 pub trait IntersperseElement<Item> {
@@ -112,3 +112,8 @@ impl<I, ElemF> Iterator for IntersperseWith<I, ElemF>
         })
     }
 }
+
+impl<I, ElemF> FusedIterator for IntersperseWith<I, ElemF>
+    where I: Iterator,
+          ElemF: IntersperseElement<I::Item>
+{}

--- a/src/zip_longest.rs
+++ b/src/zip_longest.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering::{Equal, Greater, Less};
 use super::size_hint;
-use std::iter::Fuse;
+use std::iter::{Fuse, FusedIterator};
 
 use crate::either_or_both::EitherOrBoth;
 
@@ -75,4 +75,9 @@ impl<T, U> DoubleEndedIterator for ZipLongest<T, U>
 impl<T, U> ExactSizeIterator for ZipLongest<T, U>
     where T: ExactSizeIterator,
           U: ExactSizeIterator
+{}
+
+impl<T, U> FusedIterator for ZipLongest<T, U>
+    where T: Iterator,
+          U: Iterator
 {}


### PR DESCRIPTION
`Interleave`, `IntersperseWith`, and `ZipLongest` are said to be fused in doc comment, but it wasn't marked as `FusedIterator`.