### PR TITLE
Release 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.10.2
+  - Add `Itertools::multiunzip` (#362, #565)
+  - Add `intersperse` and `intersperse_with` free functions (#555)
+  - Add `Itertools::sorted_by_cached_key` (#424, #575)
+  - Specialize `ProcessResults::fold` (#563)
+  - Fix subtraction overflow in `DuplicatesBy::size_hint` (#552)
+  - Fix specialization tests (#574)
+  - More `Debug` impls (#573)
+  - Deprecate `fold1` (use `reduce` instead) (#580)
+  - Documentation fixes (`HomogenousTuple`, `into_group_map`, `into_group_map_by`, `MultiPeek::peek`) (#543 et al.)
+
 ## 0.10.1
   - Add `Itertools::contains` (#514)
   - Add `Itertools::counts_by` (#515)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.2"
 
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-itertools/itertools"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ How to use with Cargo:
 
 ```toml
 [dependencies]
-itertools = "0.10.0"
+itertools = "0.10.2"
 ```
 
 How to use in your crate:


### PR DESCRIPTION
Prepared changelog and Cargo.toml for itertools 0.10.2, requested per https://github.com/rust-itertools/itertools/issues/584.