### PR TITLE
Fix documentation of `HomogeneousTuple`

### DIFF
--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -11,7 +11,7 @@ use std::marker::PhantomData;
 // hiding the implementation details of `TupleCollect`.
 // See https://github.com/rust-itertools/itertools/issues/387
 
-/// Implemented for homogeneous tuples of size up to 4.
+/// Implemented for homogeneous tuples of size up to 12.
 pub trait HomogeneousTuple
     : TupleCollect
 {}


### PR DESCRIPTION
Compare the docs of `Itertools::collect_tuple` that already mention the correct upper bound on the number of tuple elements.