### PR TITLE
Fix subtraction overflow in DuplicatesBy size_hint

### DIFF
--- a/src/duplicates_impl.rs
+++ b/src/duplicates_impl.rs
@@ -89,7 +89,7 @@ mod private {
             // far), plus (hi - pending) / 2 pairs of never seen before items.
             let hi = hi.map(|hi| {
                 let max_pending = std::cmp::min(self.meta.pending, hi);
-                let max_new = hi.checked_sub(self.meta.pending).unwrap_or(0) / 2;
+                let max_new = hi.saturating_sub(self.meta.pending) / 2;
                 max_pending + max_new
             });
             // The lower bound is always 0 since we might only get unique items from now on

--- a/src/duplicates_impl.rs
+++ b/src/duplicates_impl.rs
@@ -89,7 +89,7 @@ mod private {
             // far), plus (hi - pending) / 2 pairs of never seen before items.
             let hi = hi.map(|hi| {
                 let max_pending = std::cmp::min(self.meta.pending, hi);
-                let max_new = std::cmp::max(hi - self.meta.pending, 0) / 2;
+                let max_new = hi.checked_sub(self.meta.pending).unwrap_or(0) / 2;
                 max_pending + max_new
             });
             // The lower bound is always 0 since we might only get unique items from now on

--- a/src/duplicates_impl.rs
+++ b/src/duplicates_impl.rs
@@ -84,13 +84,18 @@ mod private {
         #[inline]
         fn size_hint(&self) -> (usize, Option<usize>) {
             let (_, hi) = self.iter.size_hint();
-            // There are `hi` number of items left in the base iterator. In the best case scenario,
-            // these items are exactly the same as the ones pending (i.e items seen exactly once so
-            // far), plus (hi - pending) / 2 pairs of never seen before items.
             let hi = hi.map(|hi| {
-                let max_pending = std::cmp::min(self.meta.pending, hi);
-                let max_new = hi.saturating_sub(self.meta.pending) / 2;
-                max_pending + max_new
+                if hi <= self.meta.pending {
+                    // fewer or equally many iter-remaining elements than pending elements
+                    // => at most, each iter-remaining element is matched
+                    hi
+                } else {
+                    // fewer pending elements than iter-remaining elements
+                    // => at most:
+                    //    * each pending element is matched
+                    //    * the other iter-remaining elements come in pairs
+                    self.meta.pending + (hi - self.meta.pending) / 2
+                }
             });
             // The lower bound is always 0 since we might only get unique items from now on
             (0, hi)

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -84,6 +84,13 @@ fn duplicates() {
     it::assert_equal(ys.iter(), xs.iter().rev().duplicates().rev());
     let ys_rev = [1, 0];
     it::assert_equal(ys_rev.iter(), xs.iter().duplicates().rev());
+
+    let xs = vec![0, 1, 2, 1, 2];
+    let ys = vec![1, 2];
+    assert_eq!(ys, xs.iter().duplicates().cloned().collect_vec());
+    assert_eq!(ys, xs.iter().rev().duplicates().rev().cloned().collect_vec());
+    let ys_rev = vec![2, 1];
+    assert_eq!(ys_rev, xs.iter().duplicates().rev().cloned().collect_vec());
 }
 
 #[test]


### PR DESCRIPTION
Sample that panics with `attempt to subtract with overflow` in a `debug` build:

```rust
use itertools::Itertools;

fn main() {
    println!("{:?}", vec!["a", "b", "c", "c"].iter().duplicates().collect_vec());
}
```