### PR TITLE
Deprecate `fold1` in faviour of `reduce`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2243,6 +2243,7 @@ pub trait Itertools : Iterator {
     /// assert_eq!((0..10).fold1(|x, y| x + y).unwrap_or(0), 45);
     /// assert_eq!((0..0).fold1(|x, y| x * y), None);
     /// ```
+    #[deprecated(since = "0.10.2", note = "Use `Iterator::reduce` instead")]
     fn fold1<F>(mut self, f: F) -> Option<Self::Item>
         where F: FnMut(Self::Item, Self::Item) -> Self::Item,
               Self: Sized,


### PR DESCRIPTION
[`Iterator::reduce`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.reduce) is stable since Rust 1.51 (current stable is 1.55), so this change seems reasonable (similarly to depreciation of `foreach`)