### PR TITLE
Add More FusedIterator

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -728,6 +728,11 @@ impl<I, T> Iterator for TupleCombinations<I, T>
     }
 }
 
+impl<I, T> FusedIterator for TupleCombinations<I, T>
+    where I: FusedIterator,
+          T: HasCombination<I>,
+{}
+
 #[derive(Clone, Debug)]
 pub struct Tuple1Combination<I> {
     iter: I,

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::iter::FusedIterator;
 
 use super::lazy_buffer::LazyBuffer;
 use alloc::vec::Vec;
@@ -122,3 +123,8 @@ impl<I> Iterator for Combinations<I>
         Some(self.indices.iter().map(|i| self.pool[*i].clone()).collect())
     }
 }
+
+impl<I> FusedIterator for Combinations<I>
+    where I: Iterator,
+          I::Item: Clone
+{}

--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -1,5 +1,6 @@
 use alloc::vec::Vec;
 use std::fmt;
+use std::iter::FusedIterator;
 
 use super::lazy_buffer::LazyBuffer;
 
@@ -100,3 +101,9 @@ where
         }
     }
 }
+
+impl<I> FusedIterator for CombinationsWithReplacement<I>
+where
+    I: Iterator,
+    I::Item: Clone,
+{}

--- a/src/kmerge_impl.rs
+++ b/src/kmerge_impl.rs
@@ -2,6 +2,7 @@ use crate::size_hint;
 use crate::Itertools;
 
 use alloc::vec::Vec;
+use std::iter::FusedIterator;
 use std::mem::replace;
 use std::fmt;
 
@@ -219,3 +220,8 @@ impl<I, F> Iterator for KMergeBy<I, F>
                  .unwrap_or((0, Some(0)))
     }
 }
+
+impl<I, F> FusedIterator for KMergeBy<I, F>
+    where I: Iterator,
+          F: KMergePredicate<I::Item>
+{}

--- a/src/pad_tail.rs
+++ b/src/pad_tail.rs
@@ -1,4 +1,4 @@
-use std::iter::Fuse;
+use std::iter::{Fuse, FusedIterator};
 use crate::size_hint;
 
 /// An iterator adaptor that pads a sequence to a minimum length by filling
@@ -79,5 +79,11 @@ impl<I, F> DoubleEndedIterator for PadUsing<I, F>
 
 impl<I, F> ExactSizeIterator for PadUsing<I, F>
     where I: ExactSizeIterator,
+          F: FnMut(usize) -> I::Item
+{}
+
+
+impl<I, F> FusedIterator for PadUsing<I, F>
+    where I: FusedIterator,
           F: FnMut(usize) -> I::Item
 {}

--- a/src/powerset.rs
+++ b/src/powerset.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::iter::FusedIterator;
 use std::usize;
 use alloc::vec::Vec;
 
@@ -81,3 +82,9 @@ impl<I> Iterator for Powerset<I>
         }
     }
 }
+
+impl<I> FusedIterator for Powerset<I>
+    where
+        I: Iterator,
+        I::Item: Clone,
+{}

--- a/src/rciter_impl.rs
+++ b/src/rciter_impl.rs
@@ -1,5 +1,5 @@
 
-use std::iter::IntoIterator;
+use std::iter::{FusedIterator, IntoIterator};
 use alloc::rc::Rc;
 use std::cell::RefCell;
 
@@ -93,3 +93,8 @@ impl<'a, I> IntoIterator for &'a RcIter<I>
         self.clone()
     }
 }
+
+
+impl<A, I> FusedIterator for RcIter<I>
+    where I: FusedIterator<Item = A>
+{}

--- a/src/repeatn.rs
+++ b/src/repeatn.rs
@@ -1,3 +1,4 @@
+use std::iter::FusedIterator;
 
 /// An iterator that produces *n* repetitions of an element.
 ///
@@ -50,5 +51,9 @@ impl<A> DoubleEndedIterator for RepeatN<A>
 }
 
 impl<A> ExactSizeIterator for RepeatN<A>
+    where A: Clone
+{}
+
+impl<A> FusedIterator for RepeatN<A>
     where A: Clone
 {}

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -1,6 +1,7 @@
 //! Some iterator that produces tuples
 
 use std::iter::Fuse;
+use std::iter::FusedIterator;
 use std::iter::Take;
 use std::iter::Cycle;
 use std::marker::PhantomData;
@@ -186,6 +187,12 @@ impl<I, T> Iterator for TupleWindows<I, T>
         None
     }
 }
+
+impl<I, T> FusedIterator for TupleWindows<I, T>
+    where I: FusedIterator<Item = T::Item>,
+          T: HomogeneousTuple + Clone,
+          T::Item: Clone
+{}
 
 /// An iterator over all windows,wrapping back to the first elements when the
 /// window would otherwise exceed the length of the iterator, producing tuples

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::collections::hash_map::{Entry};
 use std::hash::Hash;
 use std::fmt;
+use std::iter::FusedIterator;
 
 /// An iterator adapter to filter out duplicate elements.
 ///
@@ -92,6 +93,12 @@ impl<I, V, F> DoubleEndedIterator for UniqueBy<I, V, F>
     }
 }
 
+impl<I, V, F> FusedIterator for UniqueBy<I, V, F>
+    where I: FusedIterator,
+          V: Eq + Hash,
+          F: FnMut(&I::Item) -> V
+{}
+
 impl<I> Iterator for Unique<I>
     where I: Iterator,
           I::Item: Eq + Hash + Clone
@@ -135,6 +142,11 @@ impl<I> DoubleEndedIterator for Unique<I>
         None
     }
 }
+
+impl<I> FusedIterator for Unique<I>
+    where I: FusedIterator,
+          I::Item: Eq + Hash + Clone
+{}
 
 /// An iterator adapter to filter out duplicate elements.
 ///

--- a/src/with_position.rs
+++ b/src/with_position.rs
@@ -1,4 +1,4 @@
-use std::iter::{Fuse,Peekable};
+use std::iter::{Fuse,Peekable, FusedIterator};
 
 /// An iterator adaptor that wraps each element in an [`Position`].
 ///
@@ -95,3 +95,6 @@ impl<I: Iterator> Iterator for WithPosition<I> {
 impl<I> ExactSizeIterator for WithPosition<I>
     where I: ExactSizeIterator,
 { }
+
+impl<I: Iterator> FusedIterator for WithPosition<I> 
+{}

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -1618,6 +1618,18 @@ quickcheck! {
         is_fused(a.combinations(3))
     }
 
+    fn fused_combination_with_replacement(a: Iter<i16>) -> bool
+    {
+        is_fused(a.clone().combinations_with_replacement(1)) &&
+        is_fused(a.combinations_with_replacement(3))
+    }
+
+    fn fused_tuple_combination(a: Iter<i16>) -> bool
+    {
+        is_fused(a.clone().fuse().tuple_combinations::<(_,)>()) &&
+        is_fused(a.fuse().tuple_combinations::<(_,_,_)>())
+    }
+
     fn fused_unique(a: Iter<i16>) -> bool
     {
         is_fused(a.fuse().unique())
@@ -1668,6 +1680,16 @@ quickcheck! {
     {
         !is_fused(a.clone().update(|x|*x+=1)) &&
         is_fused(a.fuse().update(|x|*x+=1))
+    }
+
+    fn fused_tuple_windows(a: Iter<i16>) -> bool
+    {
+        is_fused(a.fuse().tuple_windows::<(_,_)>())
+    }
+
+    fn fused_pad_using(a: Iter<i16>) -> bool
+    {
+        is_fused(a.fuse().pad_using(100,|_|0))
     }
 }
 

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -1598,3 +1598,76 @@ quickcheck! {
         TestResult::from_bool(itertools::equal(x, y))
     }
 }
+
+
+fn is_fused<I: Iterator>(mut it: I) -> bool
+{
+    while let Some(_) = it.next() {}
+    for _ in 0..10{
+        if it.next().is_some(){
+            return false;
+        }
+    }
+    true
+}
+
+quickcheck! {
+    fn fused_combination(a: Iter<i16>) -> bool
+    {
+        is_fused(a.clone().combinations(1)) &&
+        is_fused(a.combinations(3))
+    }
+
+    fn fused_unique(a: Iter<i16>) -> bool
+    {
+        is_fused(a.fuse().unique())
+    }
+
+    fn fused_unique_by(a: Iter<i16>) -> bool
+    {
+        is_fused(a.fuse().unique_by(|x| x % 100))
+    }
+
+    fn fused_interleave_shortest(a: Iter<i16>, b: Iter<i16>) -> bool
+    {
+        !is_fused(a.clone().interleave_shortest(b.clone())) &&
+        is_fused(a.fuse().interleave_shortest(b.fuse()))
+    }
+    
+    fn fused_product(a: Iter<i16>, b: Iter<i16>) -> bool
+    {
+        is_fused(a.fuse().cartesian_product(b.fuse()))
+    }
+
+    fn fused_merge(a: Iter<i16>, b: Iter<i16>) -> bool
+    {
+        is_fused(a.fuse().merge(b.fuse()))
+    }
+
+    fn fused_filter_ok(a: Iter<i16>) -> bool
+    {
+        is_fused(a.map(|x| if x % 2 == 0 {Ok(x)} else {Err(x)} )
+                 .filter_ok(|x| x % 3 == 0)
+                 .fuse())
+    }
+
+    fn fused_filter_map_ok(a: Iter<i16>) -> bool
+    {
+        is_fused(a.map(|x| if x % 2 == 0 {Ok(x)} else {Err(x)} )
+                 .filter_map_ok(|x| if x % 3 == 0 {Some(x / 3)} else {None})
+                 .fuse())
+    }
+
+    fn fused_positions(a: Iter<i16>) -> bool
+    {
+        !is_fused(a.clone().positions(|x|x%2==0)) &&
+        is_fused(a.fuse().positions(|x|x%2==0))
+    }
+
+    fn fused_update(a: Iter<i16>) -> bool
+    {
+        !is_fused(a.clone().update(|x|*x+=1)) &&
+        is_fused(a.fuse().update(|x|*x+=1))
+    }
+}
+


### PR DESCRIPTION
These Iterator is fused if the underlying Iterator is fused.
-  `FilterOk`
-  `FilterMapOk`
- `InterleaveShortest`
- `KMergeBy`
- `MergeBy`
- `PadUsing`
- `Positions`
- `Product` 
- `RcIter`
- `TupleWindows`
- `Unique`
- `UniqueBy`
-  `Update`
- `WhileSome`

These is fused even though the underlying Iterator is not fused.
- `Combinations` 
- `CombinationsWithReplacement`
- `Powerset`
- `RepeatN`
- `WithPosition` 

`FusedIterator` can be added to these structs.

Related  #55, #152, #531, #533

I separate the pull request with #548 because these Iterator are sure to be fused because it was documented, but I'm not 100% sure that the structs in this PR is actually fused. (Though I believe it is.)