### PR TITLE
Compare `into_group_map_by`  with `into_grouping_map_by` in its doc (fix typo)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2791,7 +2791,7 @@ pub trait Itertools : Iterator {
 
     /// Return an `Iterator` on a `HashMap`. Keys mapped to `Vec`s of values. The key is specified
     /// in the closure.
-    /// Different to `into_group_map_by` because the key is still present. It is also more general.
+    /// Different to `into_grouping_map_by` because the key is still present. It is also more general.
     /// You can also fold the `group_map`.
     ///
     /// ```


### PR DESCRIPTION
It was confusing to have the doc compare the function with itself, so it seems to be referring to the `into_grouping_map_by`  which doesn't include a key but only the values.

Make me know if I corrected wrong, or if it was good from the start. ^^