### PR TITLE
Add iterator versions of BTreeSet operations

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -8,16 +8,16 @@ mod coalesce;
 mod map;
 mod multi_product;
 pub use self::coalesce::*;
-pub use self::map::{map_into, map_ok, MapInto, MapOk};
 #[allow(deprecated)]
 pub use self::map::MapResults;
+pub use self::map::{map_into, map_ok, MapInto, MapOk};
 #[cfg(feature = "use_alloc")]
 pub use self::multi_product::*;
 
-use std::fmt;
-use std::iter::{Fuse, Peekable, FromIterator, FusedIterator};
-use std::marker::PhantomData;
 use crate::size_hint;
+use std::fmt;
+use std::iter::{FromIterator, Fuse, FusedIterator, Peekable};
+use std::marker::PhantomData;
 
 /// An iterator adaptor that alternates elements from two iterators until both
 /// run out.
@@ -38,9 +38,13 @@ pub struct Interleave<I, J> {
 /// [`IntoIterator`] enabled version of `i.interleave(j)`.
 ///
 /// See [`.interleave()`](crate::Itertools::interleave) for more information.
-pub fn interleave<I, J>(i: I, j: J) -> Interleave<<I as IntoIterator>::IntoIter, <J as IntoIterator>::IntoIter>
-    where I: IntoIterator,
-          J: IntoIterator<Item = I::Item>
+pub fn interleave<I, J>(
+    i: I,
+    j: J,
+) -> Interleave<<I as IntoIterator>::IntoIter, <J as IntoIterator>::IntoIter>
+where
+    I: IntoIterator,
+    J: IntoIterator<Item = I::Item>,
 {
     Interleave {
         a: i.into_iter().fuse(),
@@ -50,8 +54,9 @@ pub fn interleave<I, J>(i: I, j: J) -> Interleave<<I as IntoIterator>::IntoIter,
 }
 
 impl<I, J> Iterator for Interleave<I, J>
-    where I: Iterator,
-          J: Iterator<Item = I::Item>
+where
+    I: Iterator,
+    J: Iterator<Item = I::Item>,
 {
     type Item = I::Item;
     #[inline]
@@ -76,9 +81,11 @@ impl<I, J> Iterator for Interleave<I, J>
 }
 
 impl<I, J> FusedIterator for Interleave<I, J>
-    where I: Iterator,
-          J: Iterator<Item = I::Item>
-{}
+where
+    I: Iterator,
+    J: Iterator<Item = I::Item>,
+{
+}
 
 /// An iterator adaptor that alternates elements from the two iterators until
 /// one of them runs out.
@@ -90,8 +97,9 @@ impl<I, J> FusedIterator for Interleave<I, J>
 #[derive(Clone, Debug)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct InterleaveShortest<I, J>
-    where I: Iterator,
-          J: Iterator<Item = I::Item>
+where
+    I: Iterator,
+    J: Iterator<Item = I::Item>,
 {
     it0: I,
     it1: J,
@@ -100,8 +108,9 @@ pub struct InterleaveShortest<I, J>
 
 /// Create a new `InterleaveShortest` iterator.
 pub fn interleave_shortest<I, J>(a: I, b: J) -> InterleaveShortest<I, J>
-    where I: Iterator,
-          J: Iterator<Item = I::Item>
+where
+    I: Iterator,
+    J: Iterator<Item = I::Item>,
 {
     InterleaveShortest {
         it0: a,
@@ -111,14 +120,19 @@ pub fn interleave_shortest<I, J>(a: I, b: J) -> InterleaveShortest<I, J>
 }
 
 impl<I, J> Iterator for InterleaveShortest<I, J>
-    where I: Iterator,
-          J: Iterator<Item = I::Item>
+where
+    I: Iterator,
+    J: Iterator<Item = I::Item>,
 {
     type Item = I::Item;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        let e = if self.phase { self.it1.next() } else { self.it0.next() };
+        let e = if self.phase {
+            self.it1.next()
+        } else {
+            self.it0.next()
+        };
         if e.is_some() {
             self.phase = !self.phase;
         }
@@ -140,12 +154,11 @@ impl<I, J> Iterator for InterleaveShortest<I, J>
         let (next_lower, next_upper) = next_hint;
         let (combined_lower, combined_upper) =
             size_hint::mul_scalar(size_hint::min(curr_hint, next_hint), 2);
-        let lower =
-            if curr_lower > next_lower {
-                combined_lower + 1
-            } else {
-                combined_lower
-            };
+        let lower = if curr_lower > next_lower {
+            combined_lower + 1
+        } else {
+            combined_lower
+        };
         let upper = {
             let extra_elem = match (curr_upper, next_upper) {
                 (_, None) => false,
@@ -163,9 +176,11 @@ impl<I, J> Iterator for InterleaveShortest<I, J>
 }
 
 impl<I, J> FusedIterator for InterleaveShortest<I, J>
-    where I: FusedIterator,
-          J: FusedIterator<Item = I::Item>
-{}
+where
+    I: FusedIterator,
+    J: FusedIterator<Item = I::Item>,
+{
+}
 
 #[derive(Clone, Debug)]
 /// An iterator adaptor that allows putting back a single
@@ -173,7 +188,8 @@ impl<I, J> FusedIterator for InterleaveShortest<I, J>
 ///
 /// Iterator element type is `I::Item`.
 pub struct PutBack<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     top: Option<I::Item>,
     iter: I,
@@ -181,7 +197,8 @@ pub struct PutBack<I>
 
 /// Create an iterator where you can put back a single item
 pub fn put_back<I>(iterable: I) -> PutBack<I::IntoIter>
-    where I: IntoIterator
+where
+    I: IntoIterator,
 {
     PutBack {
         top: None,
@@ -190,7 +207,8 @@ pub fn put_back<I>(iterable: I) -> PutBack<I::IntoIter>
 }
 
 impl<I> PutBack<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     /// put back value `value` (builder method)
     pub fn with_value(mut self, value: I::Item) -> Self {
@@ -201,7 +219,7 @@ impl<I> PutBack<I>
     /// Split the `PutBack` into its parts.
     #[inline]
     pub fn into_parts(self) -> (Option<I::Item>, I) {
-        let PutBack{top, iter} = self;
+        let PutBack { top, iter } = self;
         (top, iter)
     }
 
@@ -215,7 +233,8 @@ impl<I> PutBack<I>
 }
 
 impl<I> Iterator for PutBack<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     type Item = I::Item;
     #[inline]
@@ -254,7 +273,8 @@ impl<I> Iterator for PutBack<I>
     }
 
     fn all<G>(&mut self, mut f: G) -> bool
-        where G: FnMut(Self::Item) -> bool
+    where
+        G: FnMut(Self::Item) -> bool,
     {
         if let Some(elt) = self.top.take() {
             if !f(elt) {
@@ -265,7 +285,8 @@ impl<I> Iterator for PutBack<I>
     }
 
     fn fold<Acc, G>(mut self, init: Acc, mut f: G) -> Acc
-        where G: FnMut(Acc, Self::Item) -> Acc,
+    where
+        G: FnMut(Acc, Self::Item) -> Acc,
     {
         let mut accum = init;
         if let Some(elt) = self.top.take() {
@@ -284,7 +305,8 @@ impl<I> Iterator for PutBack<I>
 /// See [`.cartesian_product()`](crate::Itertools::cartesian_product) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Product<I, J>
-    where I: Iterator
+where
+    I: Iterator,
 {
     a: I,
     a_cur: Option<I::Item>,
@@ -296,9 +318,10 @@ pub struct Product<I, J>
 ///
 /// Iterator element type is `(I::Item, J::Item)`.
 pub fn cartesian_product<I, J>(mut i: I, j: J) -> Product<I, J>
-    where I: Iterator,
-          J: Clone + Iterator,
-          I::Item: Clone
+where
+    I: Iterator,
+    J: Clone + Iterator,
+    I::Item: Clone,
 {
     Product {
         a_cur: i.next(),
@@ -309,9 +332,10 @@ pub fn cartesian_product<I, J>(mut i: I, j: J) -> Product<I, J>
 }
 
 impl<I, J> Iterator for Product<I, J>
-    where I: Iterator,
-          J: Clone + Iterator,
-          I::Item: Clone
+where
+    I: Iterator,
+    J: Clone + Iterator,
+    I::Item: Clone,
 {
     type Item = (I::Item, J::Item);
 
@@ -327,13 +351,11 @@ impl<I, J> Iterator for Product<I, J>
                     }
                 }
             }
-            Some(x) => x
+            Some(x) => x,
         };
         match self.a_cur {
             None => None,
-            Some(ref a) => {
-                Some((a.clone(), elt_b))
-            }
+            Some(ref a) => Some((a.clone(), elt_b)),
         }
     }
 
@@ -345,11 +367,13 @@ impl<I, J> Iterator for Product<I, J>
         // Compute a * b_orig + b for both lower and upper bound
         size_hint::add(
             size_hint::mul(self.a.size_hint(), self.b_orig.size_hint()),
-            (b_min * has_cur, b_max.map(move |x| x * has_cur)))
+            (b_min * has_cur, b_max.map(move |x| x * has_cur)),
+        )
     }
 
     fn fold<Acc, G>(mut self, mut accum: Acc, mut f: G) -> Acc
-        where G: FnMut(Acc, Self::Item) -> Acc,
+    where
+        G: FnMut(Acc, Self::Item) -> Acc,
     {
         // use a split loop to handle the loose a_cur as well as avoiding to
         // clone b_orig at the end.
@@ -372,10 +396,12 @@ impl<I, J> Iterator for Product<I, J>
 }
 
 impl<I, J> FusedIterator for Product<I, J>
-    where I: FusedIterator,
-          J: Clone + FusedIterator,
-          I::Item: Clone
-{}
+where
+    I: FusedIterator,
+    J: Clone + FusedIterator,
+    I::Item: Clone,
+{
+}
 
 /// A “meta iterator adaptor”. Its closure receives a reference to the iterator
 /// and may pick off as many elements as it likes, to produce the next iterator element.
@@ -390,7 +416,10 @@ pub struct Batching<I, F> {
     iter: I,
 }
 
-impl<I, F> fmt::Debug for Batching<I, F> where I: fmt::Debug {
+impl<I, F> fmt::Debug for Batching<I, F>
+where
+    I: fmt::Debug,
+{
     debug_fmt_fields!(Batching, iter);
 }
 
@@ -400,8 +429,9 @@ pub fn batching<I, F>(iter: I, f: F) -> Batching<I, F> {
 }
 
 impl<B, F, I> Iterator for Batching<I, F>
-    where I: Iterator,
-          F: FnMut(&mut I) -> Option<B>
+where
+    I: Iterator,
+    F: FnMut(&mut I) -> Option<B>,
 {
     type Item = B;
     #[inline]
@@ -417,7 +447,7 @@ impl<B, F, I> Iterator for Batching<I, F>
 /// then skipping forward *n-1* elements.
 ///
 /// See [`.step()`](crate::Itertools::step) for more information.
-#[deprecated(note="Use std .step_by() instead", since="0.8.0")]
+#[deprecated(note = "Use std .step_by() instead", since = "0.8.0")]
 #[allow(deprecated)]
 #[derive(Clone, Debug)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
@@ -431,7 +461,8 @@ pub struct Step<I> {
 /// **Panics** if the step is 0.
 #[allow(deprecated)]
 pub fn step<I>(iter: I, step: usize) -> Step<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     assert!(step != 0);
     Step {
@@ -442,7 +473,8 @@ pub fn step<I>(iter: I, step: usize) -> Step<I>
 
 #[allow(deprecated)]
 impl<I> Iterator for Step<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     type Item = I::Item;
     #[inline]
@@ -469,9 +501,7 @@ impl<I> Iterator for Step<I>
 
 // known size
 #[allow(deprecated)]
-impl<I> ExactSizeIterator for Step<I>
-    where I: ExactSizeIterator
-{}
+impl<I> ExactSizeIterator for Step<I> where I: ExactSizeIterator {}
 
 pub trait MergePredicate<T> {
     fn merge_pred(&mut self, a: &T, b: &T) -> bool;
@@ -506,10 +536,14 @@ pub type Merge<I, J> = MergeBy<I, J, MergeLte>;
 ///     /* loop body */
 /// }
 /// ```
-pub fn merge<I, J>(i: I, j: J) -> Merge<<I as IntoIterator>::IntoIter, <J as IntoIterator>::IntoIter>
-    where I: IntoIterator,
-          J: IntoIterator<Item = I::Item>,
-          I::Item: PartialOrd
+pub fn merge<I, J>(
+    i: I,
+    j: J,
+) -> Merge<<I as IntoIterator>::IntoIter, <J as IntoIterator>::IntoIter>
+where
+    I: IntoIterator,
+    J: IntoIterator<Item = I::Item>,
+    I::Item: PartialOrd,
 {
     merge_by_new(i, j, MergeLte)
 }
@@ -522,8 +556,9 @@ pub fn merge<I, J>(i: I, j: J) -> Merge<<I as IntoIterator>::IntoIter, <J as Int
 /// See [`.merge_by()`](crate::Itertools::merge_by) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct MergeBy<I, J, F>
-    where I: Iterator,
-          J: Iterator<Item = I::Item>
+where
+    I: Iterator,
+    J: Iterator<Item = I::Item>,
 {
     a: Peekable<I>,
     b: Peekable<J>,
@@ -532,13 +567,15 @@ pub struct MergeBy<I, J, F>
 }
 
 impl<I, J, F> fmt::Debug for MergeBy<I, J, F>
-    where I: Iterator + fmt::Debug, J: Iterator<Item = I::Item> + fmt::Debug,
-          I::Item: fmt::Debug,
+where
+    I: Iterator + fmt::Debug,
+    J: Iterator<Item = I::Item> + fmt::Debug,
+    I::Item: fmt::Debug,
 {
     debug_fmt_fields!(MergeBy, a, b);
 }
 
-impl<T, F: FnMut(&T, &T)->bool> MergePredicate<T> for F {
+impl<T, F: FnMut(&T, &T) -> bool> MergePredicate<T> for F {
     fn merge_pred(&mut self, a: &T, b: &T) -> bool {
         self(a, b)
     }
@@ -546,9 +583,10 @@ impl<T, F: FnMut(&T, &T)->bool> MergePredicate<T> for F {
 
 /// Create a `MergeBy` iterator.
 pub fn merge_by_new<I, J, F>(a: I, b: J, cmp: F) -> MergeBy<I::IntoIter, J::IntoIter, F>
-    where I: IntoIterator,
-          J: IntoIterator<Item = I::Item>,
-          F: MergePredicate<I::Item>,
+where
+    I: IntoIterator,
+    J: IntoIterator<Item = I::Item>,
+    F: MergePredicate<I::Item>,
 {
     MergeBy {
         a: a.into_iter().peekable(),
@@ -559,19 +597,21 @@ pub fn merge_by_new<I, J, F>(a: I, b: J, cmp: F) -> MergeBy<I::IntoIter, J::Into
 }
 
 impl<I, J, F> Clone for MergeBy<I, J, F>
-    where I: Iterator,
-          J: Iterator<Item = I::Item>,
-          Peekable<I>: Clone,
-          Peekable<J>: Clone,
-          F: Clone
+where
+    I: Iterator,
+    J: Iterator<Item = I::Item>,
+    Peekable<I>: Clone,
+    Peekable<J>: Clone,
+    F: Clone,
 {
     clone_fields!(a, b, fused, cmp);
 }
 
 impl<I, J, F> Iterator for MergeBy<I, J, F>
-    where I: Iterator,
-          J: Iterator<Item = I::Item>,
-          F: MergePredicate<I::Item>
+where
+    I: Iterator,
+    J: Iterator<Item = I::Item>,
+    F: MergePredicate<I::Item>,
 {
     type Item = I::Item;
 
@@ -589,7 +629,7 @@ impl<I, J, F> Iterator for MergeBy<I, J, F>
                     false
                 }
                 (None, None) => return None,
-            }
+            },
         };
         if less_than {
             self.a.next()
@@ -605,10 +645,12 @@ impl<I, J, F> Iterator for MergeBy<I, J, F>
 }
 
 impl<I, J, F> FusedIterator for MergeBy<I, J, F>
-    where I: FusedIterator,
-          J: FusedIterator<Item = I::Item>,
-          F: MergePredicate<I::Item>
-{}
+where
+    I: FusedIterator,
+    J: FusedIterator<Item = I::Item>,
+    F: MergePredicate<I::Item>,
+{
+}
 
 /// An iterator adaptor that borrows from a `Clone`-able iterator
 /// to only pick off elements while the predicate returns `true`.
@@ -621,21 +663,24 @@ pub struct TakeWhileRef<'a, I: 'a, F> {
 }
 
 impl<'a, I, F> fmt::Debug for TakeWhileRef<'a, I, F>
-    where I: Iterator + fmt::Debug,
+where
+    I: Iterator + fmt::Debug,
 {
     debug_fmt_fields!(TakeWhileRef, iter);
 }
 
 /// Create a new `TakeWhileRef` from a reference to clonable iterator.
 pub fn take_while_ref<I, F>(iter: &mut I, f: F) -> TakeWhileRef<I, F>
-    where I: Iterator + Clone
+where
+    I: Iterator + Clone,
 {
     TakeWhileRef { iter, f }
 }
 
 impl<'a, I, F> Iterator for TakeWhileRef<'a, I, F>
-    where I: Iterator + Clone,
-          F: FnMut(&I::Item) -> bool
+where
+    I: Iterator + Clone,
+    F: FnMut(&I::Item) -> bool,
 {
     type Item = I::Item;
 
@@ -675,7 +720,8 @@ pub fn while_some<I>(iter: I) -> WhileSome<I> {
 }
 
 impl<I, A> Iterator for WhileSome<I>
-    where I: Iterator<Item = Option<A>>
+where
+    I: Iterator<Item = Option<A>>,
 {
     type Item = A;
 
@@ -699,8 +745,9 @@ impl<I, A> Iterator for WhileSome<I>
 #[derive(Clone, Debug)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct TupleCombinations<I, T>
-    where I: Iterator,
-          T: HasCombination<I>
+where
+    I: Iterator,
+    T: HasCombination<I>,
 {
     iter: T::Combination,
     _mi: PhantomData<I>,
@@ -712,9 +759,10 @@ pub trait HasCombination<I>: Sized {
 
 /// Create a new `TupleCombinations` from a clonable iterator.
 pub fn tuple_combinations<T, I>(iter: I) -> TupleCombinations<I, T>
-    where I: Iterator + Clone,
-          I::Item: Clone,
-          T: HasCombination<I>,
+where
+    I: Iterator + Clone,
+    I::Item: Clone,
+    T: HasCombination<I>,
 {
     TupleCombinations {
         iter: T::Combination::from(iter),
@@ -723,8 +771,9 @@ pub fn tuple_combinations<T, I>(iter: I) -> TupleCombinations<I, T>
 }
 
 impl<I, T> Iterator for TupleCombinations<I, T>
-    where I: Iterator,
-          T: HasCombination<I>,
+where
+    I: Iterator,
+    T: HasCombination<I>,
 {
     type Item = T;
 
@@ -734,9 +783,11 @@ impl<I, T> Iterator for TupleCombinations<I, T>
 }
 
 impl<I, T> FusedIterator for TupleCombinations<I, T>
-    where I: FusedIterator,
-          T: HasCombination<I>,
-{}
+where
+    I: FusedIterator,
+    T: HasCombination<I>,
+{
+}
 
 #[derive(Clone, Debug)]
 pub struct Tuple1Combination<I> {
@@ -846,23 +897,22 @@ impl_tuple_combination!(Tuple12Combination Tuple11Combination; a b c d e f g h i
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct FilterOk<I, F> {
     iter: I,
-    f: F
+    f: F,
 }
 
 /// Create a new `FilterOk` iterator.
 pub fn filter_ok<I, F, T, E>(iter: I, f: F) -> FilterOk<I, F>
-    where I: Iterator<Item = Result<T, E>>,
-          F: FnMut(&T) -> bool,
+where
+    I: Iterator<Item = Result<T, E>>,
+    F: FnMut(&T) -> bool,
 {
-    FilterOk {
-        iter,
-        f,
-    }
+    FilterOk { iter, f }
 }
 
 impl<I, F, T, E> Iterator for FilterOk<I, F>
-    where I: Iterator<Item = Result<T, E>>,
-          F: FnMut(&T) -> bool,
+where
+    I: Iterator<Item = Result<T, E>>,
+    F: FnMut(&T) -> bool,
 {
     type Item = Result<T, E>;
 
@@ -873,7 +923,7 @@ impl<I, F, T, E> Iterator for FilterOk<I, F>
                     if (self.f)(&v) {
                         return Some(Ok(v));
                     }
-                },
+                }
                 Some(Err(e)) => return Some(Err(e)),
                 None => return None,
             }
@@ -885,28 +935,32 @@ impl<I, F, T, E> Iterator for FilterOk<I, F>
     }
 
     fn fold<Acc, Fold>(self, init: Acc, fold_f: Fold) -> Acc
-        where Fold: FnMut(Acc, Self::Item) -> Acc,
+    where
+        Fold: FnMut(Acc, Self::Item) -> Acc,
     {
         let mut f = self.f;
-        self.iter.filter(|v| {
-            v.as_ref().map(&mut f).unwrap_or(true)
-        }).fold(init, fold_f)
+        self.iter
+            .filter(|v| v.as_ref().map(&mut f).unwrap_or(true))
+            .fold(init, fold_f)
     }
 
     fn collect<C>(self) -> C
-        where C: FromIterator<Self::Item>
+    where
+        C: FromIterator<Self::Item>,
     {
         let mut f = self.f;
-        self.iter.filter(|v| {
-            v.as_ref().map(&mut f).unwrap_or(true)
-        }).collect()
+        self.iter
+            .filter(|v| v.as_ref().map(&mut f).unwrap_or(true))
+            .collect()
     }
 }
 
 impl<I, F, T, E> FusedIterator for FilterOk<I, F>
-    where I: FusedIterator<Item = Result<T, E>>,
-          F: FnMut(&T) -> bool,
-{}
+where
+    I: FusedIterator<Item = Result<T, E>>,
+    F: FnMut(&T) -> bool,
+{
+}
 
 /// An iterator adapter to filter and apply a transformation on values within a nested `Result::Ok`.
 ///
@@ -914,7 +968,7 @@ impl<I, F, T, E> FusedIterator for FilterOk<I, F>
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct FilterMapOk<I, F> {
     iter: I,
-    f: F
+    f: F,
 }
 
 fn transpose_result<T, E>(result: Result<Option<T>, E>) -> Option<Result<T, E>> {
@@ -927,18 +981,17 @@ fn transpose_result<T, E>(result: Result<Option<T>, E>) -> Option<Result<T, E>> 
 
 /// Create a new `FilterOk` iterator.
 pub fn filter_map_ok<I, F, T, U, E>(iter: I, f: F) -> FilterMapOk<I, F>
-    where I: Iterator<Item = Result<T, E>>,
-          F: FnMut(T) -> Option<U>,
+where
+    I: Iterator<Item = Result<T, E>>,
+    F: FnMut(T) -> Option<U>,
 {
-    FilterMapOk {
-        iter,
-        f,
-    }
+    FilterMapOk { iter, f }
 }
 
 impl<I, F, T, U, E> Iterator for FilterMapOk<I, F>
-    where I: Iterator<Item = Result<T, E>>,
-          F: FnMut(T) -> Option<U>,
+where
+    I: Iterator<Item = Result<T, E>>,
+    F: FnMut(T) -> Option<U>,
 {
     type Item = Result<U, E>;
 
@@ -949,7 +1002,7 @@ impl<I, F, T, U, E> Iterator for FilterMapOk<I, F>
                     if let Some(v) = (self.f)(v) {
                         return Some(Ok(v));
                     }
-                },
+                }
                 Some(Err(e)) => return Some(Err(e)),
                 None => return None,
             }
@@ -961,28 +1014,32 @@ impl<I, F, T, U, E> Iterator for FilterMapOk<I, F>
     }
 
     fn fold<Acc, Fold>(self, init: Acc, fold_f: Fold) -> Acc
-        where Fold: FnMut(Acc, Self::Item) -> Acc,
+    where
+        Fold: FnMut(Acc, Self::Item) -> Acc,
     {
         let mut f = self.f;
-        self.iter.filter_map(|v| {
-            transpose_result(v.map(&mut f))
-        }).fold(init, fold_f)
+        self.iter
+            .filter_map(|v| transpose_result(v.map(&mut f)))
+            .fold(init, fold_f)
     }
 
     fn collect<C>(self) -> C
-        where C: FromIterator<Self::Item>
+    where
+        C: FromIterator<Self::Item>,
     {
         let mut f = self.f;
-        self.iter.filter_map(|v| {
-            transpose_result(v.map(&mut f))
-        }).collect()
+        self.iter
+            .filter_map(|v| transpose_result(v.map(&mut f)))
+            .collect()
     }
 }
 
 impl<I, F, T, U, E> FusedIterator for FilterMapOk<I, F>
-    where I: FusedIterator<Item = Result<T, E>>,
-          F: FnMut(T) -> Option<U>,
-{}
+where
+    I: FusedIterator<Item = Result<T, E>>,
+    F: FnMut(T) -> Option<U>,
+{
+}
 
 /// An iterator adapter to get the positions of each element that matches a predicate.
 ///
@@ -997,24 +1054,22 @@ pub struct Positions<I, F> {
 
 /// Create a new `Positions` iterator.
 pub fn positions<I, F>(iter: I, f: F) -> Positions<I, F>
-    where I: Iterator,
-          F: FnMut(I::Item) -> bool,
+where
+    I: Iterator,
+    F: FnMut(I::Item) -> bool,
 {
-    Positions {
-        iter,
-        f,
-        count: 0
-    }
+    Positions { iter, f, count: 0 }
 }
 
 impl<I, F> Iterator for Positions<I, F>
-    where I: Iterator,
-          F: FnMut(I::Item) -> bool,
+where
+    I: Iterator,
+    F: FnMut(I::Item) -> bool,
 {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(v) = self.iter.next() {
+        for v in &mut self.iter {
             let i = self.count;
             self.count = i + 1;
             if (self.f)(v) {
@@ -1030,13 +1085,14 @@ impl<I, F> Iterator for Positions<I, F>
 }
 
 impl<I, F> DoubleEndedIterator for Positions<I, F>
-    where I: DoubleEndedIterator + ExactSizeIterator,
-          F: FnMut(I::Item) -> bool,
+where
+    I: DoubleEndedIterator + ExactSizeIterator,
+    F: FnMut(I::Item) -> bool,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         while let Some(v) = self.iter.next_back() {
             if (self.f)(v) {
-                return Some(self.count + self.iter.len())
+                return Some(self.count + self.iter.len());
             }
         }
         None
@@ -1044,9 +1100,11 @@ impl<I, F> DoubleEndedIterator for Positions<I, F>
 }
 
 impl<I, F> FusedIterator for Positions<I, F>
-    where I: FusedIterator,
-          F: FnMut(I::Item) -> bool,
-{}
+where
+    I: FusedIterator,
+    F: FnMut(I::Item) -> bool,
+{
+}
 
 /// An iterator adapter to apply a mutating function to each element before yielding it.
 ///
@@ -1088,18 +1146,28 @@ where
     }
 
     fn fold<Acc, G>(self, init: Acc, mut g: G) -> Acc
-        where G: FnMut(Acc, Self::Item) -> Acc,
+    where
+        G: FnMut(Acc, Self::Item) -> Acc,
     {
         let mut f = self.f;
-        self.iter.fold(init, move |acc, mut v| { f(&mut v); g(acc, v) })
+        self.iter.fold(init, move |acc, mut v| {
+            f(&mut v);
+            g(acc, v)
+        })
     }
 
     // if possible, re-use inner iterator specializations in collect
     fn collect<C>(self) -> C
-        where C: FromIterator<Self::Item>
+    where
+        C: FromIterator<Self::Item>,
     {
         let mut f = self.f;
-        self.iter.map(move |mut v| { f(&mut v); v }).collect()
+        self.iter
+            .map(move |mut v| {
+                f(&mut v);
+                v
+            })
+            .collect()
     }
 }
 
@@ -1107,7 +1175,8 @@ impl<I, F> ExactSizeIterator for Update<I, F>
 where
     I: ExactSizeIterator,
     F: FnMut(&mut I::Item),
-{}
+{
+}
 
 impl<I, F> DoubleEndedIterator for Update<I, F>
 where
@@ -1128,4 +1197,5 @@ impl<I, F> FusedIterator for Update<I, F>
 where
     I: FusedIterator,
     F: FnMut(&mut I::Item),
-{}
+{
+}

--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -64,7 +64,7 @@ where
         // If this is the first iteration, return early
         if self.first {
             // In empty edge cases, stop iterating immediately
-            return if self.indices.len() != 0 && !self.pool.get_next() {
+            return if !self.indices.is_empty() && !self.pool.get_next() {
                 None
             // Otherwise, yield the initial state
             } else {
@@ -80,7 +80,7 @@ where
         // Work out where we need to update our indices
         let mut increment: Option<(usize, usize)> = None;
         for (i, indices_int) in self.indices.iter().enumerate().rev() {
-            if *indices_int < self.pool.len()-1 {
+            if *indices_int < self.pool.len() - 1 {
                 increment = Some((i, indices_int + 1));
                 break;
             }
@@ -106,4 +106,5 @@ impl<I> FusedIterator for CombinationsWithReplacement<I>
 where
     I: Iterator,
     I::Item: Clone,
-{}
+{
+}

--- a/src/either_or_both.rs
+++ b/src/either_or_both.rs
@@ -27,19 +27,13 @@ impl<A, B> EitherOrBoth<A, B> {
     /// If Left, return true otherwise, return false.
     /// Exclusive version of [`has_left`](EitherOrBoth::has_left).
     pub fn is_left(&self) -> bool {
-        match *self {
-            Left(_) => true,
-            _ => false,
-        }
+        matches!(*self, Left(_))
     }
 
     /// If Right, return true otherwise, return false.
     /// Exclusive version of [`has_right`](EitherOrBoth::has_right).
     pub fn is_right(&self) -> bool {
-        match *self {
-            Right(_) => true,
-            _ => false,
-        }
+        matches!(*self, Right(_))
     }
 
     /// If Right, return true otherwise, return false.
@@ -194,9 +188,9 @@ impl<T> EitherOrBoth<T, T> {
     }
 }
 
-impl<A, B> Into<Option<Either<A, B>>> for EitherOrBoth<A, B> {
-    fn into(self) -> Option<Either<A, B>> {
-        match self {
+impl<A, B> From<EitherOrBoth<A, B>> for Option<Either<A, B>> {
+    fn from(val: EitherOrBoth<A, B>) -> Self {
+        match val {
             EitherOrBoth::Left(l) => Some(Either::Left(l)),
             EitherOrBoth::Right(r) => Some(Either::Right(r)),
             _ => None,

--- a/src/free.rs
+++ b/src/free.rs
@@ -10,30 +10,24 @@ use std::iter::{self, Zip};
 type VecIntoIter<T> = alloc::vec::IntoIter<T>;
 
 #[cfg(feature = "use_alloc")]
-use alloc::{
-    string::String,
-};
+use alloc::string::String;
 
 #[cfg(feature = "use_alloc")]
 use crate::Itertools;
 
-pub use crate::adaptors::{
-    interleave,
-    merge,
-    put_back,
-};
+pub use crate::adaptors::{interleave, merge, put_back};
 #[cfg(feature = "use_alloc")]
-pub use crate::put_back_n_impl::put_back_n;
+pub use crate::kmerge_impl::kmerge;
+pub use crate::merge_join::merge_join_by;
 #[cfg(feature = "use_alloc")]
 pub use crate::multipeek_impl::multipeek;
 #[cfg(feature = "use_alloc")]
 pub use crate::peek_nth::peek_nth;
 #[cfg(feature = "use_alloc")]
-pub use crate::kmerge_impl::kmerge;
-pub use crate::zip_eq_impl::zip_eq;
-pub use crate::merge_join::merge_join_by;
+pub use crate::put_back_n_impl::put_back_n;
 #[cfg(feature = "use_alloc")]
 pub use crate::rciter_impl::rciter;
+pub use crate::zip_eq_impl::zip_eq;
 
 /// Iterate `iterable` with a running index.
 ///
@@ -47,7 +41,8 @@ pub use crate::rciter_impl::rciter;
 /// }
 /// ```
 pub fn enumerate<I>(iterable: I) -> iter::Enumerate<I::IntoIter>
-    where I: IntoIterator
+where
+    I: IntoIterator,
 {
     iterable.into_iter().enumerate()
 }
@@ -64,8 +59,9 @@ pub fn enumerate<I>(iterable: I) -> iter::Enumerate<I::IntoIter>
 /// }
 /// ```
 pub fn rev<I>(iterable: I) -> iter::Rev<I::IntoIter>
-    where I: IntoIterator,
-          I::IntoIter: DoubleEndedIterator
+where
+    I: IntoIterator,
+    I::IntoIter: DoubleEndedIterator,
 {
     iterable.into_iter().rev()
 }
@@ -83,8 +79,9 @@ pub fn rev<I>(iterable: I) -> iter::Rev<I::IntoIter>
 /// }
 /// ```
 pub fn zip<I, J>(i: I, j: J) -> Zip<I::IntoIter, J::IntoIter>
-    where I: IntoIterator,
-          J: IntoIterator
+where
+    I: IntoIterator,
+    J: IntoIterator,
 {
     i.into_iter().zip(j)
 }
@@ -100,9 +97,13 @@ pub fn zip<I, J>(i: I, j: J) -> Zip<I::IntoIter, J::IntoIter>
 ///     /* loop body */
 /// }
 /// ```
-pub fn chain<I, J>(i: I, j: J) -> iter::Chain<<I as IntoIterator>::IntoIter, <J as IntoIterator>::IntoIter>
-    where I: IntoIterator,
-          J: IntoIterator<Item = I::Item>
+pub fn chain<I, J>(
+    i: I,
+    j: J,
+) -> iter::Chain<<I as IntoIterator>::IntoIter, <J as IntoIterator>::IntoIter>
+where
+    I: IntoIterator,
+    J: IntoIterator<Item = I::Item>,
 {
     i.into_iter().chain(j)
 }
@@ -117,8 +118,9 @@ pub fn chain<I, J>(i: I, j: J) -> iter::Chain<<I as IntoIterator>::IntoIter, <J 
 /// assert_eq!(cloned(b"abc").next(), Some(b'a'));
 /// ```
 pub fn cloned<'a, I, T: 'a>(iterable: I) -> iter::Cloned<I::IntoIter>
-    where I: IntoIterator<Item=&'a T>,
-          T: Clone,
+where
+    I: IntoIterator<Item = &'a T>,
+    T: Clone,
 {
     iterable.into_iter().cloned()
 }
@@ -133,8 +135,9 @@ pub fn cloned<'a, I, T: 'a>(iterable: I) -> iter::Cloned<I::IntoIter>
 /// assert_eq!(fold(&[1., 2., 3.], 0., |a, &b| f32::max(a, b)), 3.);
 /// ```
 pub fn fold<I, B, F>(iterable: I, init: B, f: F) -> B
-    where I: IntoIterator,
-          F: FnMut(B, I::Item) -> B
+where
+    I: IntoIterator,
+    F: FnMut(B, I::Item) -> B,
 {
     iterable.into_iter().fold(init, f)
 }
@@ -149,8 +152,9 @@ pub fn fold<I, B, F>(iterable: I, init: B, f: F) -> B
 /// assert!(all(&[1, 2, 3], |elt| *elt > 0));
 /// ```
 pub fn all<I, F>(iterable: I, f: F) -> bool
-    where I: IntoIterator,
-          F: FnMut(I::Item) -> bool
+where
+    I: IntoIterator,
+    F: FnMut(I::Item) -> bool,
 {
     iterable.into_iter().all(f)
 }
@@ -165,8 +169,9 @@ pub fn all<I, F>(iterable: I, f: F) -> bool
 /// assert!(any(&[0, -1, 2], |elt| *elt > 0));
 /// ```
 pub fn any<I, F>(iterable: I, f: F) -> bool
-    where I: IntoIterator,
-          F: FnMut(I::Item) -> bool
+where
+    I: IntoIterator,
+    F: FnMut(I::Item) -> bool,
 {
     iterable.into_iter().any(f)
 }
@@ -181,8 +186,9 @@ pub fn any<I, F>(iterable: I, f: F) -> bool
 /// assert_eq!(max(0..10), Some(9));
 /// ```
 pub fn max<I>(iterable: I) -> Option<I::Item>
-    where I: IntoIterator,
-          I::Item: Ord
+where
+    I: IntoIterator,
+    I::Item: Ord,
 {
     iterable.into_iter().max()
 }
@@ -197,12 +203,12 @@ pub fn max<I>(iterable: I) -> Option<I::Item>
 /// assert_eq!(min(0..10), Some(0));
 /// ```
 pub fn min<I>(iterable: I) -> Option<I::Item>
-    where I: IntoIterator,
-          I::Item: Ord
+where
+    I: IntoIterator,
+    I::Item: Ord,
 {
     iterable.into_iter().min()
 }
-
 
 /// Combine all iterator elements into one String, seperated by `sep`.
 ///
@@ -215,8 +221,9 @@ pub fn min<I>(iterable: I) -> Option<I::Item>
 /// ```
 #[cfg(feature = "use_alloc")]
 pub fn join<I>(iterable: I, sep: &str) -> String
-    where I: IntoIterator,
-          I::Item: Display
+where
+    I: IntoIterator,
+    I::Item: Display,
 {
     iterable.into_iter().join(sep)
 }
@@ -233,9 +240,9 @@ pub fn join<I>(iterable: I, sep: &str) -> String
 /// ```
 #[cfg(feature = "use_alloc")]
 pub fn sorted<I>(iterable: I) -> VecIntoIter<I::Item>
-    where I: IntoIterator,
-          I::Item: Ord
+where
+    I: IntoIterator,
+    I::Item: Ord,
 {
     iterable.into_iter().sorted()
 }
-

--- a/src/free.rs
+++ b/src/free.rs
@@ -27,6 +27,7 @@ pub use crate::peek_nth::peek_nth;
 pub use crate::put_back_n_impl::put_back_n;
 #[cfg(feature = "use_alloc")]
 pub use crate::rciter_impl::rciter;
+pub use crate::set_ops::{difference, intersection, symmetric_difference, union_ref};
 pub use crate::zip_eq_impl::zip_eq;
 
 /// Iterate `iterable` with a running index.

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "use_std")]
 
 use crate::MinMaxResult;
-use std::collections::HashMap;
 use std::cmp::Ordering;
+use std::collections::HashMap;
 use std::hash::Hash;
 use std::iter::Iterator;
 use std::ops::{Add, Mul};
@@ -18,9 +18,10 @@ impl<I, F> MapForGrouping<I, F> {
 }
 
 impl<K, V, I, F> Iterator for MapForGrouping<I, F>
-    where I: Iterator<Item = V>,
-          K: Hash + Eq,
-          F: FnMut(&V) -> K,
+where
+    I: Iterator<Item = V>,
+    K: Hash + Eq,
+    F: FnMut(&V) -> K,
 {
     type Item = (K, V);
     fn next(&mut self) -> Option<Self::Item> {
@@ -30,14 +31,15 @@ impl<K, V, I, F> Iterator for MapForGrouping<I, F>
 
 /// Creates a new `GroupingMap` from `iter`
 pub fn new<I, K, V>(iter: I) -> GroupingMap<I>
-    where I: Iterator<Item = (K, V)>,
-          K: Hash + Eq,
+where
+    I: Iterator<Item = (K, V)>,
+    K: Hash + Eq,
 {
     GroupingMap { iter }
 }
 
 /// `GroupingMapBy` is an intermediate struct for efficient group-and-fold operations.
-/// 
+///
 /// See [`GroupingMap`] for more informations.
 #[must_use = "GroupingMapBy is lazy and do nothing unless consumed"]
 pub type GroupingMapBy<I, F> = GroupingMap<MapForGrouping<I, F>>;
@@ -45,7 +47,7 @@ pub type GroupingMapBy<I, F> = GroupingMap<MapForGrouping<I, F>>;
 /// `GroupingMap` is an intermediate struct for efficient group-and-fold operations.
 /// It groups elements by their key and at the same time fold each group
 /// using some aggregating operation.
-/// 
+///
 /// No method on this struct performs temporary allocations.
 #[derive(Clone, Debug)]
 #[must_use = "GroupingMap is lazy and do nothing unless consumed"]
@@ -54,13 +56,14 @@ pub struct GroupingMap<I> {
 }
 
 impl<I, K, V> GroupingMap<I>
-    where I: Iterator<Item = (K, V)>,
-          K: Hash + Eq,
+where
+    I: Iterator<Item = (K, V)>,
+    K: Hash + Eq,
 {
     /// This is the generic way to perform any operation on a `GroupingMap`.
     /// It's suggested to use this method only to implement custom operations
     /// when the already provided ones are not enough.
-    /// 
+    ///
     /// Groups elements from the `GroupingMap` source by key and applies `operation` to the elements
     /// of each group sequentially, passing the previously accumulated value, a reference to the key
     /// and the current element as arguments, and stores the results in an `HashMap`.
@@ -69,17 +72,17 @@ impl<I, K, V> GroupingMap<I>
     ///  - the current value of the accumulator of the group if there is currently one;
     ///  - a reference to the key of the group this element belongs to;
     ///  - the element from the source being aggregated;
-    /// 
+    ///
     /// If `operation` returns `Some(element)` then the accumulator is updated with `element`,
     /// otherwise the previous accumulation is discarded.
     ///
     /// Return a `HashMap` associating the key of each group with the result of aggregation of
     /// that group's elements. If the aggregation of the last element of a group discards the
     /// accumulator then there won't be an entry associated to that group's key.
-    /// 
+    ///
     /// ```
     /// use itertools::Itertools;
-    /// 
+    ///
     /// let data = vec![2, 8, 5, 7, 9, 0, 4, 10];
     /// let lookup = data.into_iter()
     ///     .into_grouping_map_by(|&n| n % 4)
@@ -90,7 +93,7 @@ impl<I, K, V> GroupingMap<I>
     ///             Some(acc.unwrap_or(0) + val)
     ///         }
     ///     });
-    /// 
+    ///
     /// assert_eq!(lookup[&0], 4);        // 0 resets the accumulator so only 4 is summed
     /// assert_eq!(lookup[&1], 5 + 9);
     /// assert_eq!(lookup.get(&2), None); // 10 resets the accumulator and nothing is summed afterward
@@ -98,7 +101,8 @@ impl<I, K, V> GroupingMap<I>
     /// assert_eq!(lookup.len(), 3);      // The final keys are only 0, 1 and 2
     /// ```
     pub fn aggregate<FO, R>(self, mut operation: FO) -> HashMap<K, R>
-        where FO: FnMut(Option<R>, &K, V) -> Option<R>,
+    where
+        FO: FnMut(Option<R>, &K, V) -> Option<R>,
     {
         let mut destination_map = HashMap::new();
 
@@ -124,22 +128,23 @@ impl<I, K, V> GroupingMap<I>
     ///  - the element from the source being accumulated.
     ///
     /// Return a `HashMap` associating the key of each group with the result of folding that group's elements.
-    /// 
+    ///
     /// ```
     /// use itertools::Itertools;
-    /// 
+    ///
     /// let lookup = (1..=7)
     ///     .into_grouping_map_by(|&n| n % 3)
     ///     .fold(0, |acc, _key, val| acc + val);
-    /// 
+    ///
     /// assert_eq!(lookup[&0], 3 + 6);
     /// assert_eq!(lookup[&1], 1 + 4 + 7);
     /// assert_eq!(lookup[&2], 2 + 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn fold<FO, R>(self, init: R, mut operation: FO) -> HashMap<K, R>
-        where R: Clone,
-              FO: FnMut(R, &K, V) -> R,
+    where
+        R: Clone,
+        FO: FnMut(R, &K, V) -> R,
     {
         self.aggregate(|acc, key, val| {
             let acc = acc.unwrap_or_else(|| init.clone());
@@ -159,23 +164,24 @@ impl<I, K, V> GroupingMap<I>
     ///  - the element from the source being accumulated.
     ///
     /// Return a `HashMap` associating the key of each group with the result of folding that group's elements.
-    /// 
+    ///
     /// [`fold`]: GroupingMap::fold
-    /// 
+    ///
     /// ```
     /// use itertools::Itertools;
-    /// 
+    ///
     /// let lookup = (1..=7)
     ///     .into_grouping_map_by(|&n| n % 3)
     ///     .fold_first(|acc, _key, val| acc + val);
-    /// 
+    ///
     /// assert_eq!(lookup[&0], 3 + 6);
     /// assert_eq!(lookup[&1], 1 + 4 + 7);
     /// assert_eq!(lookup[&2], 2 + 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn fold_first<FO>(self, mut operation: FO) -> HashMap<K, V>
-        where FO: FnMut(V, &K, V) -> V,
+    where
+        FO: FnMut(V, &K, V) -> V,
     {
         self.aggregate(|acc, key, val| {
             Some(match acc {
@@ -186,249 +192,261 @@ impl<I, K, V> GroupingMap<I>
     }
 
     /// Groups elements from the `GroupingMap` source by key and collects the elements of each group in
-    /// an instance of `C`. The iteration order is preserved when inserting elements. 
-    /// 
+    /// an instance of `C`. The iteration order is preserved when inserting elements.
+    ///
     /// Return a `HashMap` associating the key of each group with the collection containing that group's elements.
-    /// 
+    ///
     /// ```
     /// use itertools::Itertools;
     /// use std::collections::HashSet;
-    /// 
+    ///
     /// let lookup = vec![0, 1, 2, 3, 4, 5, 6, 2, 3, 6].into_iter()
     ///     .into_grouping_map_by(|&n| n % 3)
     ///     .collect::<HashSet<_>>();
-    /// 
+    ///
     /// assert_eq!(lookup[&0], vec![0, 3, 6].into_iter().collect::<HashSet<_>>());
     /// assert_eq!(lookup[&1], vec![1, 4].into_iter().collect::<HashSet<_>>());
     /// assert_eq!(lookup[&2], vec![2, 5].into_iter().collect::<HashSet<_>>());
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn collect<C>(self) -> HashMap<K, C>
-        where C: Default + Extend<V>,
+    where
+        C: Default + Extend<V>,
     {
         let mut destination_map = HashMap::new();
 
         self.iter.for_each(|(key, val)| {
-            destination_map.entry(key).or_insert_with(C::default).extend(Some(val));
+            destination_map
+                .entry(key)
+                .or_insert_with(C::default)
+                .extend(Some(val));
         });
 
         destination_map
     }
 
     /// Groups elements from the `GroupingMap` source by key and finds the maximum of each group.
-    /// 
+    ///
     /// If several elements are equally maximum, the last element is picked.
-    /// 
+    ///
     /// Returns a `HashMap` associating the key of each group with the maximum of that group's elements.
-    /// 
+    ///
     /// ```
     /// use itertools::Itertools;
-    /// 
+    ///
     /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
     ///     .into_grouping_map_by(|&n| n % 3)
     ///     .max();
-    /// 
+    ///
     /// assert_eq!(lookup[&0], 12);
     /// assert_eq!(lookup[&1], 7);
     /// assert_eq!(lookup[&2], 8);
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn max(self) -> HashMap<K, V>
-        where V: Ord,
+    where
+        V: Ord,
     {
         self.max_by(|_, v1, v2| V::cmp(v1, v2))
     }
 
     /// Groups elements from the `GroupingMap` source by key and finds the maximum of each group
     /// with respect to the specified comparison function.
-    /// 
+    ///
     /// If several elements are equally maximum, the last element is picked.
-    /// 
+    ///
     /// Returns a `HashMap` associating the key of each group with the maximum of that group's elements.
-    /// 
+    ///
     /// ```
     /// use itertools::Itertools;
-    /// 
+    ///
     /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
     ///     .into_grouping_map_by(|&n| n % 3)
     ///     .max_by(|_key, x, y| y.cmp(x));
-    /// 
+    ///
     /// assert_eq!(lookup[&0], 3);
     /// assert_eq!(lookup[&1], 1);
     /// assert_eq!(lookup[&2], 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn max_by<F>(self, mut compare: F) -> HashMap<K, V>
-        where F: FnMut(&K, &V, &V) -> Ordering,
+    where
+        F: FnMut(&K, &V, &V) -> Ordering,
     {
         self.fold_first(|acc, key, val| match compare(key, &acc, &val) {
             Ordering::Less | Ordering::Equal => val,
-            Ordering::Greater => acc
+            Ordering::Greater => acc,
         })
     }
 
     /// Groups elements from the `GroupingMap` source by key and finds the element of each group
     /// that gives the maximum from the specified function.
-    /// 
+    ///
     /// If several elements are equally maximum, the last element is picked.
-    /// 
+    ///
     /// Returns a `HashMap` associating the key of each group with the maximum of that group's elements.
-    /// 
+    ///
     /// ```
     /// use itertools::Itertools;
-    /// 
+    ///
     /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
     ///     .into_grouping_map_by(|&n| n % 3)
     ///     .max_by_key(|_key, &val| val % 4);
-    /// 
+    ///
     /// assert_eq!(lookup[&0], 3);
     /// assert_eq!(lookup[&1], 7);
     /// assert_eq!(lookup[&2], 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn max_by_key<F, CK>(self, mut f: F) -> HashMap<K, V>
-        where F: FnMut(&K, &V) -> CK,
-              CK: Ord,
+    where
+        F: FnMut(&K, &V) -> CK,
+        CK: Ord,
     {
-        self.max_by(|key, v1, v2| f(key, &v1).cmp(&f(key, &v2)))
+        self.max_by(|key, v1, v2| f(key, v1).cmp(&f(key, v2)))
     }
 
     /// Groups elements from the `GroupingMap` source by key and finds the minimum of each group.
-    /// 
+    ///
     /// If several elements are equally minimum, the first element is picked.
-    /// 
+    ///
     /// Returns a `HashMap` associating the key of each group with the minimum of that group's elements.
-    /// 
+    ///
     /// ```
     /// use itertools::Itertools;
-    /// 
+    ///
     /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
     ///     .into_grouping_map_by(|&n| n % 3)
     ///     .min();
-    /// 
+    ///
     /// assert_eq!(lookup[&0], 3);
     /// assert_eq!(lookup[&1], 1);
     /// assert_eq!(lookup[&2], 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn min(self) -> HashMap<K, V>
-        where V: Ord,
+    where
+        V: Ord,
     {
         self.min_by(|_, v1, v2| V::cmp(v1, v2))
     }
 
     /// Groups elements from the `GroupingMap` source by key and finds the minimum of each group
     /// with respect to the specified comparison function.
-    /// 
+    ///
     /// If several elements are equally minimum, the first element is picked.
-    /// 
+    ///
     /// Returns a `HashMap` associating the key of each group with the minimum of that group's elements.
-    /// 
+    ///
     /// ```
     /// use itertools::Itertools;
-    /// 
+    ///
     /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
     ///     .into_grouping_map_by(|&n| n % 3)
     ///     .min_by(|_key, x, y| y.cmp(x));
-    /// 
+    ///
     /// assert_eq!(lookup[&0], 12);
     /// assert_eq!(lookup[&1], 7);
     /// assert_eq!(lookup[&2], 8);
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn min_by<F>(self, mut compare: F) -> HashMap<K, V>
-        where F: FnMut(&K, &V, &V) -> Ordering,
+    where
+        F: FnMut(&K, &V, &V) -> Ordering,
     {
         self.fold_first(|acc, key, val| match compare(key, &acc, &val) {
             Ordering::Less | Ordering::Equal => acc,
-            Ordering::Greater => val
+            Ordering::Greater => val,
         })
     }
 
     /// Groups elements from the `GroupingMap` source by key and finds the element of each group
     /// that gives the minimum from the specified function.
-    /// 
+    ///
     /// If several elements are equally minimum, the first element is picked.
-    /// 
+    ///
     /// Returns a `HashMap` associating the key of each group with the minimum of that group's elements.
-    /// 
+    ///
     /// ```
     /// use itertools::Itertools;
-    /// 
+    ///
     /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
     ///     .into_grouping_map_by(|&n| n % 3)
     ///     .min_by_key(|_key, &val| val % 4);
-    /// 
+    ///
     /// assert_eq!(lookup[&0], 12);
     /// assert_eq!(lookup[&1], 4);
     /// assert_eq!(lookup[&2], 8);
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn min_by_key<F, CK>(self, mut f: F) -> HashMap<K, V>
-        where F: FnMut(&K, &V) -> CK,
-              CK: Ord,
+    where
+        F: FnMut(&K, &V) -> CK,
+        CK: Ord,
     {
-        self.min_by(|key, v1, v2| f(key, &v1).cmp(&f(key, &v2)))
+        self.min_by(|key, v1, v2| f(key, v1).cmp(&f(key, v2)))
     }
 
     /// Groups elements from the `GroupingMap` source by key and find the maximum and minimum of
     /// each group.
-    /// 
+    ///
     /// If several elements are equally maximum, the last element is picked.
     /// If several elements are equally minimum, the first element is picked.
-    /// 
+    ///
     /// See [.minmax()](crate::Itertools::minmax) for the non-grouping version.
-    /// 
+    ///
     /// Differences from the non grouping version:
     /// - It never produces a `MinMaxResult::NoElements`
     /// - It doesn't have any speedup
-    /// 
+    ///
     /// Returns a `HashMap` associating the key of each group with the minimum and maximum of that group's elements.
-    /// 
+    ///
     /// ```
     /// use itertools::Itertools;
     /// use itertools::MinMaxResult::{OneElement, MinMax};
-    /// 
+    ///
     /// let lookup = vec![1, 3, 4, 5, 7, 9, 12].into_iter()
     ///     .into_grouping_map_by(|&n| n % 3)
     ///     .minmax();
-    /// 
+    ///
     /// assert_eq!(lookup[&0], MinMax(3, 12));
     /// assert_eq!(lookup[&1], MinMax(1, 7));
     /// assert_eq!(lookup[&2], OneElement(5));
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn minmax(self) -> HashMap<K, MinMaxResult<V>>
-        where V: Ord,
+    where
+        V: Ord,
     {
         self.minmax_by(|_, v1, v2| V::cmp(v1, v2))
     }
 
     /// Groups elements from the `GroupingMap` source by key and find the maximum and minimum of
     /// each group with respect to the specified comparison function.
-    /// 
+    ///
     /// If several elements are equally maximum, the last element is picked.
     /// If several elements are equally minimum, the first element is picked.
-    /// 
+    ///
     /// It has the same differences from the non-grouping version as `minmax`.
-    /// 
+    ///
     /// Returns a `HashMap` associating the key of each group with the minimum and maximum of that group's elements.
-    /// 
+    ///
     /// ```
     /// use itertools::Itertools;
     /// use itertools::MinMaxResult::{OneElement, MinMax};
-    /// 
+    ///
     /// let lookup = vec![1, 3, 4, 5, 7, 9, 12].into_iter()
     ///     .into_grouping_map_by(|&n| n % 3)
     ///     .minmax_by(|_key, x, y| y.cmp(x));
-    /// 
+    ///
     /// assert_eq!(lookup[&0], MinMax(12, 3));
     /// assert_eq!(lookup[&1], MinMax(7, 1));
     /// assert_eq!(lookup[&2], OneElement(5));
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn minmax_by<F>(self, mut compare: F) -> HashMap<K, MinMaxResult<V>>
-        where F: FnMut(&K, &V, &V) -> Ordering,
+    where
+        F: FnMut(&K, &V, &V) -> Ordering,
     {
         self.aggregate(|acc, key, val| {
             Some(match acc {
@@ -456,80 +474,83 @@ impl<I, K, V> GroupingMap<I>
 
     /// Groups elements from the `GroupingMap` source by key and find the elements of each group
     /// that gives the minimum and maximum from the specified function.
-    /// 
+    ///
     /// If several elements are equally maximum, the last element is picked.
     /// If several elements are equally minimum, the first element is picked.
-    /// 
+    ///
     /// It has the same differences from the non-grouping version as `minmax`.
-    /// 
+    ///
     /// Returns a `HashMap` associating the key of each group with the minimum and maximum of that group's elements.
-    /// 
+    ///
     /// ```
     /// use itertools::Itertools;
     /// use itertools::MinMaxResult::{OneElement, MinMax};
-    /// 
+    ///
     /// let lookup = vec![1, 3, 4, 5, 7, 9, 12].into_iter()
     ///     .into_grouping_map_by(|&n| n % 3)
     ///     .minmax_by_key(|_key, &val| val % 4);
-    /// 
+    ///
     /// assert_eq!(lookup[&0], MinMax(12, 3));
     /// assert_eq!(lookup[&1], MinMax(4, 7));
     /// assert_eq!(lookup[&2], OneElement(5));
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn minmax_by_key<F, CK>(self, mut f: F) -> HashMap<K, MinMaxResult<V>>
-        where F: FnMut(&K, &V) -> CK,
-              CK: Ord,
+    where
+        F: FnMut(&K, &V) -> CK,
+        CK: Ord,
     {
-        self.minmax_by(|key, v1, v2| f(key, &v1).cmp(&f(key, &v2)))
+        self.minmax_by(|key, v1, v2| f(key, v1).cmp(&f(key, v2)))
     }
-    
+
     /// Groups elements from the `GroupingMap` source by key and sums them.
-    /// 
+    ///
     /// This is just a shorthand for `self.fold_first(|acc, _, val| acc + val)`.
     /// It is more limited than `Iterator::sum` since it doesn't use the `Sum` trait.
-    /// 
+    ///
     /// Returns a `HashMap` associating the key of each group with the sum of that group's elements.
-    /// 
+    ///
     /// ```
     /// use itertools::Itertools;
-    /// 
+    ///
     /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
     ///     .into_grouping_map_by(|&n| n % 3)
     ///     .sum();
-    /// 
+    ///
     /// assert_eq!(lookup[&0], 3 + 9 + 12);
     /// assert_eq!(lookup[&1], 1 + 4 + 7);
     /// assert_eq!(lookup[&2], 5 + 8);
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn sum(self) -> HashMap<K, V>
-        where V: Add<V, Output = V>
+    where
+        V: Add<V, Output = V>,
     {
         self.fold_first(|acc, _, val| acc + val)
     }
 
     /// Groups elements from the `GroupingMap` source by key and multiply them.
-    /// 
+    ///
     /// This is just a shorthand for `self.fold_first(|acc, _, val| acc * val)`.
     /// It is more limited than `Iterator::product` since it doesn't use the `Product` trait.
-    /// 
+    ///
     /// Returns a `HashMap` associating the key of each group with the product of that group's elements.
-    /// 
+    ///
     /// ```
     /// use itertools::Itertools;
-    /// 
+    ///
     /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
     ///     .into_grouping_map_by(|&n| n % 3)
     ///     .product();
-    /// 
+    ///
     /// assert_eq!(lookup[&0], 3 * 9 * 12);
     /// assert_eq!(lookup[&1], 1 * 4 * 7);
     /// assert_eq!(lookup[&2], 5 * 8);
     /// assert_eq!(lookup.len(), 3);
     /// ```
     pub fn product(self) -> HashMap<K, V>
-        where V: Mul<V, Output = V>,
+    where
+        V: Mul<V, Output = V>,
     {
         self.fold_first(|acc, _, val| acc * val)
     }

--- a/src/intersperse.rs
+++ b/src/intersperse.rs
@@ -1,5 +1,5 @@
-use std::iter::{Fuse, FusedIterator};
 use super::size_hint;
+use std::iter::{Fuse, FusedIterator};
 
 pub trait IntersperseElement<Item> {
     fn generate(&mut self) -> Item;
@@ -26,12 +26,13 @@ pub type Intersperse<I> = IntersperseWith<I, IntersperseElementSimple<<I as Iter
 
 /// Create a new Intersperse iterator
 pub fn intersperse<I>(iter: I, elt: I::Item) -> Intersperse<I>
-    where I: Iterator,
+where
+    I: Iterator,
 {
     intersperse_with(iter, IntersperseElementSimple(elt))
 }
 
-impl<Item, F: FnMut()->Item> IntersperseElement<Item> for F {
+impl<Item, F: FnMut() -> Item> IntersperseElement<Item> for F {
     fn generate(&mut self) -> Item {
         self()
     }
@@ -48,7 +49,8 @@ impl<Item, F: FnMut()->Item> IntersperseElement<Item> for F {
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone, Debug)]
 pub struct IntersperseWith<I, ElemF>
-    where I: Iterator,
+where
+    I: Iterator,
 {
     element: ElemF,
     iter: Fuse<I>,
@@ -57,7 +59,8 @@ pub struct IntersperseWith<I, ElemF>
 
 /// Create a new IntersperseWith iterator
 pub fn intersperse_with<I, ElemF>(iter: I, elt: ElemF) -> IntersperseWith<I, ElemF>
-    where I: Iterator,
+where
+    I: Iterator,
 {
     let mut iter = iter.fuse();
     IntersperseWith {
@@ -68,8 +71,9 @@ pub fn intersperse_with<I, ElemF>(iter: I, elt: ElemF) -> IntersperseWith<I, Ele
 }
 
 impl<I, ElemF> Iterator for IntersperseWith<I, ElemF>
-    where I: Iterator,
-          ElemF: IntersperseElement<I::Item>
+where
+    I: Iterator,
+    ElemF: IntersperseElement<I::Item>,
 {
     type Item = I::Item;
     #[inline]
@@ -93,8 +97,10 @@ impl<I, ElemF> Iterator for IntersperseWith<I, ElemF>
         size_hint::add_scalar(size_hint::add(sh, sh), has_peek)
     }
 
-    fn fold<B, F>(mut self, init: B, mut f: F) -> B where
-        Self: Sized, F: FnMut(B, Self::Item) -> B,
+    fn fold<B, F>(mut self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
     {
         let mut accum = init;
 
@@ -104,16 +110,16 @@ impl<I, ElemF> Iterator for IntersperseWith<I, ElemF>
 
         let element = &mut self.element;
 
-        self.iter.fold(accum,
-            |accum, x| {
-                let accum = f(accum, element.generate());
-                let accum = f(accum, x);
-                accum
+        self.iter.fold(accum, |accum, x| {
+            let accum = f(accum, element.generate());
+            f(accum, x)
         })
     }
 }
 
 impl<I, ElemF> FusedIterator for IntersperseWith<I, ElemF>
-    where I: Iterator,
-          ElemF: IntersperseElement<I::Item>
-{}
+where
+    I: Iterator,
+    ElemF: IntersperseElement<I::Item>,
+{
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,7 @@ pub mod structs {
     #[cfg(feature = "use_alloc")]
     pub use crate::rciter_impl::RcIter;
     pub use crate::repeatn::RepeatN;
+    pub use crate::set_ops::{Intersection, UnionRef};
     #[allow(deprecated)]
     pub use crate::sources::{Iterate, RepeatCall, Unfold};
     #[cfg(feature = "use_alloc")]
@@ -209,13 +210,12 @@ mod put_back_n_impl;
 #[cfg(feature = "use_alloc")]
 mod rciter_impl;
 mod repeatn;
+mod set_ops;
 mod size_hint;
 mod sources;
 #[cfg(feature = "use_alloc")]
 mod tee;
 mod tuple_impl;
-#[cfg(feature = "use_std")]
-mod duplicates_impl;
 #[cfg(feature = "use_std")]
 mod unique_impl;
 mod with_position;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![warn(missing_docs)]
-#![crate_name="itertools"]
+#![crate_name = "itertools"]
 #![cfg_attr(not(feature = "use_std"), no_std)]
 
 //! Extra iterator adaptors, functions and macros.
@@ -43,7 +43,7 @@
 //! ## Rust Version
 //!
 //! This version of itertools requires Rust 1.32 or later.
-#![doc(html_root_url="https://docs.rs/itertools/0.8/")]
+#![doc(html_root_url = "https://docs.rs/itertools/0.8/")]
 
 #[cfg(not(feature = "use_std"))]
 extern crate core as std;
@@ -52,25 +52,22 @@ extern crate core as std;
 extern crate alloc;
 
 #[cfg(feature = "use_alloc")]
-use alloc::{
-    string::String,
-    vec::Vec,
-};
+use alloc::{string::String, vec::Vec};
 
 pub use either::Either;
 
 use core::borrow::Borrow;
+use std::cmp::Ordering;
 #[cfg(feature = "use_std")]
 use std::collections::HashMap;
-use std::iter::{IntoIterator, once};
-use std::cmp::Ordering;
-use std::fmt;
 #[cfg(feature = "use_std")]
 use std::collections::HashSet;
-#[cfg(feature = "use_std")]
-use std::hash::Hash;
+use std::fmt;
 #[cfg(feature = "use_alloc")]
 use std::fmt::Write;
+#[cfg(feature = "use_std")]
+use std::hash::Hash;
+use std::iter::{once, IntoIterator};
 #[cfg(feature = "use_alloc")]
 type VecIntoIter<T> = alloc::vec::IntoIter<T>;
 #[cfg(feature = "use_alloc")]
@@ -85,72 +82,54 @@ pub use std::iter as __std_iter;
 
 /// The concrete iterator types.
 pub mod structs {
+    #[cfg(feature = "use_alloc")]
+    pub use crate::adaptors::MultiProduct;
     pub use crate::adaptors::{
-        Dedup,
-        DedupBy,
-        DedupWithCount,
-        DedupByWithCount,
-        Interleave,
-        InterleaveShortest,
-        FilterMapOk,
-        FilterOk,
-        Product,
-        PutBack,
-        Batching,
-        MapInto,
-        MapOk,
-        Merge,
-        MergeBy,
-        TakeWhileRef,
-        WhileSome,
-        Coalesce,
-        TupleCombinations,
-        Positions,
-        Update,
+        Batching, Coalesce, Dedup, DedupBy, DedupByWithCount, DedupWithCount, FilterMapOk,
+        FilterOk, Interleave, InterleaveShortest, MapInto, MapOk, Merge, MergeBy, Positions,
+        Product, PutBack, TakeWhileRef, TupleCombinations, Update, WhileSome,
     };
     #[allow(deprecated)]
     pub use crate::adaptors::{MapResults, Step};
-    #[cfg(feature = "use_alloc")]
-    pub use crate::adaptors::MultiProduct;
     #[cfg(feature = "use_alloc")]
     pub use crate::combinations::Combinations;
     #[cfg(feature = "use_alloc")]
     pub use crate::combinations_with_replacement::CombinationsWithReplacement;
     pub use crate::cons_tuples_impl::ConsTuples;
+    #[cfg(feature = "use_std")]
+    pub use crate::duplicates_impl::{Duplicates, DuplicatesBy};
     pub use crate::exactly_one_err::ExactlyOneError;
-    pub use crate::format::{Format, FormatWith};
     pub use crate::flatten_ok::FlattenOk;
+    pub use crate::format::{Format, FormatWith};
+    #[cfg(feature = "use_alloc")]
+    pub use crate::groupbylazy::{Chunk, Chunks, Group, GroupBy, Groups, IntoChunks};
     #[cfg(feature = "use_std")]
     pub use crate::grouping_map::{GroupingMap, GroupingMapBy};
-    #[cfg(feature = "use_alloc")]
-    pub use crate::groupbylazy::{IntoChunks, Chunk, Chunks, GroupBy, Group, Groups};
     pub use crate::intersperse::{Intersperse, IntersperseWith};
     #[cfg(feature = "use_alloc")]
     pub use crate::kmerge_impl::{KMerge, KMergeBy};
     pub use crate::merge_join::MergeJoinBy;
     #[cfg(feature = "use_alloc")]
     pub use crate::multipeek_impl::MultiPeek;
+    pub use crate::pad_tail::PadUsing;
     #[cfg(feature = "use_alloc")]
     pub use crate::peek_nth::PeekNth;
-    pub use crate::pad_tail::PadUsing;
     pub use crate::peeking_take_while::PeekingTakeWhile;
     #[cfg(feature = "use_alloc")]
     pub use crate::permutations::Permutations;
-    pub use crate::process_results_impl::ProcessResults;
     #[cfg(feature = "use_alloc")]
     pub use crate::powerset::Powerset;
+    pub use crate::process_results_impl::ProcessResults;
     #[cfg(feature = "use_alloc")]
     pub use crate::put_back_n_impl::PutBackN;
     #[cfg(feature = "use_alloc")]
     pub use crate::rciter_impl::RcIter;
     pub use crate::repeatn::RepeatN;
     #[allow(deprecated)]
-    pub use crate::sources::{RepeatCall, Unfold, Iterate};
+    pub use crate::sources::{Iterate, RepeatCall, Unfold};
     #[cfg(feature = "use_alloc")]
     pub use crate::tee::Tee;
-    pub use crate::tuple_impl::{TupleBuffer, TupleWindows, CircularTupleWindows, Tuples};
-    #[cfg(feature = "use_std")]
-    pub use crate::duplicates_impl::{Duplicates, DuplicatesBy};
+    pub use crate::tuple_impl::{CircularTupleWindows, TupleBuffer, TupleWindows, Tuples};
     #[cfg(feature = "use_std")]
     pub use crate::unique_impl::{Unique, UniqueBy};
     pub use crate::with_position::WithPosition;
@@ -164,20 +143,20 @@ pub mod traits {
     pub use crate::tuple_impl::HomogeneousTuple;
 }
 
-#[allow(deprecated)]
-pub use crate::structs::*;
 pub use crate::concat_impl::concat;
 pub use crate::cons_tuples_impl::cons_tuples;
 pub use crate::diff::diff_with;
 pub use crate::diff::Diff;
 #[cfg(feature = "use_alloc")]
-pub use crate::kmerge_impl::{kmerge_by};
+pub use crate::kmerge_impl::kmerge_by;
 pub use crate::minmax::MinMaxResult;
 pub use crate::peeking_take_while::PeekingNext;
 pub use crate::process_results_impl::process_results;
 pub use crate::repeatn::repeat_n;
 #[allow(deprecated)]
-pub use crate::sources::{repeat_call, unfold, iterate};
+pub use crate::sources::{iterate, repeat_call, unfold};
+#[allow(deprecated)]
+pub use crate::structs::*;
 pub use crate::with_position::Position;
 pub use crate::ziptuple::multizip;
 mod adaptors;
@@ -187,22 +166,24 @@ pub use crate::either_or_both::EitherOrBoth;
 pub mod free;
 #[doc(inline)]
 pub use crate::free::*;
-mod concat_impl;
-mod cons_tuples_impl;
 #[cfg(feature = "use_alloc")]
 mod combinations;
 #[cfg(feature = "use_alloc")]
 mod combinations_with_replacement;
-mod exactly_one_err;
+mod concat_impl;
+mod cons_tuples_impl;
 mod diff;
+#[cfg(feature = "use_std")]
+mod duplicates_impl;
+mod exactly_one_err;
 mod flatten_ok;
 mod format;
-#[cfg(feature = "use_std")]
-mod grouping_map;
 #[cfg(feature = "use_alloc")]
 mod group_map;
 #[cfg(feature = "use_alloc")]
 mod groupbylazy;
+#[cfg(feature = "use_std")]
+mod grouping_map;
 mod intersperse;
 #[cfg(feature = "use_alloc")]
 mod k_smallest;
@@ -424,7 +405,7 @@ macro_rules! chain {
 /// return a regular value of some other kind.
 /// [`.next_tuple()`](Itertools::next_tuple) is an example and the first regular
 /// method in the list.
-pub trait Itertools : Iterator {
+pub trait Itertools: Iterator {
     // adaptors
 
     /// Alternate elements from two iterators until both have run out.
@@ -440,8 +421,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![1, -1, 2, -2, 3, 4, 5, 6]);
     /// ```
     fn interleave<J>(self, other: J) -> Interleave<Self, J::IntoIter>
-        where J: IntoIterator<Item = Self::Item>,
-              Self: Sized
+    where
+        J: IntoIterator<Item = Self::Item>,
+        Self: Sized,
     {
         interleave(self, other)
     }
@@ -458,8 +440,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![1, -1, 2, -2, 3]);
     /// ```
     fn interleave_shortest<J>(self, other: J) -> InterleaveShortest<Self, J::IntoIter>
-        where J: IntoIterator<Item = Self::Item>,
-              Self: Sized
+    where
+        J: IntoIterator<Item = Self::Item>,
+        Self: Sized,
     {
         adaptors::interleave_shortest(self, other.into_iter())
     }
@@ -477,8 +460,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal((0..3).intersperse(8), vec![0, 8, 1, 8, 2]);
     /// ```
     fn intersperse(self, element: Self::Item) -> Intersperse<Self>
-        where Self: Sized,
-              Self::Item: Clone
+    where
+        Self: Sized,
+        Self::Item: Clone,
     {
         intersperse::intersperse(self, element)
     }
@@ -498,8 +482,9 @@ pub trait Itertools : Iterator {
     /// assert_eq!(i, 8);
     /// ```
     fn intersperse_with<F>(self, element: F) -> IntersperseWith<Self, F>
-        where Self: Sized,
-        F: FnMut() -> Self::Item
+    where
+        Self: Sized,
+        F: FnMut() -> Self::Item,
     {
         intersperse::intersperse_with(self, element)
     }
@@ -532,8 +517,9 @@ pub trait Itertools : Iterator {
     /// ```
     #[inline]
     fn zip_longest<J>(self, other: J) -> ZipLongest<Self, J::IntoIter>
-        where J: IntoIterator,
-              Self: Sized
+    where
+        J: IntoIterator,
+        Self: Sized,
     {
         zip_longest::zip_longest(self, other.into_iter())
     }
@@ -545,8 +531,9 @@ pub trait Itertools : Iterator {
     /// lengths.
     #[inline]
     fn zip_eq<J>(self, other: J) -> ZipEq<Self, J::IntoIter>
-        where J: IntoIterator,
-              Self: Sized
+    where
+        J: IntoIterator,
+        Self: Sized,
     {
         zip_eq(self, other)
     }
@@ -575,8 +562,9 @@ pub trait Itertools : Iterator {
     /// ```
     ///
     fn batching<B, F>(self, f: F) -> Batching<Self, F>
-        where F: FnMut(&mut Self) -> Option<B>,
-              Self: Sized
+    where
+        F: FnMut(&mut Self) -> Option<B>,
+        Self: Sized,
     {
         adaptors::batching(self, f)
     }
@@ -617,9 +605,10 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_alloc")]
     fn group_by<K, F>(self, key: F) -> GroupBy<K, Self, F>
-        where Self: Sized,
-              F: FnMut(&Self::Item) -> K,
-              K: PartialEq,
+    where
+        Self: Sized,
+        F: FnMut(&Self::Item) -> K,
+        K: PartialEq,
     {
         groupbylazy::new(self, key)
     }
@@ -653,7 +642,8 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_alloc")]
     fn chunks(self, size: usize) -> IntoChunks<Self>
-        where Self: Sized,
+    where
+        Self: Sized,
     {
         assert!(size != 0);
         groupbylazy::new_chunks(self, size)
@@ -693,9 +683,10 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![(1, 2, 3), (2, 3, 4)]);
     /// ```
     fn tuple_windows<T>(self) -> TupleWindows<Self, T>
-        where Self: Sized + Iterator<Item = T::Item>,
-              T: traits::HomogeneousTuple,
-              T::Item: Clone
+    where
+        Self: Sized + Iterator<Item = T::Item>,
+        T: traits::HomogeneousTuple,
+        T::Item: Clone,
     {
         tuple_impl::tuple_windows(self)
     }
@@ -728,9 +719,10 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![(1, 2, 3), (2, 3, 4), (3, 4, 1), (4, 1, 2)]);
     /// ```
     fn circular_tuple_windows<T>(self) -> CircularTupleWindows<Self, T>
-        where Self: Sized + Clone + Iterator<Item = T::Item> + ExactSizeIterator,
-              T: tuple_impl::TupleCollect + Clone,
-              T::Item: Clone
+    where
+        Self: Sized + Clone + Iterator<Item = T::Item> + ExactSizeIterator,
+        T: tuple_impl::TupleCollect + Clone,
+        T::Item: Clone,
     {
         tuple_impl::circular_tuple_windows(self)
     }
@@ -766,8 +758,9 @@ pub trait Itertools : Iterator {
     ///
     /// See also [`Tuples::into_buffer`].
     fn tuples<T>(self) -> Tuples<Self, T>
-        where Self: Sized + Iterator<Item = T::Item>,
-              T: traits::HomogeneousTuple
+    where
+        Self: Sized + Iterator<Item = T::Item>,
+        T: traits::HomogeneousTuple,
     {
         tuple_impl::tuples(self)
     }
@@ -791,8 +784,9 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_alloc")]
     fn tee(self) -> (Tee<Self>, Tee<Self>)
-        where Self: Sized,
-              Self::Item: Clone
+    where
+        Self: Sized,
+        Self::Item: Clone,
     {
         tee::new(self)
     }
@@ -813,10 +807,11 @@ pub trait Itertools : Iterator {
     /// let it = (0..8).step(3);
     /// itertools::assert_equal(it, vec![0, 3, 6]);
     /// ```
-    #[deprecated(note="Use std .step_by() instead", since="0.8.0")]
+    #[deprecated(note = "Use std .step_by() instead", since = "0.8.0")]
     #[allow(deprecated)]
     fn step(self, n: usize) -> Step<Self>
-        where Self: Sized
+    where
+        Self: Sized,
     {
         adaptors::step(self, n)
     }
@@ -829,17 +824,19 @@ pub trait Itertools : Iterator {
     /// (1i32..42i32).map_into::<f64>().collect_vec();
     /// ```
     fn map_into<R>(self) -> MapInto<Self, R>
-        where Self: Sized,
-              Self::Item: Into<R>,
+    where
+        Self: Sized,
+        Self::Item: Into<R>,
     {
         adaptors::map_into(self)
     }
 
     /// See [`.map_ok()`](Itertools::map_ok).
-    #[deprecated(note="Use .map_ok() instead", since="0.10.0")]
+    #[deprecated(note = "Use .map_ok() instead", since = "0.10.0")]
     fn map_results<F, T, U, E>(self, f: F) -> MapOk<Self, F>
-        where Self: Iterator<Item = Result<T, E>> + Sized,
-              F: FnMut(T) -> U,
+    where
+        Self: Iterator<Item = Result<T, E>> + Sized,
+        F: FnMut(T) -> U,
     {
         self.map_ok(f)
     }
@@ -856,8 +853,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![Ok(42), Err(false), Ok(12)]);
     /// ```
     fn map_ok<F, T, U, E>(self, f: F) -> MapOk<Self, F>
-        where Self: Iterator<Item = Result<T, E>> + Sized,
-              F: FnMut(T) -> U,
+    where
+        Self: Iterator<Item = Result<T, E>> + Sized,
+        F: FnMut(T) -> U,
     {
         adaptors::map_ok(self, f)
     }
@@ -874,8 +872,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![Ok(22), Err(false)]);
     /// ```
     fn filter_ok<F, T, E>(self, f: F) -> FilterOk<Self, F>
-        where Self: Iterator<Item = Result<T, E>> + Sized,
-              F: FnMut(&T) -> bool,
+    where
+        Self: Iterator<Item = Result<T, E>> + Sized,
+        F: FnMut(&T) -> bool,
     {
         adaptors::filter_ok(self, f)
     }
@@ -892,15 +891,16 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![Ok(44), Err(false)]);
     /// ```
     fn filter_map_ok<F, T, U, E>(self, f: F) -> FilterMapOk<Self, F>
-        where Self: Iterator<Item = Result<T, E>> + Sized,
-              F: FnMut(T) -> Option<U>,
+    where
+        Self: Iterator<Item = Result<T, E>> + Sized,
+        F: FnMut(T) -> Option<U>,
     {
         adaptors::filter_map_ok(self, f)
     }
 
     /// Return an iterator adaptor that flattens every `Result::Ok` value into
     /// a series of `Result::Ok` values. `Result::Err` values are unchanged.
-    /// 
+    ///
     /// This is useful when you have some common error type for your crate and
     /// need to propogate it upwards, but the `Result::Ok` case needs to be flattened.
     ///
@@ -910,14 +910,15 @@ pub trait Itertools : Iterator {
     /// let input = vec![Ok(0..2), Err(false), Ok(2..4)];
     /// let it = input.iter().cloned().flatten_ok();
     /// itertools::assert_equal(it.clone(), vec![Ok(0), Ok(1), Err(false), Ok(2), Ok(3)]);
-    /// 
+    ///
     /// // This can also be used to propogate errors when collecting.
     /// let output_result: Result<Vec<i32>, bool> = it.collect();
     /// assert_eq!(output_result, Err(false));
     /// ```
     fn flatten_ok<T, E>(self) -> FlattenOk<Self, T, E>
-        where Self: Iterator<Item = Result<T, E>> + Sized,
-              T: IntoIterator
+    where
+        Self: Iterator<Item = Result<T, E>> + Sized,
+        T: IntoIterator,
     {
         flatten_ok::flatten_ok(self)
     }
@@ -937,9 +938,10 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![0, 0, 3, 5, 6, 9, 10]);
     /// ```
     fn merge<J>(self, other: J) -> Merge<Self, J::IntoIter>
-        where Self: Sized,
-              Self::Item: PartialOrd,
-              J: IntoIterator<Item = Self::Item>
+    where
+        Self: Sized,
+        Self::Item: PartialOrd,
+        J: IntoIterator<Item = Self::Item>,
     {
         merge(self, other)
     }
@@ -961,9 +963,10 @@ pub trait Itertools : Iterator {
     /// ```
 
     fn merge_by<J, F>(self, other: J, is_first: F) -> MergeBy<Self, J::IntoIter, F>
-        where Self: Sized,
-              J: IntoIterator<Item = Self::Item>,
-              F: FnMut(&Self::Item, &Self::Item) -> bool
+    where
+        Self: Sized,
+        J: IntoIterator<Item = Self::Item>,
+        F: FnMut(&Self::Item, &Self::Item) -> bool,
     {
         adaptors::merge_by_new(self, other.into_iter(), is_first)
     }
@@ -997,9 +1000,10 @@ pub trait Itertools : Iterator {
     /// ```
     #[inline]
     fn merge_join_by<J, F>(self, other: J, cmp_fn: F) -> MergeJoinBy<Self, J::IntoIter, F>
-        where J: IntoIterator,
-              F: FnMut(&Self::Item, &J::Item) -> std::cmp::Ordering,
-              Self: Sized
+    where
+        J: IntoIterator,
+        F: FnMut(&Self::Item, &J::Item) -> std::cmp::Ordering,
+        Self: Sized,
     {
         merge_join_by(self, other, cmp_fn)
     }
@@ -1022,9 +1026,10 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_alloc")]
     fn kmerge(self) -> KMerge<<Self::Item as IntoIterator>::IntoIter>
-        where Self: Sized,
-              Self::Item: IntoIterator,
-              <Self::Item as IntoIterator>::Item: PartialOrd,
+    where
+        Self: Sized,
+        Self::Item: IntoIterator,
+        <Self::Item as IntoIterator>::Item: PartialOrd,
     {
         kmerge(self)
     }
@@ -1050,12 +1055,11 @@ pub trait Itertools : Iterator {
     /// assert_eq!(it.last(), Some(-7.));
     /// ```
     #[cfg(feature = "use_alloc")]
-    fn kmerge_by<F>(self, first: F)
-        -> KMergeBy<<Self::Item as IntoIterator>::IntoIter, F>
-        where Self: Sized,
-              Self::Item: IntoIterator,
-              F: FnMut(&<Self::Item as IntoIterator>::Item,
-                       &<Self::Item as IntoIterator>::Item) -> bool
+    fn kmerge_by<F>(self, first: F) -> KMergeBy<<Self::Item as IntoIterator>::IntoIter, F>
+    where
+        Self: Sized,
+        Self::Item: IntoIterator,
+        F: FnMut(&<Self::Item as IntoIterator>::Item, &<Self::Item as IntoIterator>::Item) -> bool,
     {
         kmerge_by(self, first)
     }
@@ -1072,10 +1076,11 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![(0, 'α'), (0, 'β'), (1, 'α'), (1, 'β')]);
     /// ```
     fn cartesian_product<J>(self, other: J) -> Product<Self, J::IntoIter>
-        where Self: Sized,
-              Self::Item: Clone,
-              J: IntoIterator,
-              J::IntoIter: Clone
+    where
+        Self: Sized,
+        Self::Item: Clone,
+        J: IntoIterator,
+        J::IntoIter: Clone,
     {
         adaptors::cartesian_product(self, other.into_iter())
     }
@@ -1107,10 +1112,11 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_alloc")]
     fn multi_cartesian_product(self) -> MultiProduct<<Self::Item as IntoIterator>::IntoIter>
-        where Self: Iterator + Sized,
-              Self::Item: IntoIterator,
-              <Self::Item as IntoIterator>::IntoIter: Clone,
-              <Self::Item as IntoIterator>::Item: Clone
+    where
+        Self: Iterator + Sized,
+        Self::Item: IntoIterator,
+        <Self::Item as IntoIterator>::IntoIter: Clone,
+        <Self::Item as IntoIterator>::Item: Clone,
     {
         adaptors::multi_cartesian_product(self)
     }
@@ -1144,9 +1150,9 @@ pub trait Itertools : Iterator {
     ///         vec![-6., 4., -1.]);
     /// ```
     fn coalesce<F>(self, f: F) -> Coalesce<Self, F>
-        where Self: Sized,
-              F: FnMut(Self::Item, Self::Item)
-                       -> Result<Self::Item, (Self::Item, Self::Item)>
+    where
+        Self: Sized,
+        F: FnMut(Self::Item, Self::Item) -> Result<Self::Item, (Self::Item, Self::Item)>,
     {
         adaptors::coalesce(self, f)
     }
@@ -1166,8 +1172,9 @@ pub trait Itertools : Iterator {
     ///                         vec![1., 2., 3., 2.]);
     /// ```
     fn dedup(self) -> Dedup<Self>
-        where Self: Sized,
-              Self::Item: PartialEq,
+    where
+        Self: Sized,
+        Self::Item: PartialEq,
     {
         adaptors::dedup(self)
     }
@@ -1188,8 +1195,9 @@ pub trait Itertools : Iterator {
     ///                         vec![(0, 1.), (0, 2.), (0, 3.), (1, 2.)]);
     /// ```
     fn dedup_by<Cmp>(self, cmp: Cmp) -> DedupBy<Self, Cmp>
-        where Self: Sized,
-              Cmp: FnMut(&Self::Item, &Self::Item)->bool,
+    where
+        Self: Sized,
+        Cmp: FnMut(&Self::Item, &Self::Item) -> bool,
     {
         adaptors::dedup_by(self, cmp)
     }
@@ -1256,8 +1264,9 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn duplicates(self) -> Duplicates<Self>
-        where Self: Sized,
-              Self::Item: Eq + Hash
+    where
+        Self: Sized,
+        Self::Item: Eq + Hash,
     {
         duplicates_impl::duplicates(self)
     }
@@ -1281,9 +1290,10 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn duplicates_by<V, F>(self, f: F) -> DuplicatesBy<Self, V, F>
-        where Self: Sized,
-              V: Eq + Hash,
-              F: FnMut(&Self::Item) -> V
+    where
+        Self: Sized,
+        V: Eq + Hash,
+        F: FnMut(&Self::Item) -> V,
     {
         duplicates_impl::duplicates_by(self, f)
     }
@@ -1308,8 +1318,9 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn unique(self) -> Unique<Self>
-        where Self: Sized,
-              Self::Item: Clone + Eq + Hash
+    where
+        Self: Sized,
+        Self::Item: Clone + Eq + Hash,
     {
         unique_impl::unique(self)
     }
@@ -1334,9 +1345,10 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn unique_by<V, F>(self, f: F) -> UniqueBy<Self, V, F>
-        where Self: Sized,
-              V: Eq + Hash,
-              F: FnMut(&Self::Item) -> V
+    where
+        Self: Sized,
+        V: Eq + Hash,
+        F: FnMut(&Self::Item) -> V,
     {
         unique_impl::unique_by(self, f)
     }
@@ -1354,8 +1366,9 @@ pub trait Itertools : Iterator {
     /// See also [`.take_while_ref()`](Itertools::take_while_ref)
     /// which is a similar adaptor.
     fn peeking_take_while<F>(&mut self, accept: F) -> PeekingTakeWhile<Self, F>
-        where Self: Sized + PeekingNext,
-              F: FnMut(&Self::Item) -> bool,
+    where
+        Self: Sized + PeekingNext,
+        F: FnMut(&Self::Item) -> bool,
     {
         peeking_take_while::peeking_take_while(self, accept)
     }
@@ -1379,8 +1392,9 @@ pub trait Itertools : Iterator {
     ///
     /// ```
     fn take_while_ref<F>(&mut self, accept: F) -> TakeWhileRef<Self, F>
-        where Self: Clone,
-              F: FnMut(&Self::Item) -> bool
+    where
+        Self: Clone,
+        F: FnMut(&Self::Item) -> bool,
     {
         adaptors::take_while_ref(self, accept)
     }
@@ -1400,7 +1414,8 @@ pub trait Itertools : Iterator {
     ///
     /// ```
     fn while_some<A>(self) -> WhileSome<Self>
-        where Self: Sized + Iterator<Item = Option<A>>
+    where
+        Self: Sized + Iterator<Item = Option<A>>,
     {
         adaptors::while_some(self)
     }
@@ -1439,9 +1454,10 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![(1, 2, 3), (1, 2, 4), (1, 3, 4), (2, 3, 4)]);
     /// ```
     fn tuple_combinations<T>(self) -> TupleCombinations<Self, T>
-        where Self: Sized + Clone,
-              Self::Item: Clone,
-              T: adaptors::HasCombination<Self>,
+    where
+        Self: Sized + Clone,
+        Self::Item: Clone,
+        T: adaptors::HasCombination<Self>,
     {
         adaptors::tuple_combinations(self)
     }
@@ -1477,8 +1493,9 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_alloc")]
     fn combinations(self, k: usize) -> Combinations<Self>
-        where Self: Sized,
-              Self::Item: Clone
+    where
+        Self: Sized,
+        Self::Item: Clone,
     {
         combinations::combinations(self, k)
     }
@@ -1550,8 +1567,9 @@ pub trait Itertools : Iterator {
     /// re-iterated if the permutations adaptor is completed and re-iterated.
     #[cfg(feature = "use_alloc")]
     fn permutations(self, k: usize) -> Permutations<Self>
-        where Self: Sized,
-              Self::Item: Clone
+    where
+        Self: Sized,
+        Self::Item: Clone,
     {
         permutations::permutations(self, k)
     }
@@ -1586,8 +1604,9 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_alloc")]
     fn powerset(self) -> Powerset<Self>
-        where Self: Sized,
-              Self::Item: Clone,
+    where
+        Self: Sized,
+        Self::Item: Clone,
     {
         powerset::powerset(self)
     }
@@ -1610,8 +1629,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![18, 16, 14, 12, 10, 4, 3, 2, 1, 0]);
     /// ```
     fn pad_using<F>(self, min: usize, f: F) -> PadUsing<Self, F>
-        where Self: Sized,
-              F: FnMut(usize) -> Self::Item
+    where
+        Self: Sized,
+        F: FnMut(usize) -> Self::Item,
     {
         pad_tail::pad_using(self, min, f)
     }
@@ -1636,7 +1656,8 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![Position::Only(0)]);
     /// ```
     fn with_position(self) -> WithPosition<Self>
-        where Self: Sized,
+    where
+        Self: Sized,
     {
         with_position::with_position(self)
     }
@@ -1655,8 +1676,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(data.iter().positions(|v| v % 2 == 1).rev(), vec![7, 6, 3, 2, 0]);
     /// ```
     fn positions<P>(self, predicate: P) -> Positions<Self, P>
-        where Self: Sized,
-              P: FnMut(Self::Item) -> bool,
+    where
+        Self: Sized,
+        P: FnMut(Self::Item) -> bool,
     {
         adaptors::positions(self, predicate)
     }
@@ -1672,8 +1694,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(it, vec![vec![1, 0], vec![3, 2, 1, 0]]);
     /// ```
     fn update<F>(self, updater: F) -> Update<Self, F>
-        where Self: Sized,
-              F: FnMut(&mut Self::Item),
+    where
+        Self: Sized,
+        F: FnMut(&mut Self::Item),
     {
         adaptors::update(self, updater)
     }
@@ -1693,8 +1716,9 @@ pub trait Itertools : Iterator {
     /// assert_eq!(Some((1, 2)), iter.next_tuple());
     /// ```
     fn next_tuple<T>(&mut self) -> Option<T>
-        where Self: Sized + Iterator<Item = T::Item>,
-              T: traits::HomogeneousTuple
+    where
+        Self: Sized + Iterator<Item = T::Item>,
+        T: traits::HomogeneousTuple,
     {
         T::collect_from_iter_no_buf(self)
     }
@@ -1718,18 +1742,18 @@ pub trait Itertools : Iterator {
     /// }
     /// ```
     fn collect_tuple<T>(mut self) -> Option<T>
-        where Self: Sized + Iterator<Item = T::Item>,
-              T: traits::HomogeneousTuple
+    where
+        Self: Sized + Iterator<Item = T::Item>,
+        T: traits::HomogeneousTuple,
     {
         match self.next_tuple() {
             elt @ Some(_) => match self.next() {
                 Some(_) => None,
                 None => elt,
             },
-            _ => None
+            _ => None,
         }
     }
-
 
     /// Find the position and value of the first element satisfying a predicate.
     ///
@@ -1742,14 +1766,13 @@ pub trait Itertools : Iterator {
     /// assert_eq!(text.chars().find_position(|ch| ch.is_lowercase()), Some((1, 'α')));
     /// ```
     fn find_position<P>(&mut self, mut pred: P) -> Option<(usize, Self::Item)>
-        where P: FnMut(&Self::Item) -> bool
+    where
+        P: FnMut(&Self::Item) -> bool,
     {
-        let mut index = 0usize;
-        for elt in self {
+        for (index, elt) in self.enumerate() {
             if pred(&elt) {
                 return Some((index, elt));
             }
-            index += 1;
         }
         None
     }
@@ -1766,12 +1789,20 @@ pub trait Itertools : Iterator {
     /// assert_eq!(std::iter::empty::<i32>().find_or_last(|&x| x > 5), None);
     /// ```
     fn find_or_last<P>(mut self, mut predicate: P) -> Option<Self::Item>
-        where Self: Sized,
-              P: FnMut(&Self::Item) -> bool,
+    where
+        Self: Sized,
+        P: FnMut(&Self::Item) -> bool,
     {
         let mut prev = None;
-        self.find_map(|x| if predicate(&x) { Some(x) } else { prev = Some(x); None })
-            .or(prev)
+        self.find_map(|x| {
+            if predicate(&x) {
+                Some(x)
+            } else {
+                prev = Some(x);
+                None
+            }
+        })
+        .or(prev)
     }
     /// Find the value of the first element satisfying a predicate or return the first element, if any.
     ///
@@ -1786,14 +1817,15 @@ pub trait Itertools : Iterator {
     /// assert_eq!(std::iter::empty::<i32>().find_or_first(|&x| x > 5), None);
     /// ```
     fn find_or_first<P>(mut self, mut predicate: P) -> Option<Self::Item>
-        where Self: Sized,
-              P: FnMut(&Self::Item) -> bool,
+    where
+        Self: Sized,
+        P: FnMut(&Self::Item) -> bool,
     {
         let first = self.next()?;
         Some(if predicate(&first) {
             first
         } else {
-            self.find(|x| predicate(&x)).unwrap_or(first)
+            self.find(|x| predicate(x)).unwrap_or(first)
         })
     }
     /// Returns `true` if the given item is present in this iterator.
@@ -1808,14 +1840,14 @@ pub trait Itertools : Iterator {
     ///
     /// #[derive(PartialEq, Debug)]
     /// enum Enum { A, B, C, D, E, }
-    /// 
+    ///
     /// let mut iter = vec![Enum::A, Enum::B, Enum::C, Enum::D].into_iter();
-    /// 
+    ///
     /// // search `iter` for `B`
     /// assert_eq!(iter.contains(&Enum::B), true);
     /// // `B` was found, so the iterator now rests at the item after `B` (i.e, `C`).
     /// assert_eq!(iter.next(), Some(Enum::C));
-    /// 
+    ///
     /// // search `iter` for `E`
     /// assert_eq!(iter.contains(&Enum::E), false);
     /// // `E` wasn't found, so `iter` is now exhausted
@@ -1847,8 +1879,9 @@ pub trait Itertools : Iterator {
     /// assert!(data.into_iter().all_equal());
     /// ```
     fn all_equal(&mut self) -> bool
-        where Self: Sized,
-              Self::Item: PartialEq,
+    where
+        Self: Sized,
+        Self::Item: PartialEq,
     {
         match self.next() {
             None => true,
@@ -1873,8 +1906,9 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn all_unique(&mut self) -> bool
-        where Self: Sized,
-              Self::Item: Eq + Hash
+    where
+        Self: Sized,
+        Self::Item: Eq + Hash,
     {
         let mut used = HashSet::new();
         self.all(move |elt| used.insert(elt))
@@ -1896,7 +1930,8 @@ pub trait Itertools : Iterator {
     /// *Fusing notes: if the iterator is exhausted by dropping,
     /// the result of calling `.next()` again depends on the iterator implementation.*
     fn dropping(mut self, n: usize) -> Self
-        where Self: Sized
+    where
+        Self: Sized,
     {
         if n > 0 {
             self.nth(n - 1);
@@ -1920,8 +1955,9 @@ pub trait Itertools : Iterator {
     /// itertools::assert_equal(init, vec![0, 3, 6]);
     /// ```
     fn dropping_back(mut self, n: usize) -> Self
-        where Self: Sized,
-              Self: DoubleEndedIterator
+    where
+        Self: Sized,
+        Self: DoubleEndedIterator,
     {
         if n > 0 {
             (&mut self).rev().nth(n - 1);
@@ -1946,10 +1982,11 @@ pub trait Itertools : Iterator {
     ///
     /// itertools::assert_equal(rx.iter(), vec![1, 3, 5, 7, 9]);
     /// ```
-    #[deprecated(note="Use .for_each() instead", since="0.8.0")]
+    #[deprecated(note = "Use .for_each() instead", since = "0.8.0")]
     fn foreach<F>(self, f: F)
-        where F: FnMut(Self::Item),
-              Self: Sized,
+    where
+        F: FnMut(Self::Item),
+        Self: Sized,
     {
         self.for_each(f)
     }
@@ -1968,8 +2005,10 @@ pub trait Itertools : Iterator {
     ///            vec![1, 2, 3, 4, 5, 6]);
     /// ```
     fn concat(self) -> Self::Item
-        where Self: Sized,
-              Self::Item: Extend<<<Self as Iterator>::Item as IntoIterator>::Item> + IntoIterator + Default
+    where
+        Self: Sized,
+        Self::Item:
+            Extend<<<Self as Iterator>::Item as IntoIterator>::Item> + IntoIterator + Default,
     {
         concat(self)
     }
@@ -1978,7 +2017,8 @@ pub trait Itertools : Iterator {
     /// for convenience.
     #[cfg(feature = "use_alloc")]
     fn collect_vec(self) -> Vec<Self::Item>
-        where Self: Sized
+    where
+        Self: Sized,
     {
         self.collect()
     }
@@ -2029,8 +2069,9 @@ pub trait Itertools : Iterator {
     /// ```
     #[inline]
     fn set_from<'a, A: 'a, J>(&mut self, from: J) -> usize
-        where Self: Iterator<Item = &'a mut A>,
-              J: IntoIterator<Item = A>
+    where
+        Self: Iterator<Item = &'a mut A>,
+        J: IntoIterator<Item = A>,
     {
         let mut count = 0;
         for elt in from {
@@ -2055,7 +2096,8 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_alloc")]
     fn join(&mut self, sep: &str) -> String
-        where Self::Item: std::fmt::Display
+    where
+        Self::Item: std::fmt::Display,
     {
         match self.next() {
             None => String::new(),
@@ -2089,7 +2131,8 @@ pub trait Itertools : Iterator {
     ///            "1.10, 2.72, -3.00");
     /// ```
     fn format(self, sep: &str) -> Format<Self>
-        where Self: Sized,
+    where
+        Self: Sized,
     {
         format::new_format_default(self, sep)
     }
@@ -2127,17 +2170,19 @@ pub trait Itertools : Iterator {
     ///
     /// ```
     fn format_with<F>(self, sep: &str, format: F) -> FormatWith<Self, F>
-        where Self: Sized,
-              F: FnMut(Self::Item, &mut dyn FnMut(&dyn fmt::Display) -> fmt::Result) -> fmt::Result,
+    where
+        Self: Sized,
+        F: FnMut(Self::Item, &mut dyn FnMut(&dyn fmt::Display) -> fmt::Result) -> fmt::Result,
     {
         format::new_format(self, sep, format)
     }
 
     /// See [`.fold_ok()`](Itertools::fold_ok).
-    #[deprecated(note="Use .fold_ok() instead", since="0.10.0")]
+    #[deprecated(note = "Use .fold_ok() instead", since = "0.10.0")]
     fn fold_results<A, E, B, F>(&mut self, start: B, f: F) -> Result<B, E>
-        where Self: Iterator<Item = Result<A, E>>,
-              F: FnMut(B, A) -> B
+    where
+        Self: Iterator<Item = Result<A, E>>,
+        F: FnMut(B, A) -> B,
     {
         self.fold_ok(start, f)
     }
@@ -2185,8 +2230,9 @@ pub trait Itertools : Iterator {
     /// );
     /// ```
     fn fold_ok<A, E, B, F>(&mut self, mut start: B, mut f: F) -> Result<B, E>
-        where Self: Iterator<Item = Result<A, E>>,
-              F: FnMut(B, A) -> B
+    where
+        Self: Iterator<Item = Result<A, E>>,
+        F: FnMut(B, A) -> B,
     {
         for elt in self {
             match elt {
@@ -2217,8 +2263,9 @@ pub trait Itertools : Iterator {
     /// assert_eq!(more_values.next().unwrap(), Some(0));
     /// ```
     fn fold_options<A, B, F>(&mut self, mut start: B, mut f: F) -> Option<B>
-        where Self: Iterator<Item = Option<A>>,
-              F: FnMut(B, A) -> B
+    where
+        Self: Iterator<Item = Option<A>>,
+        F: FnMut(B, A) -> B,
     {
         for elt in self {
             match elt {
@@ -2242,8 +2289,9 @@ pub trait Itertools : Iterator {
     /// assert_eq!((0..0).fold1(|x, y| x * y), None);
     /// ```
     fn fold1<F>(mut self, f: F) -> Option<Self::Item>
-        where F: FnMut(Self::Item, Self::Item) -> Self::Item,
-              Self: Sized,
+    where
+        F: FnMut(Self::Item, Self::Item) -> Self::Item,
+        Self: Sized,
     {
         self.next().map(move |x| self.fold(x, f))
     }
@@ -2297,44 +2345,48 @@ pub trait Itertools : Iterator {
     ///     (0..10).fold1(|x, y| x - y));
     /// ```
     fn tree_fold1<F>(mut self, mut f: F) -> Option<Self::Item>
-        where F: FnMut(Self::Item, Self::Item) -> Self::Item,
-              Self: Sized,
+    where
+        F: FnMut(Self::Item, Self::Item) -> Self::Item,
+        Self: Sized,
     {
         type State<T> = Result<T, Option<T>>;
 
         fn inner0<T, II, FF>(it: &mut II, f: &mut FF) -> State<T>
-            where
-                II: Iterator<Item = T>,
-                FF: FnMut(T, T) -> T
+        where
+            II: Iterator<Item = T>,
+            FF: FnMut(T, T) -> T,
         {
             // This function could be replaced with `it.next().ok_or(None)`,
             // but half the useful tree_fold1 work is combining adjacent items,
             // so put that in a form that LLVM is more likely to optimize well.
 
-            let a =
-                if let Some(v) = it.next() { v }
-                else { return Err(None) };
-            let b =
-                if let Some(v) = it.next() { v }
-                else { return Err(Some(a)) };
+            let a = if let Some(v) = it.next() {
+                v
+            } else {
+                return Err(None);
+            };
+            let b = if let Some(v) = it.next() {
+                v
+            } else {
+                return Err(Some(a));
+            };
             Ok(f(a, b))
         }
 
         fn inner<T, II, FF>(stop: usize, it: &mut II, f: &mut FF) -> State<T>
-            where
-                II: Iterator<Item = T>,
-                FF: FnMut(T, T) -> T
+        where
+            II: Iterator<Item = T>,
+            FF: FnMut(T, T) -> T,
         {
             let mut x = inner0(it, f)?;
             for height in 0..stop {
                 // Try to get another tree the same size with which to combine it,
                 // creating a new tree that's twice as big for next time around.
-                let next =
-                    if height == 0 {
-                        inner0(it, f)
-                    } else {
-                        inner(height, it, f)
-                    };
+                let next = if height == 0 {
+                    inner0(it, f)
+                } else {
+                    inner(height, it, f)
+                };
                 match next {
                     Ok(y) => x = f(x, y),
 
@@ -2395,19 +2447,19 @@ pub trait Itertools : Iterator {
     /// `fold()` called the provided closure for every item of the callee iterator,
     /// `fold_while()` actually stopped iterating as soon as it encountered `Fold::Done(_)`.
     fn fold_while<B, F>(&mut self, init: B, mut f: F) -> FoldWhile<B>
-        where Self: Sized,
-              F: FnMut(B, Self::Item) -> FoldWhile<B>
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> FoldWhile<B>,
     {
-        use Result::{
-            Ok as Continue,
-            Err as Break,
-        };
+        use Result::{Err as Break, Ok as Continue};
 
-        let result = self.try_fold(init, #[inline(always)] |acc, v|
-            match f(acc, v) {
-              FoldWhile::Continue(acc) => Continue(acc),
-              FoldWhile::Done(acc) => Break(acc),
-            }
+        let result = self.try_fold(
+            init,
+            #[inline(always)]
+            |acc, v| match f(acc, v) {
+                FoldWhile::Continue(acc) => Continue(acc),
+                FoldWhile::Done(acc) => Break(acc),
+            },
         );
 
         match result {
@@ -2438,11 +2490,11 @@ pub trait Itertools : Iterator {
     /// assert_eq!(nonempty_sum, Some(55));
     /// ```
     fn sum1<S>(mut self) -> Option<S>
-        where Self: Sized,
-              S: std::iter::Sum<Self::Item>,
+    where
+        Self: Sized,
+        S: std::iter::Sum<Self::Item>,
     {
-        self.next()
-            .map(|first| once(first).chain(self).sum())
+        self.next().map(|first| once(first).chain(self).sum())
     }
 
     /// Iterate over the entire iterator and multiply all the elements.
@@ -2466,11 +2518,11 @@ pub trait Itertools : Iterator {
     /// assert_eq!(nonempty_product, Some(3628800));
     /// ```
     fn product1<P>(mut self) -> Option<P>
-        where Self: Sized,
-              P: std::iter::Product<Self::Item>,
+    where
+        Self: Sized,
+        P: std::iter::Product<Self::Item>,
     {
-        self.next()
-            .map(|first| once(first).chain(self).product())
+        self.next().map(|first| once(first).chain(self).product())
     }
 
     /// Sort all iterator elements into a new iterator in ascending order.
@@ -2492,12 +2544,13 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_alloc")]
     fn sorted_unstable(self) -> VecIntoIter<Self::Item>
-        where Self: Sized,
-              Self::Item: Ord
+    where
+        Self: Sized,
+        Self::Item: Ord,
     {
         // Use .sort_unstable() directly since it is not quite identical with
         // .sort_by(Ord::cmp)
-        let mut v = Vec::from_iter(self);
+        let mut v = self.collect::<Vec<_>>();
         v.sort_unstable();
         v.into_iter()
     }
@@ -2527,10 +2580,11 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_alloc")]
     fn sorted_unstable_by<F>(self, cmp: F) -> VecIntoIter<Self::Item>
-        where Self: Sized,
-              F: FnMut(&Self::Item, &Self::Item) -> Ordering,
+    where
+        Self: Sized,
+        F: FnMut(&Self::Item, &Self::Item) -> Ordering,
     {
-        let mut v = Vec::from_iter(self);
+        let mut v = self.collect::<Vec<_>>();
         v.sort_unstable_by(cmp);
         v.into_iter()
     }
@@ -2560,11 +2614,12 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_alloc")]
     fn sorted_unstable_by_key<K, F>(self, f: F) -> VecIntoIter<Self::Item>
-        where Self: Sized,
-              K: Ord,
-              F: FnMut(&Self::Item) -> K,
+    where
+        Self: Sized,
+        K: Ord,
+        F: FnMut(&Self::Item) -> K,
     {
-        let mut v = Vec::from_iter(self);
+        let mut v = self.collect::<Vec<_>>();
         v.sort_unstable_by_key(f);
         v.into_iter()
     }
@@ -2588,12 +2643,13 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_alloc")]
     fn sorted(self) -> VecIntoIter<Self::Item>
-        where Self: Sized,
-              Self::Item: Ord
+    where
+        Self: Sized,
+        Self::Item: Ord,
     {
         // Use .sort() directly since it is not quite identical with
         // .sort_by(Ord::cmp)
-        let mut v = Vec::from_iter(self);
+        let mut v = self.collect::<Vec<_>>();
         v.sort();
         v.into_iter()
     }
@@ -2623,10 +2679,11 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_alloc")]
     fn sorted_by<F>(self, cmp: F) -> VecIntoIter<Self::Item>
-        where Self: Sized,
-              F: FnMut(&Self::Item, &Self::Item) -> Ordering,
+    where
+        Self: Sized,
+        F: FnMut(&Self::Item, &Self::Item) -> Ordering,
     {
-        let mut v = Vec::from_iter(self);
+        let mut v = self.collect::<Vec<_>>();
         v.sort_by(cmp);
         v.into_iter()
     }
@@ -2656,11 +2713,12 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_alloc")]
     fn sorted_by_key<K, F>(self, f: F) -> VecIntoIter<Self::Item>
-        where Self: Sized,
-              K: Ord,
-              F: FnMut(&Self::Item) -> K,
+    where
+        Self: Sized,
+        K: Ord,
+        F: FnMut(&Self::Item) -> K,
     {
-        let mut v = Vec::from_iter(self);
+        let mut v = self.collect::<Vec<_>>();
         v.sort_by_key(f);
         v.into_iter()
     }
@@ -2694,8 +2752,9 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_alloc")]
     fn k_smallest(self, k: usize) -> VecIntoIter<Self::Item>
-        where Self: Sized,
-              Self::Item: Ord
+    where
+        Self: Sized,
+        Self::Item: Ord,
     {
         crate::k_smallest::k_smallest(self, k)
             .into_sorted_vec()
@@ -2724,10 +2783,11 @@ pub trait Itertools : Iterator {
     /// assert_eq!(failures, [false, true]);
     /// ```
     fn partition_map<A, B, F, L, R>(self, mut predicate: F) -> (A, B)
-        where Self: Sized,
-              F: FnMut(Self::Item) -> Either<L, R>,
-              A: Default + Extend<L>,
-              B: Default + Extend<R>,
+    where
+        Self: Sized,
+        F: FnMut(Self::Item) -> Either<L, R>,
+        A: Default + Extend<L>,
+        B: Default + Extend<R>,
     {
         let mut left = A::default();
         let mut right = B::default();
@@ -2756,10 +2816,10 @@ pub trait Itertools : Iterator {
     /// assert_eq!(failures, [false, true]);
     /// ```
     fn partition_result<A, B, T, E>(self) -> (A, B)
-        where
-            Self: Iterator<Item = Result<T, E>> + Sized,
-            A: Default + Extend<T>,
-            B: Default + Extend<E>,
+    where
+        Self: Iterator<Item = Result<T, E>> + Sized,
+        A: Default + Extend<T>,
+        B: Default + Extend<E>,
     {
         self.partition_map(|r| match r {
             Ok(v) => Either::Left(v),
@@ -2783,8 +2843,9 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn into_group_map<K, V>(self) -> HashMap<K, Vec<V>>
-        where Self: Iterator<Item=(K, V)> + Sized,
-              K: Hash + Eq,
+    where
+        Self: Iterator<Item = (K, V)> + Sized,
+        K: Hash + Eq,
     {
         group_map::into_group_map(self)
     }
@@ -2818,44 +2879,46 @@ pub trait Itertools : Iterator {
     /// ```
     #[cfg(feature = "use_std")]
     fn into_group_map_by<K, V, F>(self, f: F) -> HashMap<K, Vec<V>>
-        where
-            Self: Iterator<Item=V> + Sized,
-            K: Hash + Eq,
-            F: Fn(&V) -> K,
+    where
+        Self: Iterator<Item = V> + Sized,
+        K: Hash + Eq,
+        F: Fn(&V) -> K,
     {
         group_map::into_group_map_by(self, f)
     }
 
-    /// Constructs a `GroupingMap` to be used later with one of the efficient 
+    /// Constructs a `GroupingMap` to be used later with one of the efficient
     /// group-and-fold operations it allows to perform.
-    /// 
+    ///
     /// The input iterator must yield item in the form of `(K, V)` where the
     /// value of type `K` will be used as key to identify the groups and the
     /// value of type `V` as value for the folding operation.
-    /// 
+    ///
     /// See [`GroupingMap`] for more informations
     /// on what operations are available.
     #[cfg(feature = "use_std")]
     fn into_grouping_map<K, V>(self) -> GroupingMap<Self>
-        where Self: Iterator<Item=(K, V)> + Sized,
-              K: Hash + Eq,
+    where
+        Self: Iterator<Item = (K, V)> + Sized,
+        K: Hash + Eq,
     {
         grouping_map::new(self)
     }
 
-    /// Constructs a `GroupingMap` to be used later with one of the efficient 
+    /// Constructs a `GroupingMap` to be used later with one of the efficient
     /// group-and-fold operations it allows to perform.
-    /// 
+    ///
     /// The values from this iterator will be used as values for the folding operation
     /// while the keys will be obtained from the values by calling `key_mapper`.
-    /// 
+    ///
     /// See [`GroupingMap`] for more informations
     /// on what operations are available.
     #[cfg(feature = "use_std")]
     fn into_grouping_map_by<K, V, F>(self, key_mapper: F) -> GroupingMapBy<Self, F>
-        where Self: Iterator<Item=V> + Sized,
-              K: Hash + Eq,
-              F: FnMut(&V) -> K
+    where
+        Self: Iterator<Item = V> + Sized,
+        K: Hash + Eq,
+        F: FnMut(&V) -> K,
     {
         grouping_map::new(grouping_map::MapForGrouping::new(self, key_mapper))
     }
@@ -2896,7 +2959,9 @@ pub trait Itertools : Iterator {
     /// The elements can be floats but no particular result is guaranteed
     /// if an element is NaN.
     fn minmax(self) -> MinMaxResult<Self::Item>
-        where Self: Sized, Self::Item: PartialOrd
+    where
+        Self: Sized,
+        Self::Item: PartialOrd,
     {
         minmax::minmax_impl(self, |_| (), |x, y, _, _| x < y)
     }
@@ -2913,7 +2978,10 @@ pub trait Itertools : Iterator {
     /// The keys can be floats but no particular result is guaranteed
     /// if a key is NaN.
     fn minmax_by_key<K, F>(self, key: F) -> MinMaxResult<Self::Item>
-        where Self: Sized, K: PartialOrd, F: FnMut(&Self::Item) -> K
+    where
+        Self: Sized,
+        K: PartialOrd,
+        F: FnMut(&Self::Item) -> K,
     {
         minmax::minmax_impl(self, key, |_, _, xk, yk| xk < yk)
     }
@@ -2927,13 +2995,11 @@ pub trait Itertools : Iterator {
     /// the last maximal element wins.  This matches the behavior of the standard
     /// [`Iterator::min`] and [`Iterator::max`] methods.
     fn minmax_by<F>(self, mut compare: F) -> MinMaxResult<Self::Item>
-        where Self: Sized, F: FnMut(&Self::Item, &Self::Item) -> Ordering
+    where
+        Self: Sized,
+        F: FnMut(&Self::Item, &Self::Item) -> Ordering,
     {
-        minmax::minmax_impl(
-            self,
-            |_| (),
-            |x, y, _, _| Ordering::Less == compare(x, y)
-        )
+        minmax::minmax_impl(self, |_| (), |x, y, _, _| Ordering::Less == compare(x, y))
     }
 
     /// Return the position of the maximum element in the iterator.
@@ -2956,7 +3022,9 @@ pub trait Itertools : Iterator {
     /// assert_eq!(a.iter().position_max(), Some(1));
     /// ```
     fn position_max(self) -> Option<usize>
-        where Self: Sized, Self::Item: Ord
+    where
+        Self: Sized,
+        Self::Item: Ord,
     {
         self.enumerate()
             .max_by(|x, y| Ord::cmp(&x.1, &y.1))
@@ -2984,7 +3052,10 @@ pub trait Itertools : Iterator {
     /// assert_eq!(a.iter().position_max_by_key(|x| x.abs()), Some(3));
     /// ```
     fn position_max_by_key<K, F>(self, mut key: F) -> Option<usize>
-        where Self: Sized, K: Ord, F: FnMut(&Self::Item) -> K
+    where
+        Self: Sized,
+        K: Ord,
+        F: FnMut(&Self::Item) -> K,
     {
         self.enumerate()
             .max_by(|x, y| Ord::cmp(&key(&x.1), &key(&y.1)))
@@ -3012,7 +3083,9 @@ pub trait Itertools : Iterator {
     /// assert_eq!(a.iter().position_max_by(|x, y| x.cmp(y)), Some(1));
     /// ```
     fn position_max_by<F>(self, mut compare: F) -> Option<usize>
-        where Self: Sized, F: FnMut(&Self::Item, &Self::Item) -> Ordering
+    where
+        Self: Sized,
+        F: FnMut(&Self::Item, &Self::Item) -> Ordering,
     {
         self.enumerate()
             .max_by(|x, y| compare(&x.1, &y.1))
@@ -3039,7 +3112,9 @@ pub trait Itertools : Iterator {
     /// assert_eq!(a.iter().position_min(), Some(2));
     /// ```
     fn position_min(self) -> Option<usize>
-        where Self: Sized, Self::Item: Ord
+    where
+        Self: Sized,
+        Self::Item: Ord,
     {
         self.enumerate()
             .min_by(|x, y| Ord::cmp(&x.1, &y.1))
@@ -3067,7 +3142,10 @@ pub trait Itertools : Iterator {
     /// assert_eq!(a.iter().position_min_by_key(|x| x.abs()), Some(0));
     /// ```
     fn position_min_by_key<K, F>(self, mut key: F) -> Option<usize>
-        where Self: Sized, K: Ord, F: FnMut(&Self::Item) -> K
+    where
+        Self: Sized,
+        K: Ord,
+        F: FnMut(&Self::Item) -> K,
     {
         self.enumerate()
             .min_by(|x, y| Ord::cmp(&key(&x.1), &key(&y.1)))
@@ -3095,7 +3173,9 @@ pub trait Itertools : Iterator {
     /// assert_eq!(a.iter().position_min_by(|x, y| x.cmp(y)), Some(2));
     /// ```
     fn position_min_by<F>(self, mut compare: F) -> Option<usize>
-        where Self: Sized, F: FnMut(&Self::Item, &Self::Item) -> Ordering
+    where
+        Self: Sized,
+        F: FnMut(&Self::Item, &Self::Item) -> Ordering,
     {
         self.enumerate()
             .min_by(|x, y| compare(&x.1, &y.1))
@@ -3145,9 +3225,11 @@ pub trait Itertools : Iterator {
     /// assert_eq!(a.iter().position_minmax(), MinMax(2, 1));
     /// ```
     fn position_minmax(self) -> MinMaxResult<usize>
-        where Self: Sized, Self::Item: PartialOrd
+    where
+        Self: Sized,
+        Self::Item: PartialOrd,
     {
-        use crate::MinMaxResult::{NoElements, OneElement, MinMax};
+        use crate::MinMaxResult::{MinMax, NoElements, OneElement};
         match minmax::minmax_impl(self.enumerate(), |_| (), |x, y, _, _| x.1 < y.1) {
             NoElements => NoElements,
             OneElement(x) => OneElement(x.0),
@@ -3190,9 +3272,12 @@ pub trait Itertools : Iterator {
     ///
     /// [`position_minmax`]: Self::position_minmax
     fn position_minmax_by_key<K, F>(self, mut key: F) -> MinMaxResult<usize>
-        where Self: Sized, K: PartialOrd, F: FnMut(&Self::Item) -> K
+    where
+        Self: Sized,
+        K: PartialOrd,
+        F: FnMut(&Self::Item) -> K,
     {
-        use crate::MinMaxResult::{NoElements, OneElement, MinMax};
+        use crate::MinMaxResult::{MinMax, NoElements, OneElement};
         match self.enumerate().minmax_by_key(|e| key(&e.1)) {
             NoElements => NoElements,
             OneElement(x) => OneElement(x.0),
@@ -3232,9 +3317,11 @@ pub trait Itertools : Iterator {
     ///
     /// [`position_minmax`]: Self::position_minmax
     fn position_minmax_by<F>(self, mut compare: F) -> MinMaxResult<usize>
-        where Self: Sized, F: FnMut(&Self::Item, &Self::Item) -> Ordering
+    where
+        Self: Sized,
+        F: FnMut(&Self::Item, &Self::Item) -> Ordering,
     {
-        use crate::MinMaxResult::{NoElements, OneElement, MinMax};
+        use crate::MinMaxResult::{MinMax, NoElements, OneElement};
         match self.enumerate().minmax_by(|x, y| compare(&x.1, &y.1)) {
             NoElements => NoElements,
             OneElement(x) => OneElement(x.0),
@@ -3264,16 +3351,13 @@ pub trait Itertools : Iterator {
         Self: Sized,
     {
         match self.next() {
-            Some(first) => {
-                match self.next() {
-                    Some(second) => {
-                        Err(ExactlyOneError::new(Some(Either::Left([first, second])), self))
-                    }
-                    None => {
-                        Ok(first)
-                    }
-                }
-            }
+            Some(first) => match self.next() {
+                Some(second) => Err(ExactlyOneError::new(
+                    Some(Either::Left([first, second])),
+                    self,
+                )),
+                None => Ok(first),
+            },
             None => Err(ExactlyOneError::new(None, self)),
         }
     }
@@ -3300,16 +3384,13 @@ pub trait Itertools : Iterator {
         Self: Sized,
     {
         match self.next() {
-            Some(first) => {
-                match self.next() {
-                    Some(second) => {
-                        Err(ExactlyOneError::new(Some(Either::Left([first, second])), self))
-                    }
-                    None => {
-                        Ok(Some(first))
-                    }
-                }
-            }
+            Some(first) => match self.next() {
+                Some(second) => Err(ExactlyOneError::new(
+                    Some(Either::Left([first, second])),
+                    self,
+                )),
+                None => Ok(Some(first)),
+            },
             None => Ok(None),
         }
     }
@@ -3371,7 +3452,7 @@ pub trait Itertools : Iterator {
     ///   first_name: &'static str,
     ///   last_name:  &'static str,
     /// }
-    /// 
+    ///
     /// let characters =
     ///     vec![
     ///         Character { first_name: "Amy",   last_name: "Pond"      },
@@ -3382,12 +3463,12 @@ pub trait Itertools : Iterator {
     ///         Character { first_name: "James", last_name: "Norington" },
     ///         Character { first_name: "James", last_name: "Kirk"      },
     ///     ];
-    /// 
-    /// let first_name_frequency = 
+    ///
+    /// let first_name_frequency =
     ///     characters
     ///         .into_iter()
     ///         .counts_by(|c| c.first_name);
-    ///     
+    ///
     /// assert_eq!(first_name_frequency["Amy"], 3);
     /// assert_eq!(first_name_frequency["James"], 4);
     /// assert_eq!(first_name_frequency.contains_key("Asha"), false);
@@ -3403,7 +3484,7 @@ pub trait Itertools : Iterator {
     }
 }
 
-impl<T: ?Sized> Itertools for T where T: Iterator { }
+impl<T: ?Sized> Itertools for T where T: Iterator {}
 
 /// Return `true` if both iterables produce equal sequences
 /// (elements pairwise equal and sequences of the same length),
@@ -3417,19 +3498,24 @@ impl<T: ?Sized> Itertools for T where T: Iterator { }
 /// assert!(!itertools::equal(&[0, 0], &[0, 0, 0]));
 /// ```
 pub fn equal<I, J>(a: I, b: J) -> bool
-    where I: IntoIterator,
-          J: IntoIterator,
-          I::Item: PartialEq<J::Item>
+where
+    I: IntoIterator,
+    J: IntoIterator,
+    I::Item: PartialEq<J::Item>,
 {
     let mut ia = a.into_iter();
     let mut ib = b.into_iter();
     loop {
         match ia.next() {
             Some(x) => match ib.next() {
-                Some(y) => if x != y { return false; },
+                Some(y) => {
+                    if x != y {
+                        return false;
+                    }
+                }
                 None => return false,
             },
-            None => return ib.next().is_none()
+            None => return ib.next().is_none(),
         }
     }
 }
@@ -3445,10 +3531,11 @@ pub fn equal<I, J>(a: I, b: J) -> bool
 /// // ^PANIC: panicked at 'Failed assertion Some("eed") == Some("ess") for iteration 1',
 /// ```
 pub fn assert_equal<I, J>(a: I, b: J)
-    where I: IntoIterator,
-          J: IntoIterator,
-          I::Item: fmt::Debug + PartialEq<J::Item>,
-          J::Item: fmt::Debug,
+where
+    I: IntoIterator,
+    J: IntoIterator,
+    I::Item: fmt::Debug + PartialEq<J::Item>,
+    J::Item: fmt::Debug,
 {
     let mut ia = a.into_iter();
     let mut ib = b.into_iter();
@@ -3461,8 +3548,13 @@ pub fn assert_equal<I, J>(a: I, b: J)
                     (&Some(ref a), &Some(ref b)) => a == b,
                     _ => false,
                 };
-                assert!(equal, "Failed assertion {a:?} == {b:?} for iteration {i}",
-                        i=i, a=a, b=b);
+                assert!(
+                    equal,
+                    "Failed assertion {a:?} == {b:?} for iteration {i}",
+                    i = i,
+                    a = a,
+                    b = b
+                );
                 i += 1;
             }
         }
@@ -3487,9 +3579,10 @@ pub fn assert_equal<I, J>(a: I, b: J)
 /// assert_eq!(split_index, 3);
 /// ```
 pub fn partition<'a, A: 'a, I, F>(iter: I, mut pred: F) -> usize
-    where I: IntoIterator<Item = &'a mut A>,
-          I::IntoIter: DoubleEndedIterator,
-          F: FnMut(&A) -> bool
+where
+    I: IntoIterator<Item = &'a mut A>,
+    I::IntoIter: DoubleEndedIterator,
+    F: FnMut(&A) -> bool,
 {
     let mut split_index = 0;
     let mut iter = iter.into_iter();
@@ -3497,10 +3590,12 @@ pub fn partition<'a, A: 'a, I, F>(iter: I, mut pred: F) -> usize
         if !pred(front) {
             loop {
                 match iter.next_back() {
-                    Some(back) => if pred(back) {
-                        std::mem::swap(front, back);
-                        break;
-                    },
+                    Some(back) => {
+                        if pred(back) {
+                            std::mem::swap(front, back);
+                            break;
+                        }
+                    }
                     None => break 'main,
                 }
             }

--- a/src/multipeek_impl.rs
+++ b/src/multipeek_impl.rs
@@ -1,12 +1,13 @@
-use std::iter::Fuse;
-use alloc::collections::VecDeque;
 use crate::size_hint;
 use crate::PeekingNext;
+use alloc::collections::VecDeque;
+use std::iter::Fuse;
 
 /// See [`multipeek()`] for more information.
 #[derive(Clone, Debug)]
 pub struct MultiPeek<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     iter: Fuse<I>,
     buf: VecDeque<I::Item>,
@@ -16,7 +17,8 @@ pub struct MultiPeek<I>
 /// An iterator adaptor that allows the user to peek at multiple `.next()`
 /// values without advancing the base iterator.
 pub fn multipeek<I>(iterable: I) -> MultiPeek<I::IntoIter>
-    where I: IntoIterator
+where
+    I: IntoIterator,
 {
     MultiPeek {
         iter: iterable.into_iter().fuse(),
@@ -26,7 +28,8 @@ pub fn multipeek<I>(iterable: I) -> MultiPeek<I::IntoIter>
 }
 
 impl<I> MultiPeek<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     /// Reset the peeking “cursor”
     pub fn reset_peek(&mut self) {
@@ -57,18 +60,22 @@ impl<I: Iterator> MultiPeek<I> {
 }
 
 impl<I> PeekingNext for MultiPeek<I>
-    where I: Iterator,
+where
+    I: Iterator,
 {
     fn peeking_next<F>(&mut self, accept: F) -> Option<Self::Item>
-        where F: FnOnce(&Self::Item) -> bool
+    where
+        F: FnOnce(&Self::Item) -> bool,
     {
         if self.buf.is_empty() {
             if let Some(r) = self.peek() {
-                if !accept(r) { return None }
+                if !accept(r) {
+                    return None;
+                }
             }
-        } else {
-            if let Some(r) = self.buf.get(0) {
-                if !accept(r) { return None }
+        } else if let Some(r) = self.buf.get(0) {
+            if !accept(r) {
+                return None;
             }
         }
         self.next()
@@ -76,7 +83,8 @@ impl<I> PeekingNext for MultiPeek<I>
 }
 
 impl<I> Iterator for MultiPeek<I>
-    where I: Iterator
+where
+    I: Iterator,
 {
     type Item = I::Item;
 
@@ -91,8 +99,4 @@ impl<I> Iterator for MultiPeek<I>
 }
 
 // Same size
-impl<I> ExactSizeIterator for MultiPeek<I>
-    where I: ExactSizeIterator
-{}
-
-
+impl<I> ExactSizeIterator for MultiPeek<I> where I: ExactSizeIterator {}

--- a/src/set_ops.rs
+++ b/src/set_ops.rs
@@ -1,0 +1,646 @@
+use std::{
+    cmp::{self, Ordering},
+    fmt,
+    iter::FusedIterator,
+};
+
+/// Core of an iterator that merges the output of two strictly ascending iterators,
+/// for instance a union or a symmetric difference.
+struct MergeIterInner<I: Iterator> {
+    a: I,
+    b: I,
+    peeked: Option<Peeked<I>>,
+}
+
+/// Benchmarks faster than wrapping both iterators in a Peekable,
+/// probably because we can afford to impose a FusedIterator bound.
+#[derive(Clone, Debug)]
+enum Peeked<I: Iterator> {
+    A(I::Item),
+    B(I::Item),
+}
+
+impl<I: Iterator> MergeIterInner<I> {
+    /// Creates a new core for an iterator merging a pair of sources.
+    pub fn new(a: I, b: I) -> Self {
+        MergeIterInner { a, b, peeked: None }
+    }
+
+    /// Returns the next pair of items stemming from the pair of sources
+    /// being merged. If both returned options contain a value, that value
+    /// is equal and occurs in both sources. If one of the returned options
+    /// contains a value, that value doesn't occur in the other source (or
+    /// the sources are not strictly ascending). If neither returned option
+    /// contains a value, iteration has finished and subsequent calls will
+    /// return the same empty pair.
+    pub fn nexts<Cmp: Fn(&I::Item, &I::Item) -> Ordering>(
+        &mut self,
+        cmp: Cmp,
+    ) -> (Option<I::Item>, Option<I::Item>)
+    where
+        I: FusedIterator,
+        I::Item: fmt::Debug,
+    {
+        let mut a_next;
+        let mut b_next;
+        match self.peeked.take() {
+            Some(Peeked::A(next)) => {
+                a_next = Some(next);
+                b_next = self.b.next();
+            }
+            Some(Peeked::B(next)) => {
+                b_next = Some(next);
+                a_next = self.a.next();
+            }
+            None => {
+                a_next = self.a.next();
+                b_next = self.b.next();
+            }
+        }
+        if let (Some(ref a1), Some(ref b1)) = (&a_next, &b_next) {
+            match cmp(a1, b1) {
+                Ordering::Less => self.peeked = b_next.take().map(Peeked::B),
+                Ordering::Greater => self.peeked = a_next.take().map(Peeked::A),
+                Ordering::Equal => (),
+            }
+        }
+        (a_next, b_next)
+    }
+
+    /// Returns a pair of upper bounds for the `size_hint` of the final iterator.
+    pub fn lens(&self) -> (usize, usize)
+    where
+        I: ExactSizeIterator,
+    {
+        match self.peeked {
+            Some(Peeked::A(_)) => (1 + self.a.len(), self.b.len()),
+            Some(Peeked::B(_)) => (self.a.len(), 1 + self.b.len()),
+            _ => (self.a.len(), self.b.len()),
+        }
+    }
+}
+
+impl<I> Clone for MergeIterInner<I>
+where
+    I: Iterator + Clone,
+    I::Item: Clone,
+{
+    clone_fields!(a, b, peeked);
+}
+
+impl<I> fmt::Debug for MergeIterInner<I>
+where
+    I: Iterator + fmt::Debug,
+    I::Item: fmt::Debug,
+{
+    debug_fmt_fields!(MergeIterInner, a, b, peeked);
+}
+
+/// An iterator adaptor that merge-joins items from the two base iterators in ascending order.
+///
+/// See [`.union_ref()`](crate::Itertools::union_ref) for more information.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct UnionRef<I: Iterator> {
+    inner: MergeIterInner<I>,
+}
+
+/// Return an iterator adaptor that merge-joins items from the two base iterators in ascending order.
+///
+/// See [`.union_ref()`](crate::Itertools::union_ref) for more information.
+pub fn union_ref<I>(left: I, right: I) -> UnionRef<I>
+where
+    I: Iterator,
+{
+    UnionRef {
+        inner: MergeIterInner::new(left, right),
+    }
+}
+
+impl<I> Clone for UnionRef<I>
+where
+    I: Iterator + Clone,
+    I::Item: Clone,
+{
+    clone_fields!(inner);
+}
+
+impl<I> fmt::Debug for UnionRef<I>
+where
+    I: Iterator + fmt::Debug,
+    I::Item: fmt::Debug,
+{
+    debug_fmt_fields!(UnionRef, inner);
+}
+
+impl<I> Iterator for UnionRef<I>
+where
+    I: Iterator + ExactSizeIterator + FusedIterator,
+    I::Item: Ord + fmt::Debug,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (a, b) = self.inner.nexts(Self::Item::cmp);
+        a.or(b)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (a_len, b_len) = self.inner.lens();
+        // We use checked add since we aren't guaranteed a set/map
+        // which have a storage limit of `usize::MAX / 2`.
+        (cmp::max(a_len, b_len), a_len.checked_add(b_len))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct DoubleEndedPeeker<I: Iterator> {
+    front_back: [Option<Option<I::Item>>; 2],
+    iter: I,
+}
+
+impl<I> DoubleEndedPeeker<I>
+where
+    I: Iterator + DoubleEndedIterator,
+    I::Item: Copy + fmt::Debug, // We have a &T
+{
+    fn new(iter: I) -> DoubleEndedPeeker<I> {
+        Self {
+            front_back: [None, None],
+            iter,
+        }
+    }
+
+    fn peek(&mut self) -> Option<I::Item> {
+        self.front_back[0]
+            .get_or_insert(self.iter.next())
+            .or_else(|| self.front_back[1].flatten())
+    }
+
+    fn peek_last(&mut self) -> Option<I::Item> {
+        self.front_back[1]
+            .get_or_insert(self.iter.next_back())
+            .or_else(|| self.front_back[0].flatten())
+    }
+
+    fn exact_len(&self) -> usize {
+        let (low, upper) = self.size_hint();
+        cmp::max(low, upper.unwrap_or_default())
+    }
+}
+
+impl<I: Iterator> Iterator for DoubleEndedPeeker<I> {
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.front_back {
+            [f @ Some(_), _] => f.take().flatten(),
+            [_, l @ Some(_)] => {
+                if let Some(n) = self.iter.next() {
+                    Some(n)
+                } else {
+                    l.take().flatten()
+                }
+            }
+            [None, None] => self.iter.next(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let peeked = {
+            let [f, b] = &self.front_back;
+            f.as_ref().map_or(0, |_| 1) + b.as_ref().map_or(0, |_| 1)
+        };
+        let (low, high) = self.iter.size_hint();
+        (low, high.map(|h| h + peeked))
+    }
+}
+
+impl<I: DoubleEndedIterator> DoubleEndedIterator for DoubleEndedPeeker<I> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match &mut self.front_back {
+            [_, l @ Some(_)] => l.take().flatten(),
+            [f @ Some(_), _] => {
+                if let Some(n) = self.iter.next_back() {
+                    Some(n)
+                } else {
+                    f.take().flatten()
+                }
+            }
+            [None, None] => self.iter.next_back(),
+        }
+    }
+}
+
+enum IntersectionInner<I: Iterator> {
+    Stitch {
+        // iterate similarly sized sets jointly, spotting matches along the way
+        left: DoubleEndedPeeker<I>,
+        right: DoubleEndedPeeker<I>,
+    },
+    Search {
+        // iterate a small set, look up in the large set
+        small: DoubleEndedPeeker<I>,
+        large: DoubleEndedPeeker<I>,
+    },
+    Answer(Option<I::Item>), // return a specific value or emptiness
+}
+
+impl<I> Clone for IntersectionInner<I>
+where
+    I: Iterator + Clone,
+    I::Item: Clone,
+{
+    fn clone(&self) -> Self {
+        match self {
+            IntersectionInner::Stitch { left, right } => IntersectionInner::Stitch {
+                left: left.clone(),
+                right: right.clone(),
+            },
+            IntersectionInner::Search { small, large } => IntersectionInner::Search {
+                small: small.clone(),
+                large: large.clone(),
+            },
+            IntersectionInner::Answer(answer) => IntersectionInner::Answer(answer.clone()),
+        }
+    }
+}
+
+impl<I> fmt::Debug for IntersectionInner<I>
+where
+    I: Iterator + fmt::Debug,
+    I::Item: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            IntersectionInner::Stitch { left, right } => f
+                .debug_struct("Stitch")
+                .field("left", left)
+                .field("right", right)
+                .finish(),
+            IntersectionInner::Search { small, large } => f
+                .debug_struct("Stitch")
+                .field("small", small)
+                .field("large", large)
+                .finish(),
+            IntersectionInner::Answer(iter) => f.debug_tuple("Answer").field(iter).finish(),
+        }
+    }
+}
+
+/// An iterator adaptor that merge-joins items from the two base iterators in ascending order.
+///
+/// See [`.intersection()`](crate::Itertools::intersection) for more information.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct Intersection<I: Iterator> {
+    inner: IntersectionInner<I>,
+}
+
+/// Return an iterator adaptor that contains items common to both `left` and `right`.
+///
+/// See [`.intersection()`](crate::Itertools::intersection) for more information.
+pub fn intersection<I>(left: I, right: I) -> Intersection<I>
+where
+    I: Iterator + DoubleEndedIterator + fmt::Debug,
+    I::Item: Ord + Copy + fmt::Debug, // Items should be `&T`
+{
+    let mut left = DoubleEndedPeeker::new(left);
+    let mut right = DoubleEndedPeeker::new(right);
+    let (small_cmp, large_cmp) = {
+        let (left_min, left_max) =
+            if let (Some(left_min), Some(left_max)) = (left.peek(), left.peek_last()) {
+                (left_min, left_max)
+            } else {
+                return Intersection {
+                    inner: IntersectionInner::Answer(None),
+                };
+            };
+        let (right_min, right_max) =
+            if let (Some(right_min), Some(right_max)) = (right.peek(), right.peek_last()) {
+                (right_min, right_max)
+            } else {
+                return Intersection {
+                    inner: IntersectionInner::Answer(None),
+                };
+            };
+        (left_min.cmp(&right_max), left_max.cmp(&right_min))
+    };
+    Intersection {
+        inner: match (small_cmp, large_cmp) {
+            (Ordering::Greater, _) | (_, Ordering::Less) => IntersectionInner::Answer(None),
+            (Ordering::Equal, _) => IntersectionInner::Answer(left.next()),
+            (_, Ordering::Equal) => IntersectionInner::Answer(left.last()),
+            _ if left.exact_len() <= right.exact_len() / 16 => IntersectionInner::Search {
+                small: left,
+                large: right,
+            },
+            _ => IntersectionInner::Stitch { left, right },
+        },
+    }
+}
+
+impl<I> Clone for Intersection<I>
+where
+    I: Iterator + Clone,
+    I::Item: Clone,
+{
+    clone_fields!(inner);
+}
+
+impl<I> fmt::Debug for Intersection<I>
+where
+    I: Iterator + fmt::Debug,
+    I::Item: fmt::Debug,
+{
+    debug_fmt_fields!(Intersection, inner);
+}
+
+impl<I> Iterator for Intersection<I>
+where
+    I: Iterator + FusedIterator,
+    I::Item: Ord,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.inner {
+            IntersectionInner::Stitch { left, right } => {
+                let mut a_next = left.next()?;
+                let mut b_next = right.next()?;
+                loop {
+                    match Self::Item::cmp(&a_next, &b_next) {
+                        Ordering::Less => a_next = left.next()?,
+                        Ordering::Greater => b_next = right.next()?,
+                        Ordering::Equal => return Some(a_next),
+                    }
+                }
+            }
+            IntersectionInner::Search { small, large } => loop {
+                let next = small.next()?;
+                if large.any(|b| next == b) {
+                    return Some(next);
+                }
+            },
+            IntersectionInner::Answer(answer) => answer.take(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match &self.inner {
+            IntersectionInner::Stitch { left, .. } => left.size_hint(),
+            IntersectionInner::Search { small, .. } => small.size_hint(),
+            IntersectionInner::Answer(None) => (0, Some(0)),
+            IntersectionInner::Answer(Some(_)) => (1, Some(1)),
+        }
+    }
+}
+
+enum DifferenceInner<I: Iterator> {
+    /// Iterate all of `left` and some of `right`, spotting matches along the way.
+    Stitch {
+        left_iter: DoubleEndedPeeker<I>,
+        right_iter: DoubleEndedPeeker<I>,
+    },
+    /// Iterate `left`, looking up if contained in `right`.
+    Search {
+        left_iter: DoubleEndedPeeker<I>,
+        right_iter: DoubleEndedPeeker<I>,
+    },
+    Iterate(DoubleEndedPeeker<I>), // simply produce all values in `left`
+}
+
+impl<I> Clone for DifferenceInner<I>
+where
+    I: Iterator + Clone,
+    I::Item: Clone,
+{
+    fn clone(&self) -> Self {
+        match self {
+            DifferenceInner::Stitch {
+                left_iter,
+                right_iter,
+            } => DifferenceInner::Stitch {
+                left_iter: left_iter.clone(),
+                right_iter: right_iter.clone(),
+            },
+            DifferenceInner::Search {
+                left_iter,
+                right_iter,
+            } => DifferenceInner::Search {
+                left_iter: left_iter.clone(),
+                right_iter: right_iter.clone(),
+            },
+            DifferenceInner::Iterate(iter) => DifferenceInner::Iterate(iter.clone()),
+        }
+    }
+}
+
+impl<I> fmt::Debug for DifferenceInner<I>
+where
+    I: Iterator + fmt::Debug,
+    I::Item: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DifferenceInner::Stitch {
+                left_iter,
+                right_iter,
+            } => f
+                .debug_struct("Stitch")
+                .field("left_iter", left_iter)
+                .field("right_iter", right_iter)
+                .finish(),
+            DifferenceInner::Search {
+                left_iter,
+                right_iter,
+            } => f
+                .debug_struct("Stitch")
+                .field("left_iter", left_iter)
+                .field("right_iter", right_iter)
+                .finish(),
+            DifferenceInner::Iterate(iter) => f.debug_tuple("Iterate").field(iter).finish(),
+        }
+    }
+}
+
+/// An iterator adaptor that returns the items that represent the difference.
+///
+/// See [`.difference()`](crate::Itertools::difference) for more information.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct Difference<I: Iterator> {
+    inner: DifferenceInner<I>,
+}
+
+/// Return an iterator adaptor that returns the items that represent the difference.
+///
+/// See [`.difference()`](crate::Itertools::difference) for more information.
+pub fn difference<I>(left: I, right: I) -> Difference<I>
+where
+    I: Iterator + DoubleEndedIterator,
+    I::Item: Ord + Copy + fmt::Debug, // The item should be a &T
+{
+    let mut left = DoubleEndedPeeker::new(left);
+    let mut right = DoubleEndedPeeker::new(right);
+    let (small_cmp, large_cmp) = {
+        let (left_min, left_max) =
+            if let (Some(left_min), Some(left_max)) = (left.peek(), left.peek_last()) {
+                (left_min, left_max)
+            } else {
+                return Difference {
+                    inner: DifferenceInner::Iterate(left),
+                };
+            };
+        let (right_min, right_max) =
+            if let (Some(right_min), Some(right_max)) = (right.peek(), right.peek_last()) {
+                (right_min, right_max)
+            } else {
+                return Difference {
+                    inner: DifferenceInner::Iterate(left),
+                };
+            };
+        (left_min.cmp(&right_max), left_max.cmp(&right_min))
+    };
+    Difference {
+        inner: match (small_cmp, large_cmp) {
+            (Ordering::Greater, _) | (_, Ordering::Less) => DifferenceInner::Iterate(left),
+            (Ordering::Equal, _) => {
+                left.next();
+                DifferenceInner::Iterate(left)
+            }
+            (_, Ordering::Equal) => {
+                left.next_back();
+                DifferenceInner::Iterate(left)
+            }
+            _ if dbg!(left.exact_len()) <= dbg!(right.exact_len() / 16) => {
+                DifferenceInner::Search {
+                    left_iter: left,
+                    right_iter: right,
+                }
+            }
+            _ => DifferenceInner::Stitch {
+                left_iter: left,
+                right_iter: right,
+            },
+        },
+    }
+}
+
+impl<I> Clone for Difference<I>
+where
+    I: Iterator + Clone,
+    I::Item: Clone,
+{
+    clone_fields!(inner);
+}
+
+impl<I> fmt::Debug for Difference<I>
+where
+    I: Iterator + fmt::Debug,
+    I::Item: fmt::Debug,
+{
+    debug_fmt_fields!(Difference, inner);
+}
+
+impl<I> Iterator for Difference<I>
+where
+    I: Iterator + DoubleEndedIterator + FusedIterator + fmt::Debug,
+    I::Item: Ord + Copy + fmt::Debug,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        println!("{:?}", self.inner);
+        match &mut self.inner {
+            DifferenceInner::Stitch {
+                left_iter,
+                right_iter,
+            } => {
+                let mut left_next = left_iter.next()?;
+                loop {
+                    match right_iter
+                        .peek()
+                        .map_or(Ordering::Less, |right_next| left_next.cmp(&right_next))
+                    {
+                        Ordering::Less => return Some(left_next),
+                        Ordering::Equal => {
+                            left_next = left_iter.next()?;
+                            right_iter.next();
+                        }
+                        Ordering::Greater => {
+                            right_iter.next();
+                        }
+                    }
+                }
+            }
+            DifferenceInner::Search {
+                left_iter,
+                right_iter,
+            } => loop {
+                let left_next = left_iter.next()?;
+                if !right_iter.any(|a| a == left_next) {
+                    return Some(left_next);
+                }
+            },
+            DifferenceInner::Iterate(iter) => iter.next(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (self_len, other_len) = match &self.inner {
+            DifferenceInner::Stitch {
+                left_iter,
+                right_iter,
+            } => (left_iter.exact_len(), right_iter.exact_len()),
+            DifferenceInner::Search {
+                left_iter,
+                right_iter: other_set,
+            } => (left_iter.exact_len(), other_set.exact_len()),
+            DifferenceInner::Iterate(iter) => (iter.exact_len(), 0),
+        };
+        (self_len.saturating_sub(other_len), Some(self_len))
+    }
+}
+
+/// An iterator adaptor that returns the values representing the symmetric difference.
+///
+/// See [`.symmetric_difference()`](crate::Itertools::symetric_difference) for more information.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct SymmetricDifference<I: Iterator> {
+    inner: MergeIterInner<I>,
+}
+
+/// Return an iterator adaptor that returns the values representing the symmetric difference.
+///
+/// See [`.symmetric_difference()`](crate::Itertools::symmetric_difference) for more information.
+pub fn symmetric_difference<I>(left: I, right: I) -> SymmetricDifference<I>
+where
+    I: Iterator,
+    I::Item: Ord,
+{
+    SymmetricDifference {
+        inner: MergeIterInner::new(left, right),
+    }
+}
+
+impl<I> Iterator for SymmetricDifference<I>
+where
+    I: Iterator + ExactSizeIterator + FusedIterator,
+    I::Item: Ord + fmt::Debug,
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let (a, b) = self.inner.nexts(Self::Item::cmp);
+            if a.as_ref().and(b.as_ref()).is_none() {
+                return a.or(b);
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (a, b) = self.inner.lens();
+        // We use checked add since we aren't guaranteed a set/map
+        // which have a storage limit of `usize::MAX / 2`.
+        (0, a.checked_add(b))
+    }
+}

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -1,8 +1,7 @@
-
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::collections::hash_map::{Entry};
-use std::hash::Hash;
 use std::fmt;
+use std::hash::Hash;
 use std::iter::FusedIterator;
 
 /// An iterator adapter to filter out duplicate elements.
@@ -18,17 +17,19 @@ pub struct UniqueBy<I: Iterator, V, F> {
 }
 
 impl<I, V, F> fmt::Debug for UniqueBy<I, V, F>
-    where I: Iterator + fmt::Debug,
-          V: fmt::Debug + Hash + Eq,
+where
+    I: Iterator + fmt::Debug,
+    V: fmt::Debug + Hash + Eq,
 {
     debug_fmt_fields!(UniqueBy, iter, used);
 }
 
 /// Create a new `UniqueBy` iterator.
 pub fn unique_by<I, V, F>(iter: I, f: F) -> UniqueBy<I, V, F>
-    where V: Eq + Hash,
-          F: FnMut(&I::Item) -> V,
-          I: Iterator,
+where
+    V: Eq + Hash,
+    F: FnMut(&I::Item) -> V,
+    I: Iterator,
 {
     UniqueBy {
         iter,
@@ -39,8 +40,9 @@ pub fn unique_by<I, V, F>(iter: I, f: F) -> UniqueBy<I, V, F>
 
 // count the number of new unique keys in iterable (`used` is the set already seen)
 fn count_new_keys<I, K>(mut used: HashMap<K, ()>, iterable: I) -> usize
-    where I: IntoIterator<Item=K>,
-          K: Hash + Eq,
+where
+    I: IntoIterator<Item = K>,
+    K: Hash + Eq,
 {
     let iter = iterable.into_iter();
     let current_used = used.len();
@@ -49,14 +51,15 @@ fn count_new_keys<I, K>(mut used: HashMap<K, ()>, iterable: I) -> usize
 }
 
 impl<I, V, F> Iterator for UniqueBy<I, V, F>
-    where I: Iterator,
-          V: Eq + Hash,
-          F: FnMut(&I::Item) -> V
+where
+    I: Iterator,
+    V: Eq + Hash,
+    F: FnMut(&I::Item) -> V,
 {
     type Item = I::Item;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(v) = self.iter.next() {
+        for v in &mut self.iter {
             let key = (self.f)(&v);
             if self.used.insert(key, ()).is_none() {
                 return Some(v);
@@ -78,9 +81,10 @@ impl<I, V, F> Iterator for UniqueBy<I, V, F>
 }
 
 impl<I, V, F> DoubleEndedIterator for UniqueBy<I, V, F>
-    where I: DoubleEndedIterator,
-          V: Eq + Hash,
-          F: FnMut(&I::Item) -> V
+where
+    I: DoubleEndedIterator,
+    V: Eq + Hash,
+    F: FnMut(&I::Item) -> V,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         while let Some(v) = self.iter.next_back() {
@@ -94,19 +98,22 @@ impl<I, V, F> DoubleEndedIterator for UniqueBy<I, V, F>
 }
 
 impl<I, V, F> FusedIterator for UniqueBy<I, V, F>
-    where I: FusedIterator,
-          V: Eq + Hash,
-          F: FnMut(&I::Item) -> V
-{}
+where
+    I: FusedIterator,
+    V: Eq + Hash,
+    F: FnMut(&I::Item) -> V,
+{
+}
 
 impl<I> Iterator for Unique<I>
-    where I: Iterator,
-          I::Item: Eq + Hash + Clone
+where
+    I: Iterator,
+    I::Item: Eq + Hash + Clone,
 {
     type Item = I::Item;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(v) = self.iter.iter.next() {
+        for v in &mut self.iter.iter {
             if let Entry::Vacant(entry) = self.iter.used.entry(v) {
                 let elt = entry.key().clone();
                 entry.insert(());
@@ -128,8 +135,9 @@ impl<I> Iterator for Unique<I>
 }
 
 impl<I> DoubleEndedIterator for Unique<I>
-    where I: DoubleEndedIterator,
-          I::Item: Eq + Hash + Clone
+where
+    I: DoubleEndedIterator,
+    I::Item: Eq + Hash + Clone,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         while let Some(v) = self.iter.iter.next_back() {
@@ -144,9 +152,11 @@ impl<I> DoubleEndedIterator for Unique<I>
 }
 
 impl<I> FusedIterator for Unique<I>
-    where I: FusedIterator,
-          I::Item: Eq + Hash + Clone
-{}
+where
+    I: FusedIterator,
+    I::Item: Eq + Hash + Clone,
+{
+}
 
 /// An iterator adapter to filter out duplicate elements.
 ///
@@ -158,21 +168,23 @@ pub struct Unique<I: Iterator> {
 }
 
 impl<I> fmt::Debug for Unique<I>
-    where I: Iterator + fmt::Debug,
-          I::Item: Hash + Eq + fmt::Debug,
+where
+    I: Iterator + fmt::Debug,
+    I::Item: Hash + Eq + fmt::Debug,
 {
     debug_fmt_fields!(Unique, iter);
 }
 
 pub fn unique<I>(iter: I) -> Unique<I>
-    where I: Iterator,
-          I::Item: Eq + Hash,
+where
+    I: Iterator,
+    I::Item: Eq + Hash,
 {
     Unique {
         iter: UniqueBy {
             iter,
             used: HashMap::new(),
             f: (),
-        }
+        },
     }
 }

--- a/tests/set_ops.rs
+++ b/tests/set_ops.rs
@@ -1,0 +1,95 @@
+use std::collections::BTreeSet;
+
+use itertools::free::{difference, intersection, symmetric_difference, union_ref};
+
+fn from_std<F: FnOnce(BTreeSet<u32>, &BTreeSet<u32>) -> Vec<u32>>(
+    left: &[u32],
+    right: &[u32],
+    meth: F,
+) -> Vec<u32> {
+    meth(
+        left.to_vec().into_iter().collect::<BTreeSet<_>>(),
+        &right.to_vec().into_iter().collect::<BTreeSet<_>>(),
+    )
+}
+
+#[test]
+fn right_only_union() {
+    let left: Vec<u32> = vec![];
+    let right: Vec<u32> = vec![1, 2, 3];
+    let expected_result = from_std(&left, &right, |l, r| l.union(r).copied().collect());
+    let actual_result = union_ref(left.iter(), right.iter())
+        .copied()
+        .collect::<Vec<_>>();
+    assert_eq!(expected_result, actual_result);
+}
+
+#[test]
+fn right_only_intersection() {
+    let left: Vec<u32> = vec![];
+    let right: Vec<u32> = vec![1, 2, 3];
+    let expected_result = from_std(&left, &right, |l, r| l.intersection(r).copied().collect());
+    let actual_result = intersection(left.iter(), right.iter())
+        .copied()
+        .collect::<Vec<_>>();
+    assert_eq!(expected_result, actual_result);
+}
+
+#[test]
+fn one_intersection() {
+    let left: Vec<u32> = vec![2];
+    let right: Vec<u32> = vec![1, 2, 3];
+    let expected_result = from_std(&left, &right, |l, r| l.intersection(r).copied().collect());
+    let actual_result = intersection(left.iter(), right.iter())
+        .copied()
+        .collect::<Vec<_>>();
+    assert_eq!(expected_result, actual_result);
+}
+
+#[test]
+fn right_only_difference() {
+    let left: Vec<u32> = vec![];
+    let right: Vec<u32> = vec![1, 2, 3];
+    let expected_result = from_std(&left, &right, |l, r| l.difference(r).copied().collect());
+    let actual_result = difference(left.iter(), right.iter())
+        .copied()
+        .collect::<Vec<_>>();
+    assert_eq!(expected_result, actual_result);
+}
+
+#[test]
+fn one_difference() {
+    let left: Vec<u32> = vec![2];
+    let right: Vec<u32> = vec![1, 2, 3];
+    let expected_result = from_std(&left, &right, |l, r| l.difference(r).copied().collect());
+    let actual_result = difference(left.iter(), right.iter())
+        .copied()
+        .collect::<Vec<_>>();
+    assert_eq!(expected_result, actual_result);
+}
+
+#[test]
+fn right_only_symmetric_difference() {
+    let left: Vec<u32> = vec![];
+    let right: Vec<u32> = vec![1, 2, 3];
+    let expected_result = from_std(&left, &right, |l, r| {
+        l.symmetric_difference(r).copied().collect()
+    });
+    let actual_result = symmetric_difference(left.iter(), right.iter())
+        .copied()
+        .collect::<Vec<_>>();
+    assert_eq!(expected_result, actual_result);
+}
+
+#[test]
+fn one_symmetric_difference() {
+    let left: Vec<u32> = vec![2];
+    let right: Vec<u32> = vec![1, 2, 3];
+    let expected_result = from_std(&left, &right, |l, r| {
+        l.symmetric_difference(r).copied().collect()
+    });
+    let actual_result = symmetric_difference(left.iter(), right.iter())
+        .copied()
+        .collect::<Vec<_>>();
+    assert_eq!(expected_result, actual_result);
+}

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -1,21 +1,25 @@
+use crate::it::cloned;
+use crate::it::free::put_back_n;
+use crate::it::free::rciter;
+use crate::it::iproduct;
+use crate::it::izip;
+use crate::it::multipeek;
+use crate::it::multizip;
+use crate::it::peek_nth;
+use crate::it::ExactlyOneError;
+use crate::it::FoldWhile;
+use crate::it::Itertools;
+use itertools as it;
 use paste;
 use permutohedron;
 use quickcheck as qc;
-use rand::{distributions::{Distribution, Standard}, Rng, SeedableRng, rngs::StdRng};
+use rand::{
+    distributions::{Distribution, Standard},
+    rngs::StdRng,
+    Rng, SeedableRng,
+};
 use rand::{seq::SliceRandom, thread_rng};
 use std::{cmp::min, fmt::Debug, marker::PhantomData};
-use itertools as it;
-use crate::it::Itertools;
-use crate::it::ExactlyOneError;
-use crate::it::multizip;
-use crate::it::multipeek;
-use crate::it::peek_nth;
-use crate::it::free::rciter;
-use crate::it::free::put_back_n;
-use crate::it::FoldWhile;
-use crate::it::cloned;
-use crate::it::iproduct;
-use crate::it::izip;
 
 #[test]
 fn product3() {
@@ -29,9 +33,7 @@ fn product3() {
             }
         }
     }
-    for (_, _, _, _) in iproduct!(0..3, 0..2, 0..2, 0..3) {
-        /* test compiles */
-    }
+    for (_, _, _, _) in iproduct!(0..3, 0..2, 0..2, 0..3) { /* test compiles */ }
 }
 
 #[test]
@@ -64,9 +66,15 @@ fn duplicates_by() {
     let xs = ["aaa", "bbbbb", "aa", "ccc", "bbbb", "aaaaa", "cccc"];
     let ys = ["aa", "bbbb", "cccc"];
     it::assert_equal(ys.iter(), xs.iter().duplicates_by(|x| x[..2].to_string()));
-    it::assert_equal(ys.iter(), xs.iter().rev().duplicates_by(|x| x[..2].to_string()).rev());
+    it::assert_equal(
+        ys.iter(),
+        xs.iter().rev().duplicates_by(|x| x[..2].to_string()).rev(),
+    );
     let ys_rev = ["ccc", "aa", "bbbbb"];
-    it::assert_equal(ys_rev.iter(), xs.iter().duplicates_by(|x| x[..2].to_string()).rev());
+    it::assert_equal(
+        ys_rev.iter(),
+        xs.iter().duplicates_by(|x| x[..2].to_string()).rev(),
+    );
 }
 
 #[test]
@@ -91,9 +99,15 @@ fn unique_by() {
     let xs = ["aaa", "bbbbb", "aa", "ccc", "bbbb", "aaaaa", "cccc"];
     let ys = ["aaa", "bbbbb", "ccc"];
     it::assert_equal(ys.iter(), xs.iter().unique_by(|x| x[..2].to_string()));
-    it::assert_equal(ys.iter(), xs.iter().rev().unique_by(|x| x[..2].to_string()).rev());
+    it::assert_equal(
+        ys.iter(),
+        xs.iter().rev().unique_by(|x| x[..2].to_string()).rev(),
+    );
     let ys_rev = ["cccc", "aaaaa", "bbbb"];
-    it::assert_equal(ys_rev.iter(), xs.iter().unique_by(|x| x[..2].to_string()).rev());
+    it::assert_equal(
+        ys_rev.iter(),
+        xs.iter().unique_by(|x| x[..2].to_string()).rev(),
+    );
 }
 
 #[test]
@@ -116,12 +130,12 @@ fn unique() {
 #[test]
 fn intersperse() {
     let xs = ["a", "", "b", "c"];
-    let v: Vec<&str> = xs.iter().map(|x| x.clone()).intersperse(", ").collect();
+    let v: Vec<&str> = xs.iter().copied().intersperse(", ").collect();
     let text: String = v.concat();
     assert_eq!(text, "a, , b, c".to_string());
 
     let ys = [0, 1, 2, 3];
-    let mut it = ys[..0].iter().map(|x| *x).intersperse(1);
+    let mut it = ys[..0].iter().copied().intersperse(1);
     assert!(it.next() == None);
 }
 
@@ -144,13 +158,13 @@ fn dedup() {
 #[test]
 fn coalesce() {
     let data = vec![-1., -2., -3., 3., 1., 0., -1.];
-    let it = data.iter().cloned().coalesce(|x, y|
+    let it = data.iter().cloned().coalesce(|x, y| {
         if (x >= 0.) == (y >= 0.) {
             Ok(x + y)
         } else {
             Err((x, y))
         }
-    );
+    });
     itertools::assert_equal(it.clone(), vec![-6., 4., -1.]);
     assert_eq!(
         it.fold(vec![], |mut v, n| {
@@ -163,17 +177,37 @@ fn coalesce() {
 
 #[test]
 fn dedup_by() {
-    let xs = [(0, 0), (0, 1), (1, 1), (2, 1), (0, 2), (3, 1), (0, 3), (1, 3)];
+    let xs = [
+        (0, 0),
+        (0, 1),
+        (1, 1),
+        (2, 1),
+        (0, 2),
+        (3, 1),
+        (0, 3),
+        (1, 3),
+    ];
     let ys = [(0, 0), (0, 1), (0, 2), (3, 1), (0, 3)];
-    it::assert_equal(ys.iter(), xs.iter().dedup_by(|x, y| x.1==y.1));
+    it::assert_equal(ys.iter(), xs.iter().dedup_by(|x, y| x.1 == y.1));
     let xs = [(0, 1), (0, 2), (0, 3), (0, 4), (0, 5)];
     let ys = [(0, 1)];
-    it::assert_equal(ys.iter(), xs.iter().dedup_by(|x, y| x.0==y.0));
+    it::assert_equal(ys.iter(), xs.iter().dedup_by(|x, y| x.0 == y.0));
 
-    let xs = [(0, 0), (0, 1), (1, 1), (2, 1), (0, 2), (3, 1), (0, 3), (1, 3)];
+    let xs = [
+        (0, 0),
+        (0, 1),
+        (1, 1),
+        (2, 1),
+        (0, 2),
+        (3, 1),
+        (0, 3),
+        (1, 3),
+    ];
     let ys = [(0, 0), (0, 1), (0, 2), (3, 1), (0, 3)];
     let mut xs_d = Vec::new();
-    xs.iter().dedup_by(|x, y| x.1==y.1).fold((), |(), &elt| xs_d.push(elt));
+    xs.iter()
+        .dedup_by(|x, y| x.1 == y.1)
+        .fold((), |(), &elt| xs_d.push(elt));
     assert_eq!(&xs_d, &ys);
 }
 
@@ -190,18 +224,38 @@ fn dedup_with_count() {
     it::assert_equal(ys.iter().cloned(), xs.iter().dedup_with_count());
 }
 
-
 #[test]
 fn dedup_by_with_count() {
-    let xs = [(0, 0), (0, 1), (1, 1), (2, 1), (0, 2), (3, 1), (0, 3), (1, 3)];
-    let ys = [(1, &(0, 0)), (3, &(0, 1)), (1, &(0, 2)), (1, &(3, 1)), (2, &(0, 3))];
+    let xs = [
+        (0, 0),
+        (0, 1),
+        (1, 1),
+        (2, 1),
+        (0, 2),
+        (3, 1),
+        (0, 3),
+        (1, 3),
+    ];
+    let ys = [
+        (1, &(0, 0)),
+        (3, &(0, 1)),
+        (1, &(0, 2)),
+        (1, &(3, 1)),
+        (2, &(0, 3)),
+    ];
 
-    it::assert_equal(ys.iter().cloned(), xs.iter().dedup_by_with_count(|x, y| x.1==y.1));
+    it::assert_equal(
+        ys.iter().cloned(),
+        xs.iter().dedup_by_with_count(|x, y| x.1 == y.1),
+    );
 
     let xs = [(0, 1), (0, 2), (0, 3), (0, 4), (0, 5)];
-    let ys = [( 5, &(0, 1))];
+    let ys = [(5, &(0, 1))];
 
-    it::assert_equal(ys.iter().cloned(), xs.iter().dedup_by_with_count(|x, y| x.0==y.0));
+    it::assert_equal(
+        ys.iter().cloned(),
+        xs.iter().dedup_by_with_count(|x, y| x.0 == y.0),
+    );
 }
 
 #[test]
@@ -235,7 +289,7 @@ fn test_put_back_n() {
 
 #[test]
 fn tee() {
-    let xs  = [0, 1, 2, 3];
+    let xs = [0, 1, 2, 3];
     let (mut t1, mut t2) = xs.iter().cloned().tee();
     assert_eq!(t1.next(), Some(0));
     assert_eq!(t2.next(), Some(0));
@@ -258,7 +312,6 @@ fn tee() {
     let (t1, t2) = xs.iter().cloned().tee();
     it::assert_equal(t1.zip(t2), xs.iter().cloned().zip(xs.iter().cloned()));
 }
-
 
 #[test]
 fn test_rciter() {
@@ -283,19 +336,19 @@ fn test_rciter() {
 #[allow(deprecated)]
 #[test]
 fn trait_pointers() {
-    struct ByRef<'r, I: ?Sized>(&'r mut I) ;
+    struct ByRef<'r, I: ?Sized>(&'r mut I);
 
-    impl<'r, X, I: ?Sized> Iterator for ByRef<'r, I> where
-        I: 'r + Iterator<Item=X>
+    impl<'r, X, I: ?Sized> Iterator for ByRef<'r, I>
+    where
+        I: 'r + Iterator<Item = X>,
     {
         type Item = X;
-        fn next(&mut self) -> Option<Self::Item>
-        {
+        fn next(&mut self) -> Option<Self::Item> {
             self.0.next()
         }
     }
 
-    let mut it = Box::new(0..10) as Box<dyn Iterator<Item=i32>>;
+    let mut it = Box::new(0..10) as Box<dyn Iterator<Item = i32>>;
     assert_eq!(it.next(), Some(0));
 
     {
@@ -315,9 +368,16 @@ fn trait_pointers() {
 
 #[test]
 fn merge_by() {
-    let odd : Vec<(u32, &str)> = vec![(1, "hello"), (3, "world"), (5, "!")];
+    let odd: Vec<(u32, &str)> = vec![(1, "hello"), (3, "world"), (5, "!")];
     let even = vec![(2, "foo"), (4, "bar"), (6, "baz")];
-    let expected = vec![(1, "hello"), (2, "foo"), (3, "world"), (4, "bar"), (5, "!"), (6, "baz")];
+    let expected = vec![
+        (1, "hello"),
+        (2, "foo"),
+        (3, "world"),
+        (4, "bar"),
+        (5, "!"),
+        (6, "baz"),
+    ];
     let results = odd.iter().merge_by(even.iter(), |a, b| a.0 <= b.0);
     it::assert_equal(results, expected.iter());
 }
@@ -331,7 +391,7 @@ fn merge_by_btree() {
     let mut bt2 = BTreeMap::new();
     bt2.insert("foo", 2);
     bt2.insert("bar", 4);
-    let results = bt1.into_iter().merge_by(bt2.into_iter(), |a, b| a.0 <= b.0 );
+    let results = bt1.into_iter().merge_by(bt2.into_iter(), |a, b| a.0 <= b.0);
     let expected = vec![("bar", 4), ("foo", 2), ("hello", 1), ("world", 3)];
     it::assert_equal(results, expected.into_iter());
 }
@@ -373,19 +433,17 @@ fn kmerge_empty_size_hint() {
 #[test]
 fn join() {
     let many = [1, 2, 3];
-    let one  = [1];
+    let one = [1];
     let none: Vec<i32> = vec![];
 
     assert_eq!(many.iter().join(", "), "1, 2, 3");
-    assert_eq!( one.iter().join(", "), "1");
+    assert_eq!(one.iter().join(", "), "1");
     assert_eq!(none.iter().join(", "), "");
 }
 
 #[test]
 fn sorted_unstable_by() {
-    let sc = [3, 4, 1, 2].iter().cloned().sorted_by(|&a, &b| {
-        a.cmp(&b)
-    });
+    let sc = [3, 4, 1, 2].iter().cloned().sorted_by(|&a, &b| a.cmp(&b));
     it::assert_equal(sc, vec![1, 2, 3, 4]);
 
     let v = (0..5).sorted_unstable_by(|&a, &b| a.cmp(&b).reverse());
@@ -403,9 +461,7 @@ fn sorted_unstable_by_key() {
 
 #[test]
 fn sorted_by() {
-    let sc = [3, 4, 1, 2].iter().cloned().sorted_by(|&a, &b| {
-        a.cmp(&b)
-    });
+    let sc = [3, 4, 1, 2].iter().cloned().sorted_by(|&a, &b| a.cmp(&b));
     it::assert_equal(sc, vec![1, 2, 3, 4]);
 
     let v = (0..5).sorted_by(|&a, &b| a.cmp(&b).reverse());
@@ -438,11 +494,13 @@ struct RandIter<T: 'static + Clone + Send, R: 'static + Clone + Rng + SeedableRn
     idx: usize,
     len: usize,
     rng: R,
-    _t: PhantomData<T>
+    _t: PhantomData<T>,
 }
 
 impl<T: Clone + Send, R: Clone + Rng + SeedableRng + Send> Iterator for RandIter<T, R>
-where Standard: Distribution<T> {
+where
+    Standard: Distribution<T>,
+{
     type Item = T;
     fn next(&mut self) -> Option<T> {
         if self.idx == self.len {
@@ -460,24 +518,21 @@ impl<T: Clone + Send, R: Clone + Rng + SeedableRng + Send> qc::Arbitrary for Ran
             idx: 0,
             len: g.size(),
             rng: R::seed_from_u64(g.next_u64()),
-            _t : PhantomData{},
+            _t: PhantomData {},
         }
     }
 }
 
 // Check that taking the k smallest is the same as
 //  sorting then taking the k first elements
-fn k_smallest_sort<I>(i: I, k: u16) -> ()
+fn k_smallest_sort<I>(i: I, k: u16)
 where
     I: Iterator + Clone,
     I::Item: Ord + Debug,
 {
     let j = i.clone();
     let k = k as usize;
-    it::assert_equal(
-        i.k_smallest(k),
-        j.sorted().take(k)
-    )
+    it::assert_equal(i.k_smallest(k), j.sorted().take(k))
 }
 
 macro_rules! generic_test {
@@ -505,12 +560,12 @@ fn sorted_by_key() {
 
 #[test]
 fn test_multipeek() {
-    let nums = vec![1u8,2,3,4,5];
+    let nums = vec![1u8, 2, 3, 4, 5];
 
-    let mp = multipeek(nums.iter().map(|&x| x));
+    let mp = multipeek(nums.iter().copied());
     assert_eq!(nums, mp.collect::<Vec<_>>());
 
-    let mut mp = multipeek(nums.iter().map(|&x| x));
+    let mut mp = multipeek(nums.iter().copied());
     assert_eq!(mp.peek(), Some(&1));
     assert_eq!(mp.next(), Some(1));
     assert_eq!(mp.peek(), Some(&2));
@@ -546,9 +601,9 @@ fn test_multipeek_reset() {
 #[test]
 fn test_multipeek_peeking_next() {
     use crate::it::PeekingNext;
-    let nums = vec![1u8,2,3,4,5,6,7];
+    let nums = vec![1u8, 2, 3, 4, 5, 6, 7];
 
-    let mut mp = multipeek(nums.iter().map(|&x| x));
+    let mut mp = multipeek(nums.iter().copied());
     assert_eq!(mp.peeking_next(|&x| x != 0), Some(1));
     assert_eq!(mp.next(), Some(2));
     assert_eq!(mp.peek(), Some(&3));
@@ -571,12 +626,12 @@ fn test_multipeek_peeking_next() {
 
 #[test]
 fn test_peek_nth() {
-    let nums = vec![1u8,2,3,4,5];
+    let nums = vec![1u8, 2, 3, 4, 5];
 
-    let iter = peek_nth(nums.iter().map(|&x| x));
+    let iter = peek_nth(nums.iter().copied());
     assert_eq!(nums, iter.collect::<Vec<_>>());
 
-    let mut iter = peek_nth(nums.iter().map(|&x| x));
+    let mut iter = peek_nth(nums.iter().copied());
 
     assert_eq!(iter.peek_nth(0), Some(&1));
     assert_eq!(iter.peek_nth(0), Some(&1));
@@ -606,8 +661,8 @@ fn test_peek_nth() {
 #[test]
 fn test_peek_nth_peeking_next() {
     use it::PeekingNext;
-    let nums = vec![1u8,2,3,4,5,6,7];
-    let mut iter = peek_nth(nums.iter().map(|&x| x));
+    let nums = vec![1u8, 2, 3, 4, 5, 6, 7];
+    let mut iter = peek_nth(nums.iter().copied());
 
     assert_eq!(iter.peeking_next(|&x| x != 0), Some(1));
     assert_eq!(iter.next(), Some(2));
@@ -663,7 +718,7 @@ fn group_by() {
         }
     }
 
-    let toupper = |ch: &char| ch.to_uppercase().nth(0).unwrap();
+    let toupper = |ch: &char| ch.to_uppercase().next().unwrap();
 
     // try all possible orderings
     for indices in permutohedron::Heap::new(&mut [0, 1, 2, 3]) {
@@ -672,11 +727,11 @@ fn group_by() {
 
         for &idx in &indices[..] {
             let (key, text) = match idx {
-                 0 => ('A', "Aaa".chars()),
-                 1 => ('B', "Bbb".chars()),
-                 2 => ('C', "ccCc".chars()),
-                 3 => ('D', "DDDD".chars()),
-                 _ => unreachable!(),
+                0 => ('A', "Aaa".chars()),
+                1 => ('B', "Bbb".chars()),
+                2 => ('C', "ccCc".chars()),
+                3 => ('D', "DDDD".chars()),
+                _ => unreachable!(),
             };
             assert_eq!(key, subs[idx].0);
             it::assert_equal(&mut subs[idx].1, text);
@@ -701,9 +756,11 @@ fn group_by() {
     {
         let mut ntimes = 0;
         let text = "AABCCC";
-        for (_, sub) in &text.chars().group_by(|&x| { ntimes += 1; x}) {
-            for _ in sub {
-            }
+        for (_, sub) in &text.chars().group_by(|&x| {
+            ntimes += 1;
+            x
+        }) {
+            for _ in sub {}
         }
         assert_eq!(ntimes, text.len());
     }
@@ -711,8 +768,10 @@ fn group_by() {
     {
         let mut ntimes = 0;
         let text = "AABCCC";
-        for _ in &text.chars().group_by(|&x| { ntimes += 1; x}) {
-        }
+        for _ in &text.chars().group_by(|&x| {
+            ntimes += 1;
+            x
+        }) {}
         assert_eq!(ntimes, text.len());
     }
 
@@ -752,8 +811,7 @@ fn group_by_lazy_2() {
         if i < 2 {
             groups.push(group);
         } else if i < 4 {
-            for _ in group {
-            }
+            for _ in group {}
         } else {
             groups.push(group);
         }
@@ -765,7 +823,11 @@ fn group_by_lazy_2() {
     // use groups as chunks
     let data = vec![0, 0, 0, 1, 1, 0, 0, 2, 2, 3, 3];
     let mut i = 0;
-    let grouper = data.iter().group_by(move |_| { let k = i / 3; i += 1; k });
+    let grouper = data.iter().group_by(move |_| {
+        let k = i / 3;
+        i += 1;
+        k
+    });
     for (i, group) in &grouper {
         match i {
             0 => it::assert_equal(group, &[0, 0, 0]),
@@ -816,8 +878,8 @@ fn concat_empty() {
 
 #[test]
 fn concat_non_empty() {
-    let data = vec![vec![1,2,3], vec![4,5,6], vec![7,8,9]];
-    assert_eq!(data.into_iter().concat(), vec![1,2,3,4,5,6,7,8,9])
+    let data = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
+    assert_eq!(data.into_iter().concat(), vec![1, 2, 3, 4, 5, 6, 7, 8, 9])
 }
 
 #[test]
@@ -825,19 +887,20 @@ fn combinations() {
     assert!((1..3).combinations(5).next().is_none());
 
     let it = (1..3).combinations(2);
-    it::assert_equal(it, vec![
-        vec![1, 2],
-        ]);
+    it::assert_equal(it, vec![vec![1, 2]]);
 
     let it = (1..5).combinations(2);
-    it::assert_equal(it, vec![
-        vec![1, 2],
-        vec![1, 3],
-        vec![1, 4],
-        vec![2, 3],
-        vec![2, 4],
-        vec![3, 4],
-        ]);
+    it::assert_equal(
+        it,
+        vec![
+            vec![1, 2],
+            vec![1, 3],
+            vec![1, 4],
+            vec![2, 3],
+            vec![2, 4],
+            vec![3, 4],
+        ],
+    );
 
     it::assert_equal((0..0).tuple_combinations::<(_, _)>(), <Vec<_>>::new());
     it::assert_equal((0..1).tuple_combinations::<(_, _)>(), <Vec<_>>::new());
@@ -856,7 +919,6 @@ fn combinations_of_too_short() {
         assert!((0..i - 1).combinations(i).next().is_none());
     }
 }
-
 
 #[test]
 fn combinations_zero() {
@@ -887,15 +949,9 @@ fn combinations_with_replacement() {
         ],
     );
     // Zero size
-    it::assert_equal(
-        (0..3).combinations_with_replacement(0),
-        vec![vec![]],
-    );
+    it::assert_equal((0..3).combinations_with_replacement(0), vec![vec![]]);
     // Zero size on empty pool
-    it::assert_equal(
-        (0..0).combinations_with_replacement(0),
-        vec![vec![]],
-    );
+    it::assert_equal((0..0).combinations_with_replacement(0), vec![vec![]]);
     // Empty pool
     it::assert_equal(
         (0..0).combinations_with_replacement(2),
@@ -907,13 +963,23 @@ fn combinations_with_replacement() {
 fn powerset() {
     it::assert_equal((0..0).powerset(), vec![vec![]]);
     it::assert_equal((0..1).powerset(), vec![vec![], vec![0]]);
-    it::assert_equal((0..2).powerset(), vec![vec![], vec![0], vec![1], vec![0, 1]]);
-    it::assert_equal((0..3).powerset(), vec![
-        vec![],
-        vec![0], vec![1], vec![2],
-        vec![0, 1], vec![0, 2], vec![1, 2],
-        vec![0, 1, 2]
-    ]);
+    it::assert_equal(
+        (0..2).powerset(),
+        vec![vec![], vec![0], vec![1], vec![0, 1]],
+    );
+    it::assert_equal(
+        (0..3).powerset(),
+        vec![
+            vec![],
+            vec![0],
+            vec![1],
+            vec![2],
+            vec![0, 1],
+            vec![0, 2],
+            vec![1, 2],
+            vec![0, 1, 2],
+        ],
+    );
 
     assert_eq!((0..4).powerset().count(), 1 << 4);
     assert_eq!((0..8).powerset().count(), 1 << 8);
@@ -942,8 +1008,7 @@ fn diff_longer() {
     let diff = it::diff_with(a.iter(), b_map, |a, b| *a == b);
 
     assert!(match diff {
-        Some(it::Diff::Longer(_, remaining)) =>
-            remaining.collect::<Vec<_>>() == vec![5, 6],
+        Some(it::Diff::Longer(_, remaining)) => remaining.collect::<Vec<_>>() == vec![5, 6],
         _ => false,
     });
 }
@@ -963,8 +1028,8 @@ fn diff_shorter() {
 
 #[test]
 fn minmax() {
-    use std::cmp::Ordering;
     use crate::it::MinMaxResult;
+    use std::cmp::Ordering;
 
     // A peculiar type: Equality compares both tuple items, but ordering only the
     // first item.  This is so we can check the stability property easily.
@@ -983,7 +1048,10 @@ fn minmax() {
         }
     }
 
-    assert_eq!(None::<Option<u32>>.iter().minmax(), MinMaxResult::NoElements);
+    assert_eq!(
+        None::<Option<u32>>.iter().minmax(),
+        MinMaxResult::NoElements
+    );
 
     assert_eq!(Some(1u32).iter().minmax(), MinMaxResult::OneElement(&1));
 
@@ -996,7 +1064,11 @@ fn minmax() {
     assert_eq!(min, &Val(2, 0));
     assert_eq!(max, &Val(0, 2));
 
-    let (min, max) = data.iter().minmax_by(|x, y| x.1.cmp(&y.1)).into_option().unwrap();
+    let (min, max) = data
+        .iter()
+        .minmax_by(|x, y| x.1.cmp(&y.1))
+        .into_option()
+        .unwrap();
     assert_eq!(min, &Val(2, 0));
     assert_eq!(max, &Val(0, 2));
 }
@@ -1012,15 +1084,16 @@ fn format() {
     let t2 = format!("{:?}", data.iter().format("--"));
     assert_eq!(t2, ans2);
 
-    let dataf = [1.1, 2.71828, -22.];
+    let dataf = [1.1, std::f64::consts::E, -22.];
     let t3 = format!("{:.2e}", dataf.iter().format(", "));
     assert_eq!(t3, "1.10e0, 2.72e0, -2.20e1");
 }
 
 #[test]
 fn while_some() {
-    let ns = (1..10).map(|x| if x % 5 != 0 { Some(x) } else { None })
-                    .while_some();
+    let ns = (1..10)
+        .map(|x| if x % 5 != 0 { Some(x) } else { None })
+        .while_some();
     it::assert_equal(ns, vec![1, 2, 3, 4]);
 }
 
@@ -1029,15 +1102,18 @@ fn while_some() {
 fn fold_while() {
     let mut iterations = 0;
     let vec = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    let sum = vec.into_iter().fold_while(0, |acc, item| {
-        iterations += 1;
-        let new_sum = acc.clone() + item;
-        if new_sum <= 20 {
-            FoldWhile::Continue(new_sum)
-        } else {
-            FoldWhile::Done(acc)
-        }
-    }).into_inner();
+    let sum = vec
+        .into_iter()
+        .fold_while(0, |acc, item| {
+            iterations += 1;
+            let new_sum = acc + item;
+            if new_sum <= 20 {
+                FoldWhile::Continue(new_sum)
+            } else {
+                FoldWhile::Done(acc)
+            }
+        })
+        .into_inner();
     assert_eq!(iterations, 6);
     assert_eq!(sum, 15);
 }
@@ -1064,7 +1140,11 @@ fn tree_fold1() {
         "0 1 x 2 3 x x 4 5 x 6 7 x x x 8 9 x 10 11 x x 12 13 x 14 15 x x x x",
     ];
     for (i, &s) in x.iter().enumerate() {
-        let expected = if s == "" { None } else { Some(s.to_string()) };
+        let expected = if s.is_empty() {
+            None
+        } else {
+            Some(s.to_string())
+        };
         let num_strings = (0..i).map(|x| x.to_string());
         let actual = num_strings.tree_fold1(|a, b| format!("{} {} x", a, b));
         assert_eq!(actual, expected);
@@ -1076,7 +1156,8 @@ fn exactly_one_question_mark_syntax_works() {
     exactly_one_question_mark_return().unwrap_err();
 }
 
-fn exactly_one_question_mark_return() -> Result<(), ExactlyOneError<std::slice::Iter<'static, ()>>> {
+fn exactly_one_question_mark_return() -> Result<(), ExactlyOneError<std::slice::Iter<'static, ()>>>
+{
     [].iter().exactly_one()?;
     Ok(())
 }


### PR DESCRIPTION
The motivation for this is when using `union`, `intersection`, `difference`, and `symmetric_difference` the items have to be cloned, this avoids that and can return borrowed items. What I was shooting for was as if the signature to `BTreeSet::intersection` was
```rust
pub fn difference<'a>(&'a self, other: &'a BTreeSet<Q>) -> Difference<'a, Q>
where
    T: Borrow<Q>,
    Q: Ord,
{...}
```
The code is taken from the std lib and altered to work with iterators so it should be sound, still working out a few kinks but nothing major.

I did try implementing the above signature in the std lib but was unable (could be just me) so I tried this out and got it working! Let me know if this is helpful as part of `itertools`.

Thanks by the way for a great crate!

## Huge problem
This relies on the iterator returning items in sorted order, is this an acceptable invariant to only document (is there any way to add a trait to signify that the iterator needs to be sorted?).