### PR TITLE
Avoid warning

### DIFF
--- a/src/adaptors/coalesce.rs
+++ b/src/adaptors/coalesce.rs
@@ -3,6 +3,7 @@ use std::iter::FusedIterator;
 
 use crate::size_hint;
 
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct CoalesceBy<I, F, T>
 where
     I: Iterator,
@@ -86,7 +87,6 @@ impl<I: Iterator, F: CoalescePredicate<I::Item, T>, T> FusedIterator for Coalesc
 /// An iterator adaptor that may join together adjacent elements.
 ///
 /// See [`.coalesce()`](crate::Itertools::coalesce) for more information.
-#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub type Coalesce<I, F> = CoalesceBy<I, F, <I as Iterator>::Item>;
 
 impl<F, Item, T> CoalescePredicate<Item, T> for F
@@ -113,7 +113,6 @@ where
 /// An iterator adaptor that removes repeated duplicates, determining equality using a comparison function.
 ///
 /// See [`.dedup_by()`](crate::Itertools::dedup_by) or [`.dedup()`](crate::Itertools::dedup) for more information.
-#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub type DedupBy<I, Pred> = CoalesceBy<I, DedupPred2CoalescePred<Pred>, <I as Iterator>::Item>;
 
 #[derive(Clone)]
@@ -186,7 +185,6 @@ where
 ///
 /// See [`.dedup_by_with_count()`](crate::Itertools::dedup_by_with_count) or
 /// [`.dedup_with_count()`](crate::Itertools::dedup_with_count) for more information.
-#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub type DedupByWithCount<I, Pred> =
     CoalesceBy<I, DedupPredWithCount2CoalescePred<Pred>, (usize, <I as Iterator>::Item)>;
 

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -490,7 +490,6 @@ impl<T: PartialOrd> MergePredicate<T> for MergeLte {
 /// Iterator element type is `I::Item`.
 ///
 /// See [`.merge()`](crate::Itertools::merge_by) for more information.
-#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub type Merge<I, J> = MergeBy<I, J, MergeLte>;
 
 /// Create an iterator that merges elements in `i` and `j`.

--- a/src/duplicates_impl.rs
+++ b/src/duplicates_impl.rs
@@ -188,7 +188,6 @@ mod private {
 /// An iterator adapter to filter for duplicate elements.
 ///
 /// See [`.duplicates_by()`](crate::Itertools::duplicates_by) for more information.
-#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub type DuplicatesBy<I, V, F> = private::DuplicatesBy<I, V, private::ByFn<F>>;
 
 /// Create a new `DuplicatesBy` iterator.

--- a/src/flatten_ok.rs
+++ b/src/flatten_ok.rs
@@ -138,7 +138,6 @@ where
     T: IntoIterator,
     T::IntoIter: Clone,
 {
-    #[inline]
     clone_fields!(iter, inner_front, inner_back);
 }
 

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -39,7 +39,6 @@ pub fn new<I, K, V>(iter: I) -> GroupingMap<I>
 /// `GroupingMapBy` is an intermediate struct for efficient group-and-fold operations.
 /// 
 /// See [`GroupingMap`] for more informations.
-#[must_use = "GroupingMapBy is lazy and do nothing unless consumed"]
 pub type GroupingMapBy<I, F> = GroupingMap<MapForGrouping<I, F>>;
 
 /// `GroupingMap` is an intermediate struct for efficient group-and-fold operations.

--- a/src/impl_macros.rs
+++ b/src/impl_macros.rs
@@ -15,6 +15,7 @@ macro_rules! debug_fmt_fields {
 
 macro_rules! clone_fields {
     ($($field:ident),*) => {
+        #[inline] // TODO is this sensible?
         fn clone(&self) -> Self {
             Self {
                 $($field: self.$field.clone(),)*

--- a/src/kmerge_impl.rs
+++ b/src/kmerge_impl.rs
@@ -104,7 +104,6 @@ fn sift_down<T, S>(heap: &mut [T], index: usize, mut less_than: S)
 /// Iterator element type is `I::Item`.
 ///
 /// See [`.kmerge()`](crate::Itertools::kmerge) for more information.
-#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub type KMerge<I> = KMergeBy<I, KMergeByLt>;
 
 pub trait KMergePredicate<T> {

--- a/src/rciter_impl.rs
+++ b/src/rciter_impl.rs
@@ -51,7 +51,6 @@ pub fn rciter<I>(iterable: I) -> RcIter<I::IntoIter>
 }
 
 impl<I> Clone for RcIter<I> {
-    #[inline]
     clone_fields!(rciter);
 }
 


### PR DESCRIPTION
Fixes two warnings that would clutter output.

* `#[inline]` not meaningful before macro call. I pulled it into the macro, but with a TODO asking whether this is sensible. As far as I know, we do not have an established guideline for this, so I thought it's ok to leave it in there.
* `#[must_use]` not meaningful on type alias. Pulled to the original type where not present before.