### PR TITLE
Add `equal() -> Option<Self::Item>` as companion to `all_equal() -> bool`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1882,6 +1882,33 @@ pub trait Itertools : Iterator {
         self.all(move |elt| used.insert(elt))
     }
 
+    /// Check whether all elements compare equal, and return `Some` with the equal element.
+    ///
+    /// Empty iterators return `None`, and so do iterators with non-equal elements.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let data = vec![1u8, 1, 1, 2, 2, 3, 3, 3, 4, 5, 5];
+    /// assert_eq!(data.iter().equal(), None);
+    /// assert_eq!(data[0..3].iter().equal(), Some(&1));
+    /// assert_eq!(data[3..5].iter().equal(), Some(&2));
+    /// assert_eq!(data[5..8].iter().equal(), Some(&3));
+    ///
+    /// let data : Option<usize> = None;
+    /// assert_eq!(data.into_iter().equal(), None);
+    /// ```
+    fn equal(&mut self) -> Option<Self::Item>
+    where
+        Self: Sized,
+        Self::Item: PartialEq,
+    {
+        match self.next() {
+            None => None,
+            Some(a) => self.all(|x| a == x).then(|| a),
+        }
+    }
+
     /// Consume the first `n` elements from the iterator eagerly,
     /// and return the same iterator again.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1905,7 +1905,7 @@ pub trait Itertools : Iterator {
     {
         match self.next() {
             None => None,
-            Some(a) => self.all(|x| a == x).then(|| a),
+            Some(a) => if self.all(|x| a == x) { Some(a) } else { None }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1890,15 +1890,15 @@ pub trait Itertools : Iterator {
     /// use itertools::Itertools;
     ///
     /// let data = vec![1u8, 1, 1, 2, 2, 3, 3, 3, 4, 5, 5];
-    /// assert_eq!(data.iter().equal(), None);
-    /// assert_eq!(data[0..3].iter().equal(), Some(&1));
-    /// assert_eq!(data[3..5].iter().equal(), Some(&2));
-    /// assert_eq!(data[5..8].iter().equal(), Some(&3));
+    /// assert_eq!(data.iter().all_equal_item(), None);
+    /// assert_eq!(data[0..3].iter().all_equal_item(), Some(&1));
+    /// assert_eq!(data[3..5].iter().all_equal_item(), Some(&2));
+    /// assert_eq!(data[5..8].iter().all_equal_item(), Some(&3));
     ///
     /// let data : Option<usize> = None;
-    /// assert_eq!(data.into_iter().equal(), None);
+    /// assert_eq!(data.into_iter().all_equal_item(), None);
     /// ```
-    fn equal(&mut self) -> Option<Self::Item>
+    fn all_equal_item(&mut self) -> Option<Self::Item>
     where
         Self: Sized,
         Self::Item: PartialEq,

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -224,12 +224,12 @@ fn all_equal() {
 
 #[test]
 fn equal() {
-    assert_eq!("".chars().equal(), None);
-    assert_eq!("A".chars().equal(), Some('A'));
-    assert_eq!("AABBCCC".chars().equal(), None);
-    assert_eq!("AAAAAAA".chars().equal(), Some('A'));
+    assert_eq!("".chars().all_equal_item(), None);
+    assert_eq!("A".chars().all_equal_item(), Some('A'));
+    assert_eq!("AABBCCC".chars().all_equal_item(), None);
+    assert_eq!("AAAAAAA".chars().all_equal_item(), Some('A'));
     for (key, mut sub) in &"AABBCCC".chars().group_by(|&x| x) {
-        assert_eq!(sub.equal(), Some(key));
+        assert_eq!(sub.all_equal_item(), Some(key));
     }
 }
 

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -223,6 +223,17 @@ fn all_equal() {
 }
 
 #[test]
+fn equal() {
+    assert_eq!("".chars().equal(), None);
+    assert_eq!("A".chars().equal(), Some('A'));
+    assert_eq!("AABBCCC".chars().equal(), None);
+    assert_eq!("AAAAAAA".chars().equal(), Some('A'));
+    for (key, mut sub) in &"AABBCCC".chars().group_by(|&x| x) {
+        assert_eq!(sub.equal(), Some(key));
+    }
+}
+
+#[test]
 fn all_unique() {
     assert!("ABCDEFGH".chars().all_unique());
     assert!(!"ABCDEFGA".chars().all_unique());


### PR DESCRIPTION
This allows use the equal value or to default it, which otherwise is cumbersome and complex as indicated in this example from `nameless`:

```diff
diff --git a/examples/text-cat.rs b/examples/text-cat.rs
index de1ceea..aac4db5 100644
--- a/examples/text-cat.rs
+++ b/examples/text-cat.rs
@@ -10,12 +10,12 @@ use nameless::{InputTextStream, LazyOutput, MediaType, OutputTextStream};
 /// * `inputs` - Input sources, stdin if none
 #[kommand::main]
 fn main(output: LazyOutput<OutputTextStream>, inputs: Vec<InputTextStream>) -> anyhow::Result<()> {
-    let media_type = match inputs.iter().next() {
-        Some(first) if inputs.iter().map(InputTextStream::media_type).all_equal() => {
-            first.media_type().clone()
-        }
-        _ => MediaType::text(),
-    };
+    let media_type = inputs
+        .iter()
+        .map(InputTextStream::media_type)
+        .equal()
+        .cloned()
+        .unwrap_or_else(MediaType::text);

     let mut output = output.materialize(media_type)?;
```

### Open Questions

* Is `equal()` a fitting name? Are there better alternatives?