### PR TITLE
Debug impls

### DIFF
--- a/src/adaptors/coalesce.rs
+++ b/src/adaptors/coalesce.rs
@@ -137,7 +137,7 @@ where
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DedupEq;
 
 impl<T: PartialEq> DedupPredicate<T> for DedupEq {
@@ -186,7 +186,7 @@ where
 pub type DedupByWithCount<I, Pred> =
     CoalesceBy<I, DedupPredWithCount2CoalescePred<Pred>, (usize, <I as Iterator>::Item)>;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DedupPredWithCount2CoalescePred<DP>(DP);
 
 impl<DP, T> CoalescePredicate<T, (usize, T)> for DedupPredWithCount2CoalescePred<DP>

--- a/src/adaptors/coalesce.rs
+++ b/src/adaptors/coalesce.rs
@@ -119,6 +119,10 @@ pub type DedupBy<I, Pred> = CoalesceBy<I, DedupPred2CoalescePred<Pred>, <I as It
 #[derive(Clone)]
 pub struct DedupPred2CoalescePred<DP>(DP);
 
+impl<DP> fmt::Debug for DedupPred2CoalescePred<DP> {
+    debug_fmt_fields!(DedupPred2CoalescePred,);
+}
+
 pub trait DedupPredicate<T> {
     // TODO replace by Fn(&T, &T)->bool once Rust supports it
     fn dedup_pair(&mut self, a: &T, b: &T) -> bool;

--- a/src/adaptors/map.rs
+++ b/src/adaptors/map.rs
@@ -84,6 +84,10 @@ where
 #[derive(Clone)]
 pub struct MapSpecialCaseFnOk<F>(F);
 
+impl<F> std::fmt::Debug for MapSpecialCaseFnOk<F> {
+    debug_fmt_fields!(MapSpecialCaseFnOk,);
+}
+
 /// Create a new `MapOk` iterator.
 pub fn map_ok<I, F, T, U, E>(iter: I, f: F) -> MapOk<I, F>
 where

--- a/src/adaptors/map.rs
+++ b/src/adaptors/map.rs
@@ -1,7 +1,7 @@
 use std::iter::FromIterator;
 use std::marker::PhantomData;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct MapSpecialCase<I, F> {
     iter: I,
@@ -108,7 +108,7 @@ impl<T: Into<U>, U> MapSpecialCaseFn<T> for MapSpecialCaseFnInto<U> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MapSpecialCaseFnInto<U>(PhantomData<U>);
 
 /// Create a new [`MapInto`] iterator.

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -849,6 +849,13 @@ pub struct FilterOk<I, F> {
     f: F
 }
 
+impl<I, F> fmt::Debug for FilterOk<I, F>
+where
+    I: fmt::Debug,
+{
+    debug_fmt_fields!(FilterOk, iter);
+}
+
 /// Create a new `FilterOk` iterator.
 pub fn filter_ok<I, F, T, E>(iter: I, f: F) -> FilterOk<I, F>
     where I: Iterator<Item = Result<T, E>>,
@@ -915,6 +922,13 @@ impl<I, F, T, E> FusedIterator for FilterOk<I, F>
 pub struct FilterMapOk<I, F> {
     iter: I,
     f: F
+}
+
+impl<I, F> fmt::Debug for FilterMapOk<I, F>
+where
+    I: fmt::Debug,
+{
+    debug_fmt_fields!(FilterMapOk, iter);
 }
 
 fn transpose_result<T, E>(result: Result<Option<T>, E>) -> Option<Result<T, E>> {
@@ -995,6 +1009,13 @@ pub struct Positions<I, F> {
     count: usize,
 }
 
+impl<I, F> fmt::Debug for Positions<I, F>
+where
+    I: fmt::Debug,
+{
+    debug_fmt_fields!(Positions, iter, count);
+}
+
 /// Create a new `Positions` iterator.
 pub fn positions<I, F>(iter: I, f: F) -> Positions<I, F>
     where I: Iterator,
@@ -1056,6 +1077,13 @@ impl<I, F> FusedIterator for Positions<I, F>
 pub struct Update<I, F> {
     iter: I,
     f: F,
+}
+
+impl<I, F> fmt::Debug for Update<I, F>
+where
+    I: fmt::Debug,
+{
+    debug_fmt_fields!(Update, iter);
 }
 
 /// Create a new `Update` iterator.

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -477,7 +477,7 @@ pub trait MergePredicate<T> {
     fn merge_pred(&mut self, a: &T, b: &T) -> bool;
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MergeLte;
 
 impl<T: PartialOrd> MergePredicate<T> for MergeLte {

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -18,6 +18,14 @@ pub struct MultiProduct<I>(Vec<MultiProductIter<I>>)
     where I: Iterator + Clone,
           I::Item: Clone;
 
+impl<I> std::fmt::Debug for MultiProduct<I>
+where
+    I: Iterator + Clone + std::fmt::Debug,
+    I::Item: Clone + std::fmt::Debug,
+{
+    debug_fmt_fields!(CoalesceBy, 0);
+}
+
 /// Create a new cartesian product iterator over an arbitrary number
 /// of iterators of the same type.
 ///

--- a/src/duplicates_impl.rs
+++ b/src/duplicates_impl.rs
@@ -134,6 +134,9 @@ mod private {
 
     /// Apply a user-supplied function to elements before checking them for equality.
     pub struct ByFn<F>(pub(crate) F);
+    impl<F> fmt::Debug for ByFn<F> {
+        debug_fmt_fields!(ByFn,);
+    }
     impl<K, V, F> KeyMethod<K, V> for ByFn<F>
     where
         F: FnMut(&V) -> K,

--- a/src/duplicates_impl.rs
+++ b/src/duplicates_impl.rs
@@ -122,6 +122,7 @@ mod private {
     }
 
     /// Apply the identity function to elements before checking them for equality.
+    #[derive(Debug)]
     pub struct ById;
     impl<V> KeyMethod<V, V> for ById {
         type Container = JustValue<V>;
@@ -152,6 +153,7 @@ mod private {
         fn value(self) -> V;
     }
 
+    #[derive(Debug)]
     pub struct KeyValue<K, V>(K, V);
     impl<K, V> KeyXorValue<K, V> for KeyValue<K, V> {
         fn key_ref(&self) -> &K {
@@ -165,6 +167,7 @@ mod private {
         }
     }
 
+    #[derive(Debug)]
     pub struct JustValue<V>(V);
     impl<V> KeyXorValue<V, V> for JustValue<V> {
         fn key_ref(&self) -> &V {

--- a/src/impl_macros.rs
+++ b/src/impl_macros.rs
@@ -2,7 +2,7 @@
 //! Implementation's internal macros
 
 macro_rules! debug_fmt_fields {
-    ($tyname:ident, $($($field:ident).+),*) => {
+    ($tyname:ident, $($($field:tt/*TODO ideally we would accept ident or tuple element here*/).+),*) => {
         fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
             f.debug_struct(stringify!($tyname))
                 $(

--- a/src/kmerge_impl.rs
+++ b/src/kmerge_impl.rs
@@ -111,7 +111,7 @@ pub trait KMergePredicate<T> {
     fn kmerge_pred(&mut self, a: &T, b: &T) -> bool;
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct KMergeByLt;
 
 impl<T: PartialOrd> KMergePredicate<T> for KMergeByLt {

--- a/src/pad_tail.rs
+++ b/src/pad_tail.rs
@@ -16,6 +16,13 @@ pub struct PadUsing<I, F> {
     filler: F,
 }
 
+impl<I, F> std::fmt::Debug for PadUsing<I, F>
+where
+    I: std::fmt::Debug,
+{
+    debug_fmt_fields!(PadUsing, iter, min, pos);
+}
+
 /// Create a new **PadUsing** iterator.
 pub fn pad_using<I, F>(iter: I, min: usize, filler: F) -> PadUsing<I, F>
     where I: Iterator,

--- a/src/peeking_take_while.rs
+++ b/src/peeking_take_while.rs
@@ -83,6 +83,13 @@ pub struct PeekingTakeWhile<'a, I: 'a, F>
     f: F,
 }
 
+impl<'a, I: 'a, F> std::fmt::Debug for PeekingTakeWhile<'a, I, F>
+where
+    I: Iterator + std::fmt::Debug,
+{
+    debug_fmt_fields!(PeekingTakeWhile, iter);
+}
+
 /// Create a PeekingTakeWhile
 pub fn peeking_take_while<I, F>(iter: &mut I, f: F) -> PeekingTakeWhile<I, F>
     where I: Iterator,

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -77,7 +77,7 @@ impl<T> ExactSizeIterator for TupleBuffer<T>
 /// An iterator that groups the items in tuples of a specific size.
 ///
 /// See [`.tuples()`](crate::Itertools::tuples) for more information.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct Tuples<I, T>
     where I: Iterator<Item = T::Item>,


### PR DESCRIPTION
To solve https://github.com/rust-itertools/itertools/issues/32 a bit further, this adds some `Debug` impls, following our established guidelines (see https://github.com/rust-itertools/itertools/pull/268#issuecomment-372105788).

* `derive(Debug)` on structs without closures.
* `debug_fmt_fields` on structs with closures. I extended `debug_fmt_fields` to support debug-formatting tuple elemts.

This does not yet cover all cases, but a good fraction of them.