### PR TITLE
Fix overflow in duplicates size hint

### DIFF
--- a/src/duplicates_impl.rs
+++ b/src/duplicates_impl.rs
@@ -2,8 +2,8 @@ use std::hash::Hash;
 
 mod private {
     use std::collections::HashMap;
-    use std::hash::Hash;
     use std::fmt;
+    use std::hash::Hash;
 
     #[derive(Clone)]
     #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
@@ -89,7 +89,7 @@ mod private {
             // far), plus (hi - pending) / 2 pairs of never seen before items.
             let hi = hi.map(|hi| {
                 let max_pending = std::cmp::min(self.meta.pending, hi);
-                let max_new = std::cmp::max(hi - self.meta.pending, 0) / 2;
+                let max_new = hi.saturating_sub(self.meta.pending) / 2;
                 max_pending + max_new
             });
             // The lower bound is always 0 since we might only get unique items from now on
@@ -203,4 +203,3 @@ where
 {
     Duplicates::new(iter, private::ById)
 }
-

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -3,34 +3,21 @@
 //!
 //! In particular we test the tedious size_hint and exact size correctness.
 
+use itertools::free::{
+    cloned, enumerate, multipeek, peek_nth, put_back, put_back_n, rciter, zip, zip_eq,
+};
+use itertools::Itertools;
+use itertools::{iproduct, izip, multizip, EitherOrBoth};
 use quickcheck as qc;
+use std::cmp::{max, min, Ordering};
+use std::collections::{HashMap, HashSet};
 use std::default::Default;
 use std::num::Wrapping;
 use std::ops::Range;
-use std::cmp::{max, min, Ordering};
-use std::collections::{HashMap, HashSet};
-use itertools::Itertools;
-use itertools::{
-    multizip,
-    EitherOrBoth,
-    iproduct,
-    izip,
-};
-use itertools::free::{
-    cloned,
-    enumerate,
-    multipeek,
-    peek_nth,
-    put_back,
-    put_back_n,
-    rciter,
-    zip,
-    zip_eq,
-};
 
-use rand::Rng;
-use rand::seq::SliceRandom;
 use quickcheck::TestResult;
+use rand::seq::SliceRandom;
+use rand::Rng;
 
 /// Trait for size hint modifier types
 trait HintKind: Copy + Send + qc::Arbitrary {
@@ -66,8 +53,10 @@ struct Inexact {
 impl HintKind for Inexact {
     fn loosen_bounds(&self, org_hint: (usize, Option<usize>)) -> (usize, Option<usize>) {
         let (org_lower, org_upper) = org_hint;
-        (org_lower.saturating_sub(self.underestimate),
-         org_upper.and_then(move |x| x.checked_add(self.overestimate)))
+        (
+            org_lower.saturating_sub(self.underestimate),
+            org_upper.and_then(move |x| x.checked_add(self.overestimate)),
+        )
     }
 }
 
@@ -84,19 +73,15 @@ impl qc::Arbitrary for Inexact {
         }
     }
 
-    fn shrink(&self) -> Box<dyn Iterator<Item=Self>> {
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
         let underestimate_value = self.underestimate;
         let overestimate_value = self.overestimate;
-        Box::new(
-            underestimate_value.shrink().flat_map(move |ue_value|
-                overestimate_value.shrink().map(move |oe_value|
-                    Inexact {
-                        underestimate: ue_value,
-                        overestimate: oe_value,
-                    }
-                )
-            )
-        )
+        Box::new(underestimate_value.shrink().flat_map(move |ue_value| {
+            overestimate_value.shrink().map(move |oe_value| Inexact {
+                underestimate: ue_value,
+                overestimate: oe_value,
+            })
+        }))
     }
 }
 
@@ -116,7 +101,9 @@ struct Iter<T, SK: HintKind = Inexact> {
     hint_kind: SK,
 }
 
-impl<T, HK> Iter<T, HK> where HK: HintKind
+impl<T, HK> Iter<T, HK>
+where
+    HK: HintKind,
 {
     fn new(it: Range<T>, hint_kind: HK) -> Self {
         Iter {
@@ -128,64 +115,66 @@ impl<T, HK> Iter<T, HK> where HK: HintKind
 }
 
 impl<T, HK> Iterator for Iter<T, HK>
-    where Range<T>: Iterator,
-          <Range<T> as Iterator>::Item: Default,
-          HK: HintKind,
+where
+    Range<T>: Iterator,
+    <Range<T> as Iterator>::Item: Default,
+    HK: HintKind,
 {
     type Item = <Range<T> as Iterator>::Item;
 
-    fn next(&mut self) -> Option<Self::Item>
-    {
+    fn next(&mut self) -> Option<Self::Item> {
         let elt = self.iterator.next();
         if elt.is_none() {
             self.fuse_flag += 1;
             // check fuse flag
             if self.fuse_flag == 2 {
-                return Some(Default::default())
+                return Some(Default::default());
             }
         }
         elt
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>)
-    {
+    fn size_hint(&self) -> (usize, Option<usize>) {
         let org_hint = self.iterator.size_hint();
         self.hint_kind.loosen_bounds(org_hint)
     }
 }
 
 impl<T, HK> DoubleEndedIterator for Iter<T, HK>
-    where Range<T>: DoubleEndedIterator,
-          <Range<T> as Iterator>::Item: Default,
-          HK: HintKind
+where
+    Range<T>: DoubleEndedIterator,
+    <Range<T> as Iterator>::Item: Default,
+    HK: HintKind,
 {
-    fn next_back(&mut self) -> Option<Self::Item> { self.iterator.next_back() }
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iterator.next_back()
+    }
 }
 
-impl<T> ExactSizeIterator for Iter<T, Exact> where Range<T>: ExactSizeIterator,
+impl<T> ExactSizeIterator for Iter<T, Exact>
+where
+    Range<T>: ExactSizeIterator,
     <Range<T> as Iterator>::Item: Default,
-{ }
+{
+}
 
 impl<T, HK> qc::Arbitrary for Iter<T, HK>
-    where T: qc::Arbitrary,
-          HK: HintKind,
+where
+    T: qc::Arbitrary,
+    HK: HintKind,
 {
-    fn arbitrary<G: qc::Gen>(g: &mut G) -> Self
-    {
+    fn arbitrary<G: qc::Gen>(g: &mut G) -> Self {
         Iter::new(T::arbitrary(g)..T::arbitrary(g), HK::arbitrary(g))
     }
 
-    fn shrink(&self) -> Box<dyn Iterator<Item=Iter<T, HK>>>
-    {
+    fn shrink(&self) -> Box<dyn Iterator<Item = Iter<T, HK>>> {
         let r = self.iterator.clone();
         let hint_kind = self.hint_kind;
-        Box::new(
-            r.start.shrink().flat_map(move |a|
-                r.end.shrink().map(move |b|
-                    Iter::new(a.clone()..b, hint_kind)
-                )
-            )
-        )
+        Box::new(r.start.shrink().flat_map(move |a| {
+            r.end
+                .shrink()
+                .map(move |b| Iter::new(a.clone()..b, hint_kind))
+        }))
     }
 }
 
@@ -201,7 +190,10 @@ struct ShiftRange<HK = Inexact> {
     hint_kind: HK,
 }
 
-impl<HK> Iterator for ShiftRange<HK> where HK: HintKind {
+impl<HK> Iterator for ShiftRange<HK>
+where
+    HK: HintKind,
+{
     type Item = Iter<i32, HK>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -219,10 +211,11 @@ impl<HK> Iterator for ShiftRange<HK> where HK: HintKind {
     }
 }
 
-impl ExactSizeIterator for ShiftRange<Exact> { }
+impl ExactSizeIterator for ShiftRange<Exact> {}
 
 impl<HK> qc::Arbitrary for ShiftRange<HK>
-    where HK: HintKind
+where
+    HK: HintKind,
 {
     fn arbitrary<G: qc::Gen>(g: &mut G) -> Self {
         const MAX_STARTING_RANGE_DIFF: i32 = 32;
@@ -250,7 +243,7 @@ impl<HK> qc::Arbitrary for ShiftRange<HK>
 fn correct_count<I, F>(get_it: F) -> bool
 where
     I: Iterator,
-    F: Fn() -> I
+    F: Fn() -> I,
 {
     let mut counts = vec![get_it().count()];
 
@@ -275,7 +268,10 @@ where
     for (i, returned_count) in counts.into_iter().enumerate() {
         let actual_count = total_actual_count - i;
         if actual_count != returned_count {
-            println!("Total iterations: {} True count: {} returned count: {}", i, actual_count, returned_count);
+            println!(
+                "Total iterations: {} True count: {} returned count: {}",
+                i, actual_count, returned_count
+            );
 
             return false;
         }
@@ -298,12 +294,10 @@ fn correct_size_hint<I: Iterator>(mut it: I) -> bool {
     // check all the size hints
     for &(low, hi) in &hints {
         true_count -= 1;
-        if low > true_count ||
-            (hi.is_some() && hi.unwrap() < true_count)
-        {
+        if low > true_count || (hi.is_some() && hi.unwrap() < true_count) {
             println!("True size: {:?}, size hint: {:?}", true_count, (low, hi));
             //println!("All hints: {:?}", hints);
-            return false
+            return false;
         }
     }
     true
@@ -312,13 +306,19 @@ fn correct_size_hint<I: Iterator>(mut it: I) -> bool {
 fn exact_size<I: ExactSizeIterator>(mut it: I) -> bool {
     // check every iteration
     let (mut low, mut hi) = it.size_hint();
-    if Some(low) != hi { return false; }
+    if Some(low) != hi {
+        return false;
+    }
     while let Some(_) = it.next() {
         let (xlow, xhi) = it.size_hint();
-        if low != xlow + 1 { return false; }
+        if low != xlow + 1 {
+            return false;
+        }
         low = xlow;
         hi = xhi;
-        if Some(low) != hi { return false; }
+        if Some(low) != hi {
+            return false;
+        }
     }
     let (low, hi) = it.size_hint();
     low == 0 && hi == Some(0)
@@ -328,13 +328,19 @@ fn exact_size<I: ExactSizeIterator>(mut it: I) -> bool {
 fn exact_size_for_this<I: Iterator>(mut it: I) -> bool {
     // check every iteration
     let (mut low, mut hi) = it.size_hint();
-    if Some(low) != hi { return false; }
+    if Some(low) != hi {
+        return false;
+    }
     while let Some(_) = it.next() {
         let (xlow, xhi) = it.size_hint();
-        if low != xlow + 1 { return false; }
+        if low != xlow + 1 {
+            return false;
+        }
         low = xlow;
         hi = xhi;
-        if Some(low) != hi { return false; }
+        if Some(low) != hi {
+            return false;
+        }
     }
     let (low, hi) = it.size_hint();
     low == 0 && hi == Some(0)
@@ -919,6 +925,10 @@ quickcheck! {
     fn size_duplicates(it: Iter<i8>) -> bool {
         correct_size_hint(it.duplicates())
     }
+
+    fn size_duplicates_skip(it: Iter<i8>, skip: u8) -> bool {
+        correct_size_hint(it.duplicates().skip(skip as usize))
+    }
 }
 
 quickcheck! {
@@ -1237,7 +1247,7 @@ quickcheck! {
                     Some(acc.unwrap_or(0) + val)
                 }
             });
-        
+
         let group_map_lookup = a.iter()
             .map(|&b| b as u64)
             .map(|i| (i % modulo, i))
@@ -1257,7 +1267,7 @@ quickcheck! {
 
         for m in 0..modulo {
             assert_eq!(
-                lookup.get(&m).copied(), 
+                lookup.get(&m).copied(),
                 a.iter()
                     .map(|&b| b as u64)
                     .filter(|&val| val % modulo == m)
@@ -1377,7 +1387,7 @@ quickcheck! {
             assert_eq!(Some(max), a.iter().copied().filter(|&val| val % modulo == key).max_by_key(|&val| val));
         }
     }
-    
+
     fn correct_grouping_map_by_min_modulo_key(a: Vec<u8>, modulo: u8) -> () {
         let modulo = if modulo == 0 { 1 } else { modulo }; // Avoid `% 0`
         let lookup = a.iter().copied().into_grouping_map_by(|i| i % modulo).min();
@@ -1428,7 +1438,7 @@ quickcheck! {
             assert_eq!(Some(min), a.iter().copied().filter(|&val| val % modulo == key).min_by_key(|&val| val));
         }
     }
-    
+
     fn correct_grouping_map_by_minmax_modulo_key(a: Vec<u8>, modulo: u8) -> () {
         let modulo = if modulo == 0 { 1 } else { modulo }; // Avoid `% 0`
         let lookup = a.iter().copied().into_grouping_map_by(|i| i % modulo).minmax();
@@ -1541,7 +1551,7 @@ quickcheck! {
             .min_by(|_, _, _| Ordering::Equal);
 
         assert_eq!(lookup[&0], 0);
-        
+
         let lookup = (0..=10)
             .into_grouping_map_by(|_| 0)
             .minmax_by(|_, _, _| Ordering::Equal);
@@ -1599,12 +1609,10 @@ quickcheck! {
     }
 }
 
-
-fn is_fused<I: Iterator>(mut it: I) -> bool
-{
+fn is_fused<I: Iterator>(mut it: I) -> bool {
     while let Some(_) = it.next() {}
-    for _ in 0..10{
-        if it.next().is_some(){
+    for _ in 0..10 {
+        if it.next().is_some() {
             return false;
         }
     }
@@ -1645,7 +1653,7 @@ quickcheck! {
         !is_fused(a.clone().interleave_shortest(b.clone())) &&
         is_fused(a.fuse().interleave_shortest(b.fuse()))
     }
-    
+
     fn fused_product(a: Iter<i16>, b: Iter<i16>) -> bool
     {
         is_fused(a.fuse().cartesian_product(b.fuse()))
@@ -1692,4 +1700,3 @@ quickcheck! {
         is_fused(a.fuse().pad_using(100,|_|0))
     }
 }
-

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -1,21 +1,25 @@
+use crate::it::cloned;
+use crate::it::free::put_back_n;
+use crate::it::free::rciter;
+use crate::it::iproduct;
+use crate::it::izip;
+use crate::it::multipeek;
+use crate::it::multizip;
+use crate::it::peek_nth;
+use crate::it::ExactlyOneError;
+use crate::it::FoldWhile;
+use crate::it::Itertools;
+use itertools as it;
 use paste;
 use permutohedron;
 use quickcheck as qc;
-use rand::{distributions::{Distribution, Standard}, Rng, SeedableRng, rngs::StdRng};
+use rand::{
+    distributions::{Distribution, Standard},
+    rngs::StdRng,
+    Rng, SeedableRng,
+};
 use rand::{seq::SliceRandom, thread_rng};
 use std::{cmp::min, fmt::Debug, marker::PhantomData};
-use itertools as it;
-use crate::it::Itertools;
-use crate::it::ExactlyOneError;
-use crate::it::multizip;
-use crate::it::multipeek;
-use crate::it::peek_nth;
-use crate::it::free::rciter;
-use crate::it::free::put_back_n;
-use crate::it::FoldWhile;
-use crate::it::cloned;
-use crate::it::iproduct;
-use crate::it::izip;
 
 #[test]
 fn product3() {
@@ -29,9 +33,7 @@ fn product3() {
             }
         }
     }
-    for (_, _, _, _) in iproduct!(0..3, 0..2, 0..2, 0..3) {
-        /* test compiles */
-    }
+    for (_, _, _, _) in iproduct!(0..3, 0..2, 0..2, 0..3) { /* test compiles */ }
 }
 
 #[test]
@@ -64,9 +66,15 @@ fn duplicates_by() {
     let xs = ["aaa", "bbbbb", "aa", "ccc", "bbbb", "aaaaa", "cccc"];
     let ys = ["aa", "bbbb", "cccc"];
     it::assert_equal(ys.iter(), xs.iter().duplicates_by(|x| x[..2].to_string()));
-    it::assert_equal(ys.iter(), xs.iter().rev().duplicates_by(|x| x[..2].to_string()).rev());
+    it::assert_equal(
+        ys.iter(),
+        xs.iter().rev().duplicates_by(|x| x[..2].to_string()).rev(),
+    );
     let ys_rev = ["ccc", "aa", "bbbbb"];
-    it::assert_equal(ys_rev.iter(), xs.iter().duplicates_by(|x| x[..2].to_string()).rev());
+    it::assert_equal(
+        ys_rev.iter(),
+        xs.iter().duplicates_by(|x| x[..2].to_string()).rev(),
+    );
 }
 
 #[test]
@@ -84,6 +92,10 @@ fn duplicates() {
     it::assert_equal(ys.iter(), xs.iter().rev().duplicates().rev());
     let ys_rev = [1, 0];
     it::assert_equal(ys_rev.iter(), xs.iter().duplicates().rev());
+
+    let xs = vec![0, 1, 0];
+    let ys = vec![0];
+    assert_eq!(ys, xs.into_iter().duplicates().collect::<Vec<_>>());
 }
 
 #[test]
@@ -91,9 +103,15 @@ fn unique_by() {
     let xs = ["aaa", "bbbbb", "aa", "ccc", "bbbb", "aaaaa", "cccc"];
     let ys = ["aaa", "bbbbb", "ccc"];
     it::assert_equal(ys.iter(), xs.iter().unique_by(|x| x[..2].to_string()));
-    it::assert_equal(ys.iter(), xs.iter().rev().unique_by(|x| x[..2].to_string()).rev());
+    it::assert_equal(
+        ys.iter(),
+        xs.iter().rev().unique_by(|x| x[..2].to_string()).rev(),
+    );
     let ys_rev = ["cccc", "aaaaa", "bbbb"];
-    it::assert_equal(ys_rev.iter(), xs.iter().unique_by(|x| x[..2].to_string()).rev());
+    it::assert_equal(
+        ys_rev.iter(),
+        xs.iter().unique_by(|x| x[..2].to_string()).rev(),
+    );
 }
 
 #[test]
@@ -144,13 +162,13 @@ fn dedup() {
 #[test]
 fn coalesce() {
     let data = vec![-1., -2., -3., 3., 1., 0., -1.];
-    let it = data.iter().cloned().coalesce(|x, y|
+    let it = data.iter().cloned().coalesce(|x, y| {
         if (x >= 0.) == (y >= 0.) {
             Ok(x + y)
         } else {
             Err((x, y))
         }
-    );
+    });
     itertools::assert_equal(it.clone(), vec![-6., 4., -1.]);
     assert_eq!(
         it.fold(vec![], |mut v, n| {
@@ -163,17 +181,37 @@ fn coalesce() {
 
 #[test]
 fn dedup_by() {
-    let xs = [(0, 0), (0, 1), (1, 1), (2, 1), (0, 2), (3, 1), (0, 3), (1, 3)];
+    let xs = [
+        (0, 0),
+        (0, 1),
+        (1, 1),
+        (2, 1),
+        (0, 2),
+        (3, 1),
+        (0, 3),
+        (1, 3),
+    ];
     let ys = [(0, 0), (0, 1), (0, 2), (3, 1), (0, 3)];
-    it::assert_equal(ys.iter(), xs.iter().dedup_by(|x, y| x.1==y.1));
+    it::assert_equal(ys.iter(), xs.iter().dedup_by(|x, y| x.1 == y.1));
     let xs = [(0, 1), (0, 2), (0, 3), (0, 4), (0, 5)];
     let ys = [(0, 1)];
-    it::assert_equal(ys.iter(), xs.iter().dedup_by(|x, y| x.0==y.0));
+    it::assert_equal(ys.iter(), xs.iter().dedup_by(|x, y| x.0 == y.0));
 
-    let xs = [(0, 0), (0, 1), (1, 1), (2, 1), (0, 2), (3, 1), (0, 3), (1, 3)];
+    let xs = [
+        (0, 0),
+        (0, 1),
+        (1, 1),
+        (2, 1),
+        (0, 2),
+        (3, 1),
+        (0, 3),
+        (1, 3),
+    ];
     let ys = [(0, 0), (0, 1), (0, 2), (3, 1), (0, 3)];
     let mut xs_d = Vec::new();
-    xs.iter().dedup_by(|x, y| x.1==y.1).fold((), |(), &elt| xs_d.push(elt));
+    xs.iter()
+        .dedup_by(|x, y| x.1 == y.1)
+        .fold((), |(), &elt| xs_d.push(elt));
     assert_eq!(&xs_d, &ys);
 }
 
@@ -190,18 +228,38 @@ fn dedup_with_count() {
     it::assert_equal(ys.iter().cloned(), xs.iter().dedup_with_count());
 }
 
-
 #[test]
 fn dedup_by_with_count() {
-    let xs = [(0, 0), (0, 1), (1, 1), (2, 1), (0, 2), (3, 1), (0, 3), (1, 3)];
-    let ys = [(1, &(0, 0)), (3, &(0, 1)), (1, &(0, 2)), (1, &(3, 1)), (2, &(0, 3))];
+    let xs = [
+        (0, 0),
+        (0, 1),
+        (1, 1),
+        (2, 1),
+        (0, 2),
+        (3, 1),
+        (0, 3),
+        (1, 3),
+    ];
+    let ys = [
+        (1, &(0, 0)),
+        (3, &(0, 1)),
+        (1, &(0, 2)),
+        (1, &(3, 1)),
+        (2, &(0, 3)),
+    ];
 
-    it::assert_equal(ys.iter().cloned(), xs.iter().dedup_by_with_count(|x, y| x.1==y.1));
+    it::assert_equal(
+        ys.iter().cloned(),
+        xs.iter().dedup_by_with_count(|x, y| x.1 == y.1),
+    );
 
     let xs = [(0, 1), (0, 2), (0, 3), (0, 4), (0, 5)];
-    let ys = [( 5, &(0, 1))];
+    let ys = [(5, &(0, 1))];
 
-    it::assert_equal(ys.iter().cloned(), xs.iter().dedup_by_with_count(|x, y| x.0==y.0));
+    it::assert_equal(
+        ys.iter().cloned(),
+        xs.iter().dedup_by_with_count(|x, y| x.0 == y.0),
+    );
 }
 
 #[test]
@@ -235,7 +293,7 @@ fn test_put_back_n() {
 
 #[test]
 fn tee() {
-    let xs  = [0, 1, 2, 3];
+    let xs = [0, 1, 2, 3];
     let (mut t1, mut t2) = xs.iter().cloned().tee();
     assert_eq!(t1.next(), Some(0));
     assert_eq!(t2.next(), Some(0));
@@ -258,7 +316,6 @@ fn tee() {
     let (t1, t2) = xs.iter().cloned().tee();
     it::assert_equal(t1.zip(t2), xs.iter().cloned().zip(xs.iter().cloned()));
 }
-
 
 #[test]
 fn test_rciter() {
@@ -283,19 +340,19 @@ fn test_rciter() {
 #[allow(deprecated)]
 #[test]
 fn trait_pointers() {
-    struct ByRef<'r, I: ?Sized>(&'r mut I) ;
+    struct ByRef<'r, I: ?Sized>(&'r mut I);
 
-    impl<'r, X, I: ?Sized> Iterator for ByRef<'r, I> where
-        I: 'r + Iterator<Item=X>
+    impl<'r, X, I: ?Sized> Iterator for ByRef<'r, I>
+    where
+        I: 'r + Iterator<Item = X>,
     {
         type Item = X;
-        fn next(&mut self) -> Option<Self::Item>
-        {
+        fn next(&mut self) -> Option<Self::Item> {
             self.0.next()
         }
     }
 
-    let mut it = Box::new(0..10) as Box<dyn Iterator<Item=i32>>;
+    let mut it = Box::new(0..10) as Box<dyn Iterator<Item = i32>>;
     assert_eq!(it.next(), Some(0));
 
     {
@@ -315,9 +372,16 @@ fn trait_pointers() {
 
 #[test]
 fn merge_by() {
-    let odd : Vec<(u32, &str)> = vec![(1, "hello"), (3, "world"), (5, "!")];
+    let odd: Vec<(u32, &str)> = vec![(1, "hello"), (3, "world"), (5, "!")];
     let even = vec![(2, "foo"), (4, "bar"), (6, "baz")];
-    let expected = vec![(1, "hello"), (2, "foo"), (3, "world"), (4, "bar"), (5, "!"), (6, "baz")];
+    let expected = vec![
+        (1, "hello"),
+        (2, "foo"),
+        (3, "world"),
+        (4, "bar"),
+        (5, "!"),
+        (6, "baz"),
+    ];
     let results = odd.iter().merge_by(even.iter(), |a, b| a.0 <= b.0);
     it::assert_equal(results, expected.iter());
 }
@@ -331,7 +395,7 @@ fn merge_by_btree() {
     let mut bt2 = BTreeMap::new();
     bt2.insert("foo", 2);
     bt2.insert("bar", 4);
-    let results = bt1.into_iter().merge_by(bt2.into_iter(), |a, b| a.0 <= b.0 );
+    let results = bt1.into_iter().merge_by(bt2.into_iter(), |a, b| a.0 <= b.0);
     let expected = vec![("bar", 4), ("foo", 2), ("hello", 1), ("world", 3)];
     it::assert_equal(results, expected.into_iter());
 }
@@ -373,19 +437,17 @@ fn kmerge_empty_size_hint() {
 #[test]
 fn join() {
     let many = [1, 2, 3];
-    let one  = [1];
+    let one = [1];
     let none: Vec<i32> = vec![];
 
     assert_eq!(many.iter().join(", "), "1, 2, 3");
-    assert_eq!( one.iter().join(", "), "1");
+    assert_eq!(one.iter().join(", "), "1");
     assert_eq!(none.iter().join(", "), "");
 }
 
 #[test]
 fn sorted_unstable_by() {
-    let sc = [3, 4, 1, 2].iter().cloned().sorted_by(|&a, &b| {
-        a.cmp(&b)
-    });
+    let sc = [3, 4, 1, 2].iter().cloned().sorted_by(|&a, &b| a.cmp(&b));
     it::assert_equal(sc, vec![1, 2, 3, 4]);
 
     let v = (0..5).sorted_unstable_by(|&a, &b| a.cmp(&b).reverse());
@@ -403,9 +465,7 @@ fn sorted_unstable_by_key() {
 
 #[test]
 fn sorted_by() {
-    let sc = [3, 4, 1, 2].iter().cloned().sorted_by(|&a, &b| {
-        a.cmp(&b)
-    });
+    let sc = [3, 4, 1, 2].iter().cloned().sorted_by(|&a, &b| a.cmp(&b));
     it::assert_equal(sc, vec![1, 2, 3, 4]);
 
     let v = (0..5).sorted_by(|&a, &b| a.cmp(&b).reverse());
@@ -438,11 +498,13 @@ struct RandIter<T: 'static + Clone + Send, R: 'static + Clone + Rng + SeedableRn
     idx: usize,
     len: usize,
     rng: R,
-    _t: PhantomData<T>
+    _t: PhantomData<T>,
 }
 
 impl<T: Clone + Send, R: Clone + Rng + SeedableRng + Send> Iterator for RandIter<T, R>
-where Standard: Distribution<T> {
+where
+    Standard: Distribution<T>,
+{
     type Item = T;
     fn next(&mut self) -> Option<T> {
         if self.idx == self.len {
@@ -460,7 +522,7 @@ impl<T: Clone + Send, R: Clone + Rng + SeedableRng + Send> qc::Arbitrary for Ran
             idx: 0,
             len: g.size(),
             rng: R::seed_from_u64(g.next_u64()),
-            _t : PhantomData{},
+            _t: PhantomData {},
         }
     }
 }
@@ -474,10 +536,7 @@ where
 {
     let j = i.clone();
     let k = k as usize;
-    it::assert_equal(
-        i.k_smallest(k),
-        j.sorted().take(k)
-    )
+    it::assert_equal(i.k_smallest(k), j.sorted().take(k))
 }
 
 macro_rules! generic_test {
@@ -505,7 +564,7 @@ fn sorted_by_key() {
 
 #[test]
 fn test_multipeek() {
-    let nums = vec![1u8,2,3,4,5];
+    let nums = vec![1u8, 2, 3, 4, 5];
 
     let mp = multipeek(nums.iter().map(|&x| x));
     assert_eq!(nums, mp.collect::<Vec<_>>());
@@ -546,7 +605,7 @@ fn test_multipeek_reset() {
 #[test]
 fn test_multipeek_peeking_next() {
     use crate::it::PeekingNext;
-    let nums = vec![1u8,2,3,4,5,6,7];
+    let nums = vec![1u8, 2, 3, 4, 5, 6, 7];
 
     let mut mp = multipeek(nums.iter().map(|&x| x));
     assert_eq!(mp.peeking_next(|&x| x != 0), Some(1));
@@ -571,7 +630,7 @@ fn test_multipeek_peeking_next() {
 
 #[test]
 fn test_peek_nth() {
-    let nums = vec![1u8,2,3,4,5];
+    let nums = vec![1u8, 2, 3, 4, 5];
 
     let iter = peek_nth(nums.iter().map(|&x| x));
     assert_eq!(nums, iter.collect::<Vec<_>>());
@@ -606,7 +665,7 @@ fn test_peek_nth() {
 #[test]
 fn test_peek_nth_peeking_next() {
     use it::PeekingNext;
-    let nums = vec![1u8,2,3,4,5,6,7];
+    let nums = vec![1u8, 2, 3, 4, 5, 6, 7];
     let mut iter = peek_nth(nums.iter().map(|&x| x));
 
     assert_eq!(iter.peeking_next(|&x| x != 0), Some(1));
@@ -672,11 +731,11 @@ fn group_by() {
 
         for &idx in &indices[..] {
             let (key, text) = match idx {
-                 0 => ('A', "Aaa".chars()),
-                 1 => ('B', "Bbb".chars()),
-                 2 => ('C', "ccCc".chars()),
-                 3 => ('D', "DDDD".chars()),
-                 _ => unreachable!(),
+                0 => ('A', "Aaa".chars()),
+                1 => ('B', "Bbb".chars()),
+                2 => ('C', "ccCc".chars()),
+                3 => ('D', "DDDD".chars()),
+                _ => unreachable!(),
             };
             assert_eq!(key, subs[idx].0);
             it::assert_equal(&mut subs[idx].1, text);
@@ -701,9 +760,11 @@ fn group_by() {
     {
         let mut ntimes = 0;
         let text = "AABCCC";
-        for (_, sub) in &text.chars().group_by(|&x| { ntimes += 1; x}) {
-            for _ in sub {
-            }
+        for (_, sub) in &text.chars().group_by(|&x| {
+            ntimes += 1;
+            x
+        }) {
+            for _ in sub {}
         }
         assert_eq!(ntimes, text.len());
     }
@@ -711,8 +772,10 @@ fn group_by() {
     {
         let mut ntimes = 0;
         let text = "AABCCC";
-        for _ in &text.chars().group_by(|&x| { ntimes += 1; x}) {
-        }
+        for _ in &text.chars().group_by(|&x| {
+            ntimes += 1;
+            x
+        }) {}
         assert_eq!(ntimes, text.len());
     }
 
@@ -752,8 +815,7 @@ fn group_by_lazy_2() {
         if i < 2 {
             groups.push(group);
         } else if i < 4 {
-            for _ in group {
-            }
+            for _ in group {}
         } else {
             groups.push(group);
         }
@@ -765,7 +827,11 @@ fn group_by_lazy_2() {
     // use groups as chunks
     let data = vec![0, 0, 0, 1, 1, 0, 0, 2, 2, 3, 3];
     let mut i = 0;
-    let grouper = data.iter().group_by(move |_| { let k = i / 3; i += 1; k });
+    let grouper = data.iter().group_by(move |_| {
+        let k = i / 3;
+        i += 1;
+        k
+    });
     for (i, group) in &grouper {
         match i {
             0 => it::assert_equal(group, &[0, 0, 0]),
@@ -816,8 +882,8 @@ fn concat_empty() {
 
 #[test]
 fn concat_non_empty() {
-    let data = vec![vec![1,2,3], vec![4,5,6], vec![7,8,9]];
-    assert_eq!(data.into_iter().concat(), vec![1,2,3,4,5,6,7,8,9])
+    let data = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
+    assert_eq!(data.into_iter().concat(), vec![1, 2, 3, 4, 5, 6, 7, 8, 9])
 }
 
 #[test]
@@ -825,19 +891,20 @@ fn combinations() {
     assert!((1..3).combinations(5).next().is_none());
 
     let it = (1..3).combinations(2);
-    it::assert_equal(it, vec![
-        vec![1, 2],
-        ]);
+    it::assert_equal(it, vec![vec![1, 2]]);
 
     let it = (1..5).combinations(2);
-    it::assert_equal(it, vec![
-        vec![1, 2],
-        vec![1, 3],
-        vec![1, 4],
-        vec![2, 3],
-        vec![2, 4],
-        vec![3, 4],
-        ]);
+    it::assert_equal(
+        it,
+        vec![
+            vec![1, 2],
+            vec![1, 3],
+            vec![1, 4],
+            vec![2, 3],
+            vec![2, 4],
+            vec![3, 4],
+        ],
+    );
 
     it::assert_equal((0..0).tuple_combinations::<(_, _)>(), <Vec<_>>::new());
     it::assert_equal((0..1).tuple_combinations::<(_, _)>(), <Vec<_>>::new());
@@ -856,7 +923,6 @@ fn combinations_of_too_short() {
         assert!((0..i - 1).combinations(i).next().is_none());
     }
 }
-
 
 #[test]
 fn combinations_zero() {
@@ -887,15 +953,9 @@ fn combinations_with_replacement() {
         ],
     );
     // Zero size
-    it::assert_equal(
-        (0..3).combinations_with_replacement(0),
-        vec![vec![]],
-    );
+    it::assert_equal((0..3).combinations_with_replacement(0), vec![vec![]]);
     // Zero size on empty pool
-    it::assert_equal(
-        (0..0).combinations_with_replacement(0),
-        vec![vec![]],
-    );
+    it::assert_equal((0..0).combinations_with_replacement(0), vec![vec![]]);
     // Empty pool
     it::assert_equal(
         (0..0).combinations_with_replacement(2),
@@ -907,13 +967,23 @@ fn combinations_with_replacement() {
 fn powerset() {
     it::assert_equal((0..0).powerset(), vec![vec![]]);
     it::assert_equal((0..1).powerset(), vec![vec![], vec![0]]);
-    it::assert_equal((0..2).powerset(), vec![vec![], vec![0], vec![1], vec![0, 1]]);
-    it::assert_equal((0..3).powerset(), vec![
-        vec![],
-        vec![0], vec![1], vec![2],
-        vec![0, 1], vec![0, 2], vec![1, 2],
-        vec![0, 1, 2]
-    ]);
+    it::assert_equal(
+        (0..2).powerset(),
+        vec![vec![], vec![0], vec![1], vec![0, 1]],
+    );
+    it::assert_equal(
+        (0..3).powerset(),
+        vec![
+            vec![],
+            vec![0],
+            vec![1],
+            vec![2],
+            vec![0, 1],
+            vec![0, 2],
+            vec![1, 2],
+            vec![0, 1, 2],
+        ],
+    );
 
     assert_eq!((0..4).powerset().count(), 1 << 4);
     assert_eq!((0..8).powerset().count(), 1 << 8);
@@ -942,8 +1012,7 @@ fn diff_longer() {
     let diff = it::diff_with(a.iter(), b_map, |a, b| *a == b);
 
     assert!(match diff {
-        Some(it::Diff::Longer(_, remaining)) =>
-            remaining.collect::<Vec<_>>() == vec![5, 6],
+        Some(it::Diff::Longer(_, remaining)) => remaining.collect::<Vec<_>>() == vec![5, 6],
         _ => false,
     });
 }
@@ -963,8 +1032,8 @@ fn diff_shorter() {
 
 #[test]
 fn minmax() {
-    use std::cmp::Ordering;
     use crate::it::MinMaxResult;
+    use std::cmp::Ordering;
 
     // A peculiar type: Equality compares both tuple items, but ordering only the
     // first item.  This is so we can check the stability property easily.
@@ -983,7 +1052,10 @@ fn minmax() {
         }
     }
 
-    assert_eq!(None::<Option<u32>>.iter().minmax(), MinMaxResult::NoElements);
+    assert_eq!(
+        None::<Option<u32>>.iter().minmax(),
+        MinMaxResult::NoElements
+    );
 
     assert_eq!(Some(1u32).iter().minmax(), MinMaxResult::OneElement(&1));
 
@@ -996,7 +1068,11 @@ fn minmax() {
     assert_eq!(min, &Val(2, 0));
     assert_eq!(max, &Val(0, 2));
 
-    let (min, max) = data.iter().minmax_by(|x, y| x.1.cmp(&y.1)).into_option().unwrap();
+    let (min, max) = data
+        .iter()
+        .minmax_by(|x, y| x.1.cmp(&y.1))
+        .into_option()
+        .unwrap();
     assert_eq!(min, &Val(2, 0));
     assert_eq!(max, &Val(0, 2));
 }
@@ -1019,8 +1095,9 @@ fn format() {
 
 #[test]
 fn while_some() {
-    let ns = (1..10).map(|x| if x % 5 != 0 { Some(x) } else { None })
-                    .while_some();
+    let ns = (1..10)
+        .map(|x| if x % 5 != 0 { Some(x) } else { None })
+        .while_some();
     it::assert_equal(ns, vec![1, 2, 3, 4]);
 }
 
@@ -1029,15 +1106,18 @@ fn while_some() {
 fn fold_while() {
     let mut iterations = 0;
     let vec = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-    let sum = vec.into_iter().fold_while(0, |acc, item| {
-        iterations += 1;
-        let new_sum = acc.clone() + item;
-        if new_sum <= 20 {
-            FoldWhile::Continue(new_sum)
-        } else {
-            FoldWhile::Done(acc)
-        }
-    }).into_inner();
+    let sum = vec
+        .into_iter()
+        .fold_while(0, |acc, item| {
+            iterations += 1;
+            let new_sum = acc.clone() + item;
+            if new_sum <= 20 {
+                FoldWhile::Continue(new_sum)
+            } else {
+                FoldWhile::Done(acc)
+            }
+        })
+        .into_inner();
     assert_eq!(iterations, 6);
     assert_eq!(sum, 15);
 }
@@ -1076,7 +1156,8 @@ fn exactly_one_question_mark_syntax_works() {
     exactly_one_question_mark_return().unwrap_err();
 }
 
-fn exactly_one_question_mark_return() -> Result<(), ExactlyOneError<std::slice::Iter<'static, ()>>> {
+fn exactly_one_question_mark_return() -> Result<(), ExactlyOneError<std::slice::Iter<'static, ()>>>
+{
     [].iter().exactly_one()?;
     Ok(())
 }


### PR DESCRIPTION
The math for size hint on duplicates would panic (with an overflow) if more elements were pending than remained in the size hint of the input iterator. This wasn't being tested since `pending` is only updated once some elements are advanced from the iterator.

This is actually pretty common, since collecting to a vector calls `next` first (before getting the size hint), for some reason related to branch prediction.

This adds an explicit test for collecting a vector from duplicates as well as a quick check case that skips elements before checking the size hint. It's not clear why the exhaustive check inside quickcheck wasn't catching this. 