### PR TITLE
Add `take_until` method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1411,8 +1411,27 @@ pub trait Itertools : Iterator {
     /// use itertools::Itertools;
     ///
     /// let items = vec![1, 2, 3, 4, 5];
-    /// let filtered: Vec<i32> = items.into_iter().take_until(|&n| n % 3 != 0).collect();
+    /// let filtered: Vec<_> = items.into_iter().take_until(|&n| n % 3 != 0).collect();
+    ///
     /// assert_eq!(filtered, vec![1, 2, 3]);
+    /// ```
+    ///
+    /// ```rust
+    /// use itertools::Itertools;
+    /// let items = vec![1, 2, 3, 4, 5];
+    ///
+    /// let take_until_result: Vec<_> = items
+    ///     .clone()
+    ///     .into_iter()
+    ///     .take_until(|&n| n % 3 != 0)
+    ///     .collect();
+    /// let take_while_result: Vec<_> = items
+    ///     .into_iter()
+    ///     .take_while(|&n| n % 3 != 0)
+    ///     .collect();
+    ///
+    /// assert_eq!(take_until_result, vec![1, 2, 3]);
+    /// assert_eq!(take_while_result, vec![1, 2]);
     /// ```
     ///
     /// ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1391,24 +1391,22 @@ pub trait Itertools : Iterator {
         adaptors::take_while_ref(self, accept)
     }
 
-    /// An iterator adaptor that consumes elements while the given predicate is
-    /// true, including the element for which the predicate first returned
-    /// false.
+    /// Returns an iterator adaptor that consumes elements while the given
+    /// predicate is `true`, *including* the element for which the predicate
+    /// first returned `false`.
     ///
     /// The [`.take_while()`][std::iter::Iterator::take_while] adaptor is useful
     /// when you want items satisfying a predicate, but to know when to stop
     /// taking elements, we have to consume that last element that doesn't
-    /// satisfy the predicate. This adaptor simply includest that element where
+    /// satisfy the predicate. This adaptor simply includes that element where
     /// [`.take_while()`][std::iter::Iterator::take_while] would drop it.
     ///
     /// The [`.take_while_ref()`][crate::Itertools::take_while_ref] adaptor
-    /// serves a similar purpose, but this adaptor doesn't require cloning the
-    /// underlying elements.
-    ///
-    /// # Examples
+    /// serves a similar purpose, but this adaptor doesn't require [`Clone`]ing
+    /// the underlying elements.
     ///
     /// ```rust
-    /// use itertools::Itertools;
+    /// # use itertools::Itertools;
     ///
     /// let items = vec![1, 2, 3, 4, 5];
     /// let filtered: Vec<_> = items.into_iter().take_until(|&n| n % 3 != 0).collect();
@@ -1417,7 +1415,7 @@ pub trait Itertools : Iterator {
     /// ```
     ///
     /// ```rust
-    /// use itertools::Itertools;
+    /// # use itertools::Itertools;
     /// let items = vec![1, 2, 3, 4, 5];
     ///
     /// let take_until_result: Vec<_> = items
@@ -1435,7 +1433,7 @@ pub trait Itertools : Iterator {
     /// ```
     ///
     /// ```rust
-    /// use itertools::Itertools;
+    /// # use itertools::Itertools;
     /// #[derive(Debug, PartialEq)]
     /// struct NoCloneImpl(i32);
     ///

--- a/src/take_until.rs
+++ b/src/take_until.rs
@@ -1,0 +1,54 @@
+use std::fmt;
+
+/// An iterator adaptor that consumes elements while the given predicate is true, including the
+/// element for which the predicate first returned false.
+///
+/// See [`.take_until()`](crate::Itertools::take_until) for more information.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct TakeUntil<'a, I: 'a, F> {
+    iter: &'a mut I,
+    f: F,
+    done: bool,
+}
+
+impl<'a, I, F> TakeUntil<'a, I, F>
+where
+    I: Iterator,
+    F: FnMut(&I::Item) -> bool,
+{
+    /// Create a new [`TakeUntil`] from an iterator and a predicate.
+    pub fn new(iter: &'a mut I, f: F) -> Self {
+        Self { iter, f, done: false}
+    }
+}
+
+impl<'a, I, F> fmt::Debug for TakeUntil<'a, I, F>
+    where I: Iterator + fmt::Debug,
+{
+    debug_fmt_fields!(TakeUntil, iter);
+}
+
+impl<'a, I, F> Iterator for TakeUntil<'a, I, F>
+where
+    I: Iterator,
+    F: FnMut(&I::Item) -> bool
+{
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            None
+        } else {
+            self.iter.next().map(|item| {
+                if !(self.f)(&item) {
+                    self.done = true;
+                }
+                item
+            })
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, self.iter.size_hint().1)
+    }
+}


### PR DESCRIPTION
Adds `take_until` method that returns elements as long as a predicate is satisfied, but including the first element that doesn't satisfy the predicate.

First discussed addition to std in <https://github.com/rust-lang/rust/issues/62208>.

Closes #597.