### PR TITLE
add rustdoc and clippy to github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
           components: clippy
       - run: RUSTFLAGS="--deny warnings" cargo clippy ${{ matrix.features }}
 
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: RUSTDOCFLAGS="-Dwarnings" cargo doc --all-features
+
   msrv:
     runs-on: ubuntu-latest
     env:

--- a/benches/extra/zipslices.rs
+++ b/benches/extra/zipslices.rs
@@ -58,7 +58,7 @@ where
     #[inline(always)]
     pub fn from_slices(a: T, b: U) -> Self {
         let minl = cmp::min(a.len(), b.len());
-        ZipSlices {
+        Self {
             t: a,
             u: b,
             len: minl,

--- a/examples/iris.rs
+++ b/examples/iris.rs
@@ -25,7 +25,7 @@ enum ParseError {
 
 impl From<ParseFloatError> for ParseError {
     fn from(err: ParseFloatError) -> Self {
-        ParseError::Numeric(err)
+        Self::Numeric(err)
     }
 }
 
@@ -34,7 +34,7 @@ impl FromStr for Iris {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut iris = Iris {
+        let mut iris = Self {
             name: "".into(),
             data: [0.; 4],
         };

--- a/src/adaptors/coalesce.rs
+++ b/src/adaptors/coalesce.rs
@@ -17,9 +17,10 @@ where
     f: F,
 }
 
-impl<I: Clone, F: Clone, C> Clone for CoalesceBy<I, F, C>
+impl<I, F, C> Clone for CoalesceBy<I, F, C>
 where
-    I: Iterator,
+    I: Clone + Iterator,
+    F: Clone,
     C: CountItem<I::Item>,
     C::CItem: Clone,
 {

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -218,7 +218,7 @@ where
     /// Split the `PutBack` into its parts.
     #[inline]
     pub fn into_parts(self) -> (Option<I::Item>, I) {
-        let PutBack { top, iter } = self;
+        let Self { top, iter } = self;
         (top, iter)
     }
 
@@ -689,7 +689,7 @@ pub struct Tuple1Combination<I> {
 
 impl<I> From<I> for Tuple1Combination<I> {
     fn from(iter: I) -> Self {
-        Tuple1Combination { iter }
+        Self { iter }
     }
 }
 

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -123,11 +123,7 @@ where
     /// Returns true if iteration has started and has not yet finished; false
     /// otherwise.
     fn in_progress(&self) -> bool {
-        if let Some(last) = self.0.last() {
-            last.in_progress()
-        } else {
-            false
-        }
+        self.0.last().map_or(false, |last| last.in_progress())
     }
 }
 

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -123,7 +123,7 @@ where
     /// Returns true if iteration has started and has not yet finished; false
     /// otherwise.
     fn in_progress(&self) -> bool {
-        self.0.last().map_or(false, |last| last.in_progress())
+        self.0.last().map_or(false, MultiProductIter::in_progress)
     }
 }
 

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -77,16 +77,14 @@ where
         multi_iters: &mut [MultiProductIter<I>],
         mut state: MultiProductIterState,
     ) -> bool {
-        use self::MultiProductIterState::*;
-
         if let Some((last, rest)) = multi_iters.split_last_mut() {
             let on_first_iter = match state {
-                StartOfIter => {
+                MultiProductIterState::StartOfIter => {
                     let on_first_iter = !last.in_progress();
-                    state = MidIter { on_first_iter };
+                    state = MultiProductIterState::MidIter { on_first_iter };
                     on_first_iter
                 }
-                MidIter { on_first_iter } => on_first_iter,
+                MultiProductIterState::MidIter { on_first_iter } => on_first_iter,
             };
 
             if !on_first_iter {
@@ -108,8 +106,8 @@ where
             // Reached end of iterator list. On initialisation, return true.
             // At end of iteration (final iterator finishes), finish.
             match state {
-                StartOfIter => false,
-                MidIter { on_first_iter } => on_first_iter,
+                MultiProductIterState::StartOfIter => false,
+                MultiProductIterState::MidIter { on_first_iter } => on_first_iter,
             }
         }
     }

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -93,7 +93,7 @@ where
 
             if last.in_progress() {
                 true
-            } else if MultiProduct::iterate_last(rest, state) {
+            } else if Self::iterate_last(rest, state) {
                 last.reset();
                 last.iterate();
                 // If iterator is None twice consecutively, then iterator is
@@ -133,7 +133,7 @@ where
     I::Item: Clone,
 {
     fn new(iter: I) -> Self {
-        MultiProductIter {
+        Self {
             cur: None,
             iter: iter.clone(),
             iter_orig: iter,
@@ -165,7 +165,7 @@ where
     type Item = Vec<I::Item>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if MultiProduct::iterate_last(&mut self.0, MultiProductIterState::StartOfIter) {
+        if Self::iterate_last(&mut self.0, MultiProductIterState::StartOfIter) {
             Some(self.curr_iterator())
         } else {
             None

--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -65,13 +65,13 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         // If this is the first iteration, return early
         if self.first {
-            // In empty edge cases, stop iterating immediately
-            return if !(self.indices.is_empty() || self.pool.get_next()) {
-                None
-            // Otherwise, yield the initial state
-            } else {
+            return if self.indices.is_empty() || self.pool.get_next() {
+                // yield the initial state
                 self.first = false;
                 Some(self.current())
+            } else {
+                // In empty edge cases, stop iterating immediately
+                None
             };
         }
 

--- a/src/duplicates_impl.rs
+++ b/src/duplicates_impl.rs
@@ -22,7 +22,7 @@ mod private {
 
     impl<I: Iterator, Key: Eq + Hash, F> DuplicatesBy<I, Key, F> {
         pub(crate) fn new(iter: I, key_method: F) -> Self {
-            DuplicatesBy {
+            Self {
                 iter,
                 meta: Meta {
                     used: HashMap::new(),
@@ -77,7 +77,7 @@ mod private {
         type Item = I::Item;
 
         fn next(&mut self) -> Option<Self::Item> {
-            let DuplicatesBy { iter, meta } = self;
+            let Self { iter, meta } = self;
             iter.find_map(|v| meta.filter(v))
         }
 
@@ -109,7 +109,7 @@ mod private {
         F: KeyMethod<Key, I::Item>,
     {
         fn next_back(&mut self) -> Option<Self::Item> {
-            let DuplicatesBy { iter, meta } = self;
+            let Self { iter, meta } = self;
             iter.rev().find_map(|v| meta.filter(v))
         }
     }

--- a/src/either_or_both.rs
+++ b/src/either_or_both.rs
@@ -1,7 +1,5 @@
 use core::ops::{Deref, DerefMut};
 
-use crate::EitherOrBoth::*;
-
 use either::Either;
 
 /// Value that either holds a single A or B, or both.
@@ -29,13 +27,13 @@ impl<A, B> EitherOrBoth<A, B> {
     /// If `Left`, return true. Otherwise, return false.
     /// Exclusive version of [`has_left`](EitherOrBoth::has_left).
     pub fn is_left(&self) -> bool {
-        matches!(self, Left(_))
+        matches!(self, EitherOrBoth::Left(_))
     }
 
     /// If `Right`, return true. Otherwise, return false.
     /// Exclusive version of [`has_right`](EitherOrBoth::has_right).
     pub fn is_right(&self) -> bool {
-        matches!(self, Right(_))
+        matches!(self, EitherOrBoth::Right(_))
     }
 
     /// If `Both`, return true. Otherwise, return false.
@@ -46,16 +44,16 @@ impl<A, B> EitherOrBoth<A, B> {
     /// If `Left`, or `Both`, return `Some` with the left value. Otherwise, return `None`.
     pub fn left(self) -> Option<A> {
         match self {
-            Left(left) | Both(left, _) => Some(left),
-            _ => None,
+            EitherOrBoth::Left(left) | EitherOrBoth::Both(left, _) => Some(left),
+            EitherOrBoth::Right(_) => None,
         }
     }
 
     /// If `Right`, or `Both`, return `Some` with the right value. Otherwise, return `None`.
     pub fn right(self) -> Option<B> {
         match self {
-            Right(right) | Both(_, right) => Some(right),
-            _ => None,
+            EitherOrBoth::Right(right) | EitherOrBoth::Both(_, right) => Some(right),
+            EitherOrBoth::Left(_) => None,
         }
     }
 
@@ -87,7 +85,7 @@ impl<A, B> EitherOrBoth<A, B> {
     /// ```
     pub fn just_left(self) -> Option<A> {
         match self {
-            Left(left) => Some(left),
+            EitherOrBoth::Left(left) => Some(left),
             _ => None,
         }
     }
@@ -112,7 +110,7 @@ impl<A, B> EitherOrBoth<A, B> {
     /// ```
     pub fn just_right(self) -> Option<B> {
         match self {
-            Right(right) => Some(right),
+            EitherOrBoth::Right(right) => Some(right),
             _ => None,
         }
     }
@@ -120,7 +118,7 @@ impl<A, B> EitherOrBoth<A, B> {
     /// If `Both`, return `Some` containing the left and right values. Otherwise, return `None`.
     pub fn both(self) -> Option<(A, B)> {
         match self {
-            Both(a, b) => Some((a, b)),
+            EitherOrBoth::Both(a, b) => Some((a, b)),
             _ => None,
         }
     }
@@ -131,8 +129,8 @@ impl<A, B> EitherOrBoth<A, B> {
         B: Into<A>,
     {
         match self {
-            Left(a) | Both(a, _) => a,
-            Right(b) => b.into(),
+            EitherOrBoth::Left(a) | EitherOrBoth::Both(a, _) => a,
+            EitherOrBoth::Right(b) => b.into(),
         }
     }
 
@@ -142,26 +140,26 @@ impl<A, B> EitherOrBoth<A, B> {
         A: Into<B>,
     {
         match self {
-            Right(b) | Both(_, b) => b,
-            Left(a) => a.into(),
+            EitherOrBoth::Right(b) | EitherOrBoth::Both(_, b) => b,
+            EitherOrBoth::Left(a) => a.into(),
         }
     }
 
     /// Converts from `&EitherOrBoth<A, B>` to `EitherOrBoth<&A, &B>`.
     pub fn as_ref(&self) -> EitherOrBoth<&A, &B> {
         match *self {
-            Left(ref left) => Left(left),
-            Right(ref right) => Right(right),
-            Both(ref left, ref right) => Both(left, right),
+            EitherOrBoth::Left(ref left) => EitherOrBoth::Left(left),
+            EitherOrBoth::Right(ref right) => EitherOrBoth::Right(right),
+            EitherOrBoth::Both(ref left, ref right) => EitherOrBoth::Both(left, right),
         }
     }
 
     /// Converts from `&mut EitherOrBoth<A, B>` to `EitherOrBoth<&mut A, &mut B>`.
     pub fn as_mut(&mut self) -> EitherOrBoth<&mut A, &mut B> {
         match *self {
-            Left(ref mut left) => Left(left),
-            Right(ref mut right) => Right(right),
-            Both(ref mut left, ref mut right) => Both(left, right),
+            EitherOrBoth::Left(ref mut left) => EitherOrBoth::Left(left),
+            EitherOrBoth::Right(ref mut right) => EitherOrBoth::Right(right),
+            EitherOrBoth::Both(ref mut left, ref mut right) => EitherOrBoth::Both(left, right),
         }
     }
 
@@ -172,9 +170,9 @@ impl<A, B> EitherOrBoth<A, B> {
         B: Deref,
     {
         match *self {
-            Left(ref left) => Left(left),
-            Right(ref right) => Right(right),
-            Both(ref left, ref right) => Both(left, right),
+            EitherOrBoth::Left(ref left) => EitherOrBoth::Left(left),
+            EitherOrBoth::Right(ref right) => EitherOrBoth::Right(right),
+            EitherOrBoth::Both(ref left, ref right) => EitherOrBoth::Both(left, right),
         }
     }
 
@@ -185,18 +183,18 @@ impl<A, B> EitherOrBoth<A, B> {
         B: DerefMut,
     {
         match *self {
-            Left(ref mut left) => Left(left),
-            Right(ref mut right) => Right(right),
-            Both(ref mut left, ref mut right) => Both(left, right),
+            EitherOrBoth::Left(ref mut left) => EitherOrBoth::Left(left),
+            EitherOrBoth::Right(ref mut right) => EitherOrBoth::Right(right),
+            EitherOrBoth::Both(ref mut left, ref mut right) => EitherOrBoth::Both(left, right),
         }
     }
 
     /// Convert `EitherOrBoth<A, B>` to `EitherOrBoth<B, A>`.
     pub fn flip(self) -> EitherOrBoth<B, A> {
         match self {
-            Left(a) => Right(a),
-            Right(b) => Left(b),
-            Both(a, b) => Both(b, a),
+            EitherOrBoth::Left(a) => EitherOrBoth::Right(a),
+            EitherOrBoth::Right(b) => EitherOrBoth::Left(b),
+            EitherOrBoth::Both(a, b) => EitherOrBoth::Both(b, a),
         }
     }
 
@@ -207,9 +205,9 @@ impl<A, B> EitherOrBoth<A, B> {
         F: FnOnce(A) -> M,
     {
         match self {
-            Both(a, b) => Both(f(a), b),
-            Left(a) => Left(f(a)),
-            Right(b) => Right(b),
+            EitherOrBoth::Both(a, b) => EitherOrBoth::Both(f(a), b),
+            EitherOrBoth::Left(a) => EitherOrBoth::Left(f(a)),
+            EitherOrBoth::Right(b) => EitherOrBoth::Right(b),
         }
     }
 
@@ -220,9 +218,9 @@ impl<A, B> EitherOrBoth<A, B> {
         F: FnOnce(B) -> M,
     {
         match self {
-            Left(a) => Left(a),
-            Right(b) => Right(f(b)),
-            Both(a, b) => Both(a, f(b)),
+            EitherOrBoth::Left(a) => EitherOrBoth::Left(a),
+            EitherOrBoth::Right(b) => EitherOrBoth::Right(f(b)),
+            EitherOrBoth::Both(a, b) => EitherOrBoth::Both(a, f(b)),
         }
     }
 
@@ -235,9 +233,9 @@ impl<A, B> EitherOrBoth<A, B> {
         G: FnOnce(B) -> R,
     {
         match self {
-            Left(a) => Left(f(a)),
-            Right(b) => Right(g(b)),
-            Both(a, b) => Both(f(a), g(b)),
+            EitherOrBoth::Left(a) => EitherOrBoth::Left(f(a)),
+            EitherOrBoth::Right(b) => EitherOrBoth::Right(g(b)),
+            EitherOrBoth::Both(a, b) => EitherOrBoth::Both(f(a), g(b)),
         }
     }
 
@@ -248,8 +246,8 @@ impl<A, B> EitherOrBoth<A, B> {
         F: FnOnce(A) -> EitherOrBoth<L, B>,
     {
         match self {
-            Left(a) | Both(a, _) => f(a),
-            Right(b) => Right(b),
+            EitherOrBoth::Left(a) | EitherOrBoth::Both(a, _) => f(a),
+            EitherOrBoth::Right(b) => EitherOrBoth::Right(b),
         }
     }
 
@@ -260,8 +258,8 @@ impl<A, B> EitherOrBoth<A, B> {
         F: FnOnce(B) -> EitherOrBoth<A, R>,
     {
         match self {
-            Left(a) => Left(a),
-            Right(b) | Both(_, b) => f(b),
+            EitherOrBoth::Left(a) => EitherOrBoth::Left(a),
+            EitherOrBoth::Right(b) | EitherOrBoth::Both(_, b) => f(b),
         }
     }
 
@@ -286,9 +284,9 @@ impl<A, B> EitherOrBoth<A, B> {
     /// ```
     pub fn or(self, l: A, r: B) -> (A, B) {
         match self {
-            Left(inner_l) => (inner_l, r),
-            Right(inner_r) => (l, inner_r),
-            Both(inner_l, inner_r) => (inner_l, inner_r),
+            EitherOrBoth::Left(inner_l) => (inner_l, r),
+            EitherOrBoth::Right(inner_r) => (l, inner_r),
+            EitherOrBoth::Both(inner_l, inner_r) => (inner_l, inner_r),
         }
     }
 
@@ -323,9 +321,9 @@ impl<A, B> EitherOrBoth<A, B> {
     /// ```
     pub fn or_else<L: FnOnce() -> A, R: FnOnce() -> B>(self, l: L, r: R) -> (A, B) {
         match self {
-            Left(inner_l) => (inner_l, r()),
-            Right(inner_r) => (l(), inner_r),
-            Both(inner_l, inner_r) => (inner_l, inner_r),
+            EitherOrBoth::Left(inner_l) => (inner_l, r()),
+            EitherOrBoth::Right(inner_r) => (l(), inner_r),
+            EitherOrBoth::Both(inner_l, inner_r) => (inner_l, inner_r),
         }
     }
 
@@ -348,8 +346,8 @@ impl<A, B> EitherOrBoth<A, B> {
         F: FnOnce() -> A,
     {
         match self {
-            Left(left) | Both(left, _) => left,
-            Right(_) => self.insert_left(f()),
+            EitherOrBoth::Left(left) | EitherOrBoth::Both(left, _) => left,
+            EitherOrBoth::Right(_) => self.insert_left(f()),
         }
     }
 
@@ -360,8 +358,8 @@ impl<A, B> EitherOrBoth<A, B> {
         F: FnOnce() -> B,
     {
         match self {
-            Right(right) | Both(_, right) => right,
-            Left(_) => self.insert_right(f()),
+            EitherOrBoth::Right(right) | EitherOrBoth::Both(_, right) => right,
+            EitherOrBoth::Left(_) => self.insert_right(f()),
         }
     }
 
@@ -383,21 +381,21 @@ impl<A, B> EitherOrBoth<A, B> {
     /// ```
     pub fn insert_left(&mut self, val: A) -> &mut A {
         match self {
-            Left(left) | Both(left, _) => {
+            EitherOrBoth::Left(left) | EitherOrBoth::Both(left, _) => {
                 *left = val;
                 left
             }
-            Right(right) => {
+            EitherOrBoth::Right(right) => {
                 // This is like a map in place operation. We move out of the reference,
                 // change the value, and then move back into the reference.
                 unsafe {
                     // SAFETY: We know this pointer is valid for reading since we got it from a reference.
                     let right = std::ptr::read(right as *mut _);
                     // SAFETY: Again, we know the pointer is valid since we got it from a reference.
-                    std::ptr::write(self as *mut _, Both(val, right));
+                    std::ptr::write(self as *mut _, EitherOrBoth::Both(val, right));
                 }
 
-                if let Both(left, _) = self {
+                if let EitherOrBoth::Both(left, _) = self {
                     left
                 } else {
                     // SAFETY: The above pattern will always match, since we just
@@ -425,20 +423,20 @@ impl<A, B> EitherOrBoth<A, B> {
     /// ```
     pub fn insert_right(&mut self, val: B) -> &mut B {
         match self {
-            Right(right) | Both(_, right) => {
+            EitherOrBoth::Right(right) | EitherOrBoth::Both(_, right) => {
                 *right = val;
                 right
             }
-            Left(left) => {
+            EitherOrBoth::Left(left) => {
                 // This is like a map in place operation. We move out of the reference,
                 // change the value, and then move back into the reference.
                 unsafe {
                     // SAFETY: We know this pointer is valid for reading since we got it from a reference.
                     let left = std::ptr::read(left as *mut _);
                     // SAFETY: Again, we know the pointer is valid since we got it from a reference.
-                    std::ptr::write(self as *mut _, Both(left, val));
+                    std::ptr::write(self as *mut _, EitherOrBoth::Both(left, val));
                 }
-                if let Both(_, right) = self {
+                if let EitherOrBoth::Both(_, right) = self {
                     right
                 } else {
                     // SAFETY: The above pattern will always match, since we just
@@ -452,8 +450,8 @@ impl<A, B> EitherOrBoth<A, B> {
     /// Set `self` to `Both(..)`, containing the specified left and right values,
     /// and returns a mutable reference to those values.
     pub fn insert_both(&mut self, left: A, right: B) -> (&mut A, &mut B) {
-        *self = Both(left, right);
-        if let Both(left, right) = self {
+        *self = EitherOrBoth::Both(left, right);
+        if let EitherOrBoth::Both(left, right) = self {
             (left, right)
         } else {
             // SAFETY: The above pattern will always match, since we just
@@ -487,9 +485,9 @@ impl<T> EitherOrBoth<T, T> {
         F: FnOnce(T, T) -> T,
     {
         match self {
-            Left(a) => a,
-            Right(b) => b,
-            Both(a, b) => f(a, b),
+            EitherOrBoth::Left(a) => a,
+            EitherOrBoth::Right(b) => b,
+            EitherOrBoth::Both(a, b) => f(a, b),
         }
     }
 }
@@ -500,7 +498,7 @@ impl<A, B> Into<Option<Either<A, B>>> for EitherOrBoth<A, B> {
         match self {
             EitherOrBoth::Left(l) => Some(Either::Left(l)),
             EitherOrBoth::Right(r) => Some(Either::Right(r)),
-            _ => None,
+            EitherOrBoth::Both(..) => None,
         }
     }
 }

--- a/src/either_or_both.rs
+++ b/src/either_or_both.rs
@@ -27,13 +27,13 @@ impl<A, B> EitherOrBoth<A, B> {
     /// If `Left`, return true. Otherwise, return false.
     /// Exclusive version of [`has_left`](EitherOrBoth::has_left).
     pub fn is_left(&self) -> bool {
-        matches!(self, EitherOrBoth::Left(_))
+        matches!(self, Self::Left(_))
     }
 
     /// If `Right`, return true. Otherwise, return false.
     /// Exclusive version of [`has_right`](EitherOrBoth::has_right).
     pub fn is_right(&self) -> bool {
-        matches!(self, EitherOrBoth::Right(_))
+        matches!(self, Self::Right(_))
     }
 
     /// If `Both`, return true. Otherwise, return false.
@@ -44,16 +44,16 @@ impl<A, B> EitherOrBoth<A, B> {
     /// If `Left`, or `Both`, return `Some` with the left value. Otherwise, return `None`.
     pub fn left(self) -> Option<A> {
         match self {
-            EitherOrBoth::Left(left) | EitherOrBoth::Both(left, _) => Some(left),
-            EitherOrBoth::Right(_) => None,
+            Self::Left(left) | Self::Both(left, _) => Some(left),
+            Self::Right(_) => None,
         }
     }
 
     /// If `Right`, or `Both`, return `Some` with the right value. Otherwise, return `None`.
     pub fn right(self) -> Option<B> {
         match self {
-            EitherOrBoth::Right(right) | EitherOrBoth::Both(_, right) => Some(right),
-            EitherOrBoth::Left(_) => None,
+            Self::Right(right) | Self::Both(_, right) => Some(right),
+            Self::Left(_) => None,
         }
     }
 
@@ -85,7 +85,7 @@ impl<A, B> EitherOrBoth<A, B> {
     /// ```
     pub fn just_left(self) -> Option<A> {
         match self {
-            EitherOrBoth::Left(left) => Some(left),
+            Self::Left(left) => Some(left),
             _ => None,
         }
     }
@@ -110,7 +110,7 @@ impl<A, B> EitherOrBoth<A, B> {
     /// ```
     pub fn just_right(self) -> Option<B> {
         match self {
-            EitherOrBoth::Right(right) => Some(right),
+            Self::Right(right) => Some(right),
             _ => None,
         }
     }
@@ -118,7 +118,7 @@ impl<A, B> EitherOrBoth<A, B> {
     /// If `Both`, return `Some` containing the left and right values. Otherwise, return `None`.
     pub fn both(self) -> Option<(A, B)> {
         match self {
-            EitherOrBoth::Both(a, b) => Some((a, b)),
+            Self::Both(a, b) => Some((a, b)),
             _ => None,
         }
     }
@@ -129,8 +129,8 @@ impl<A, B> EitherOrBoth<A, B> {
         B: Into<A>,
     {
         match self {
-            EitherOrBoth::Left(a) | EitherOrBoth::Both(a, _) => a,
-            EitherOrBoth::Right(b) => b.into(),
+            Self::Left(a) | Self::Both(a, _) => a,
+            Self::Right(b) => b.into(),
         }
     }
 
@@ -140,26 +140,26 @@ impl<A, B> EitherOrBoth<A, B> {
         A: Into<B>,
     {
         match self {
-            EitherOrBoth::Right(b) | EitherOrBoth::Both(_, b) => b,
-            EitherOrBoth::Left(a) => a.into(),
+            Self::Right(b) | Self::Both(_, b) => b,
+            Self::Left(a) => a.into(),
         }
     }
 
     /// Converts from `&EitherOrBoth<A, B>` to `EitherOrBoth<&A, &B>`.
     pub fn as_ref(&self) -> EitherOrBoth<&A, &B> {
         match *self {
-            EitherOrBoth::Left(ref left) => EitherOrBoth::Left(left),
-            EitherOrBoth::Right(ref right) => EitherOrBoth::Right(right),
-            EitherOrBoth::Both(ref left, ref right) => EitherOrBoth::Both(left, right),
+            Self::Left(ref left) => EitherOrBoth::Left(left),
+            Self::Right(ref right) => EitherOrBoth::Right(right),
+            Self::Both(ref left, ref right) => EitherOrBoth::Both(left, right),
         }
     }
 
     /// Converts from `&mut EitherOrBoth<A, B>` to `EitherOrBoth<&mut A, &mut B>`.
     pub fn as_mut(&mut self) -> EitherOrBoth<&mut A, &mut B> {
         match *self {
-            EitherOrBoth::Left(ref mut left) => EitherOrBoth::Left(left),
-            EitherOrBoth::Right(ref mut right) => EitherOrBoth::Right(right),
-            EitherOrBoth::Both(ref mut left, ref mut right) => EitherOrBoth::Both(left, right),
+            Self::Left(ref mut left) => EitherOrBoth::Left(left),
+            Self::Right(ref mut right) => EitherOrBoth::Right(right),
+            Self::Both(ref mut left, ref mut right) => EitherOrBoth::Both(left, right),
         }
     }
 
@@ -170,9 +170,9 @@ impl<A, B> EitherOrBoth<A, B> {
         B: Deref,
     {
         match *self {
-            EitherOrBoth::Left(ref left) => EitherOrBoth::Left(left),
-            EitherOrBoth::Right(ref right) => EitherOrBoth::Right(right),
-            EitherOrBoth::Both(ref left, ref right) => EitherOrBoth::Both(left, right),
+            Self::Left(ref left) => EitherOrBoth::Left(left),
+            Self::Right(ref right) => EitherOrBoth::Right(right),
+            Self::Both(ref left, ref right) => EitherOrBoth::Both(left, right),
         }
     }
 
@@ -183,18 +183,18 @@ impl<A, B> EitherOrBoth<A, B> {
         B: DerefMut,
     {
         match *self {
-            EitherOrBoth::Left(ref mut left) => EitherOrBoth::Left(left),
-            EitherOrBoth::Right(ref mut right) => EitherOrBoth::Right(right),
-            EitherOrBoth::Both(ref mut left, ref mut right) => EitherOrBoth::Both(left, right),
+            Self::Left(ref mut left) => EitherOrBoth::Left(left),
+            Self::Right(ref mut right) => EitherOrBoth::Right(right),
+            Self::Both(ref mut left, ref mut right) => EitherOrBoth::Both(left, right),
         }
     }
 
     /// Convert `EitherOrBoth<A, B>` to `EitherOrBoth<B, A>`.
     pub fn flip(self) -> EitherOrBoth<B, A> {
         match self {
-            EitherOrBoth::Left(a) => EitherOrBoth::Right(a),
-            EitherOrBoth::Right(b) => EitherOrBoth::Left(b),
-            EitherOrBoth::Both(a, b) => EitherOrBoth::Both(b, a),
+            Self::Left(a) => EitherOrBoth::Right(a),
+            Self::Right(b) => EitherOrBoth::Left(b),
+            Self::Both(a, b) => EitherOrBoth::Both(b, a),
         }
     }
 
@@ -205,9 +205,9 @@ impl<A, B> EitherOrBoth<A, B> {
         F: FnOnce(A) -> M,
     {
         match self {
-            EitherOrBoth::Both(a, b) => EitherOrBoth::Both(f(a), b),
-            EitherOrBoth::Left(a) => EitherOrBoth::Left(f(a)),
-            EitherOrBoth::Right(b) => EitherOrBoth::Right(b),
+            Self::Both(a, b) => EitherOrBoth::Both(f(a), b),
+            Self::Left(a) => EitherOrBoth::Left(f(a)),
+            Self::Right(b) => EitherOrBoth::Right(b),
         }
     }
 
@@ -218,9 +218,9 @@ impl<A, B> EitherOrBoth<A, B> {
         F: FnOnce(B) -> M,
     {
         match self {
-            EitherOrBoth::Left(a) => EitherOrBoth::Left(a),
-            EitherOrBoth::Right(b) => EitherOrBoth::Right(f(b)),
-            EitherOrBoth::Both(a, b) => EitherOrBoth::Both(a, f(b)),
+            Self::Left(a) => EitherOrBoth::Left(a),
+            Self::Right(b) => EitherOrBoth::Right(f(b)),
+            Self::Both(a, b) => EitherOrBoth::Both(a, f(b)),
         }
     }
 
@@ -233,9 +233,9 @@ impl<A, B> EitherOrBoth<A, B> {
         G: FnOnce(B) -> R,
     {
         match self {
-            EitherOrBoth::Left(a) => EitherOrBoth::Left(f(a)),
-            EitherOrBoth::Right(b) => EitherOrBoth::Right(g(b)),
-            EitherOrBoth::Both(a, b) => EitherOrBoth::Both(f(a), g(b)),
+            Self::Left(a) => EitherOrBoth::Left(f(a)),
+            Self::Right(b) => EitherOrBoth::Right(g(b)),
+            Self::Both(a, b) => EitherOrBoth::Both(f(a), g(b)),
         }
     }
 
@@ -246,8 +246,8 @@ impl<A, B> EitherOrBoth<A, B> {
         F: FnOnce(A) -> EitherOrBoth<L, B>,
     {
         match self {
-            EitherOrBoth::Left(a) | EitherOrBoth::Both(a, _) => f(a),
-            EitherOrBoth::Right(b) => EitherOrBoth::Right(b),
+            Self::Left(a) | Self::Both(a, _) => f(a),
+            Self::Right(b) => EitherOrBoth::Right(b),
         }
     }
 
@@ -258,8 +258,8 @@ impl<A, B> EitherOrBoth<A, B> {
         F: FnOnce(B) -> EitherOrBoth<A, R>,
     {
         match self {
-            EitherOrBoth::Left(a) => EitherOrBoth::Left(a),
-            EitherOrBoth::Right(b) | EitherOrBoth::Both(_, b) => f(b),
+            Self::Left(a) => EitherOrBoth::Left(a),
+            Self::Right(b) | Self::Both(_, b) => f(b),
         }
     }
 
@@ -284,9 +284,9 @@ impl<A, B> EitherOrBoth<A, B> {
     /// ```
     pub fn or(self, l: A, r: B) -> (A, B) {
         match self {
-            EitherOrBoth::Left(inner_l) => (inner_l, r),
-            EitherOrBoth::Right(inner_r) => (l, inner_r),
-            EitherOrBoth::Both(inner_l, inner_r) => (inner_l, inner_r),
+            Self::Left(inner_l) => (inner_l, r),
+            Self::Right(inner_r) => (l, inner_r),
+            Self::Both(inner_l, inner_r) => (inner_l, inner_r),
         }
     }
 
@@ -299,9 +299,9 @@ impl<A, B> EitherOrBoth<A, B> {
         B: Default,
     {
         match self {
-            EitherOrBoth::Left(l) => (l, B::default()),
-            EitherOrBoth::Right(r) => (A::default(), r),
-            EitherOrBoth::Both(l, r) => (l, r),
+            Self::Left(l) => (l, B::default()),
+            Self::Right(r) => (A::default(), r),
+            Self::Both(l, r) => (l, r),
         }
     }
 
@@ -321,9 +321,9 @@ impl<A, B> EitherOrBoth<A, B> {
     /// ```
     pub fn or_else<L: FnOnce() -> A, R: FnOnce() -> B>(self, l: L, r: R) -> (A, B) {
         match self {
-            EitherOrBoth::Left(inner_l) => (inner_l, r()),
-            EitherOrBoth::Right(inner_r) => (l(), inner_r),
-            EitherOrBoth::Both(inner_l, inner_r) => (inner_l, inner_r),
+            Self::Left(inner_l) => (inner_l, r()),
+            Self::Right(inner_r) => (l(), inner_r),
+            Self::Both(inner_l, inner_r) => (inner_l, inner_r),
         }
     }
 
@@ -346,8 +346,8 @@ impl<A, B> EitherOrBoth<A, B> {
         F: FnOnce() -> A,
     {
         match self {
-            EitherOrBoth::Left(left) | EitherOrBoth::Both(left, _) => left,
-            EitherOrBoth::Right(_) => self.insert_left(f()),
+            Self::Left(left) | Self::Both(left, _) => left,
+            Self::Right(_) => self.insert_left(f()),
         }
     }
 
@@ -358,8 +358,8 @@ impl<A, B> EitherOrBoth<A, B> {
         F: FnOnce() -> B,
     {
         match self {
-            EitherOrBoth::Right(right) | EitherOrBoth::Both(_, right) => right,
-            EitherOrBoth::Left(_) => self.insert_right(f()),
+            Self::Right(right) | Self::Both(_, right) => right,
+            Self::Left(_) => self.insert_right(f()),
         }
     }
 
@@ -381,21 +381,21 @@ impl<A, B> EitherOrBoth<A, B> {
     /// ```
     pub fn insert_left(&mut self, val: A) -> &mut A {
         match self {
-            EitherOrBoth::Left(left) | EitherOrBoth::Both(left, _) => {
+            Self::Left(left) | Self::Both(left, _) => {
                 *left = val;
                 left
             }
-            EitherOrBoth::Right(right) => {
+            Self::Right(right) => {
                 // This is like a map in place operation. We move out of the reference,
                 // change the value, and then move back into the reference.
                 unsafe {
                     // SAFETY: We know this pointer is valid for reading since we got it from a reference.
                     let right = std::ptr::read(right as *mut _);
                     // SAFETY: Again, we know the pointer is valid since we got it from a reference.
-                    std::ptr::write(self as *mut _, EitherOrBoth::Both(val, right));
+                    std::ptr::write(self as *mut _, Self::Both(val, right));
                 }
 
-                if let EitherOrBoth::Both(left, _) = self {
+                if let Self::Both(left, _) = self {
                     left
                 } else {
                     // SAFETY: The above pattern will always match, since we just
@@ -423,20 +423,20 @@ impl<A, B> EitherOrBoth<A, B> {
     /// ```
     pub fn insert_right(&mut self, val: B) -> &mut B {
         match self {
-            EitherOrBoth::Right(right) | EitherOrBoth::Both(_, right) => {
+            Self::Right(right) | Self::Both(_, right) => {
                 *right = val;
                 right
             }
-            EitherOrBoth::Left(left) => {
+            Self::Left(left) => {
                 // This is like a map in place operation. We move out of the reference,
                 // change the value, and then move back into the reference.
                 unsafe {
                     // SAFETY: We know this pointer is valid for reading since we got it from a reference.
                     let left = std::ptr::read(left as *mut _);
                     // SAFETY: Again, we know the pointer is valid since we got it from a reference.
-                    std::ptr::write(self as *mut _, EitherOrBoth::Both(left, val));
+                    std::ptr::write(self as *mut _, Self::Both(left, val));
                 }
-                if let EitherOrBoth::Both(_, right) = self {
+                if let Self::Both(_, right) = self {
                     right
                 } else {
                     // SAFETY: The above pattern will always match, since we just
@@ -450,8 +450,8 @@ impl<A, B> EitherOrBoth<A, B> {
     /// Set `self` to `Both(..)`, containing the specified left and right values,
     /// and returns a mutable reference to those values.
     pub fn insert_both(&mut self, left: A, right: B) -> (&mut A, &mut B) {
-        *self = EitherOrBoth::Both(left, right);
-        if let EitherOrBoth::Both(left, right) = self {
+        *self = Self::Both(left, right);
+        if let Self::Both(left, right) = self {
             (left, right)
         } else {
             // SAFETY: The above pattern will always match, since we just
@@ -485,9 +485,9 @@ impl<T> EitherOrBoth<T, T> {
         F: FnOnce(T, T) -> T,
     {
         match self {
-            EitherOrBoth::Left(a) => a,
-            EitherOrBoth::Right(b) => b,
-            EitherOrBoth::Both(a, b) => f(a, b),
+            Self::Left(a) => a,
+            Self::Right(b) => b,
+            Self::Both(a, b) => f(a, b),
         }
     }
 }
@@ -496,9 +496,9 @@ impl<T> EitherOrBoth<T, T> {
 impl<A, B> Into<Option<Either<A, B>>> for EitherOrBoth<A, B> {
     fn into(self) -> Option<Either<A, B>> {
         match self {
-            EitherOrBoth::Left(l) => Some(Either::Left(l)),
-            EitherOrBoth::Right(r) => Some(Either::Right(r)),
-            EitherOrBoth::Both(..) => None,
+            Self::Left(l) => Some(Either::Left(l)),
+            Self::Right(r) => Some(Either::Right(r)),
+            Self::Both(..) => None,
         }
     }
 }
@@ -506,8 +506,8 @@ impl<A, B> Into<Option<Either<A, B>>> for EitherOrBoth<A, B> {
 impl<A, B> From<Either<A, B>> for EitherOrBoth<A, B> {
     fn from(either: Either<A, B>) -> Self {
         match either {
-            Either::Left(l) => EitherOrBoth::Left(l),
-            Either::Right(l) => EitherOrBoth::Right(l),
+            Either::Left(l) => Self::Left(l),
+            Either::Right(l) => Self::Right(l),
         }
     }
 }

--- a/src/flatten_ok.rs
+++ b/src/flatten_ok.rs
@@ -73,11 +73,8 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let inner_hint = |inner: &Option<T::IntoIter>| {
-            inner
-                .as_ref()
-                .map_or((0, Some(0)), Iterator::size_hint)
-        };
+        let inner_hint =
+            |inner: &Option<T::IntoIter>| inner.as_ref().map_or((0, Some(0)), Iterator::size_hint);
         let inner_front = inner_hint(&self.inner_front);
         let inner_back = inner_hint(&self.inner_back);
         // The outer iterator `Ok` case could be (0, None) as we don't know its size_hint yet.

--- a/src/flatten_ok.rs
+++ b/src/flatten_ok.rs
@@ -76,8 +76,7 @@ where
         let inner_hint = |inner: &Option<T::IntoIter>| {
             inner
                 .as_ref()
-                .map(Iterator::size_hint)
-                .unwrap_or((0, Some(0)))
+                .map_or((0, Some(0)), Iterator::size_hint)
         };
         let inner_front = inner_hint(&self.inner_front);
         let inner_back = inner_hint(&self.inner_back);

--- a/src/free.rs
+++ b/src/free.rs
@@ -166,10 +166,10 @@ where
 ///
 /// assert_eq!(cloned(b"abc").next(), Some(b'a'));
 /// ```
-pub fn cloned<'a, I, T: 'a>(iterable: I) -> iter::Cloned<I::IntoIter>
+pub fn cloned<'a, I, T>(iterable: I) -> iter::Cloned<I::IntoIter>
 where
     I: IntoIterator<Item = &'a T>,
-    T: Clone,
+    T: Clone + 'a,
 {
     iterable.into_iter().cloned()
 }

--- a/src/groupbylazy.rs
+++ b/src/groupbylazy.rs
@@ -7,9 +7,9 @@ trait KeyFunction<A> {
     fn call_mut(&mut self, arg: A) -> Self::Key;
 }
 
-impl<A, K, F: ?Sized> KeyFunction<A> for F
+impl<A, K, F> KeyFunction<A> for F
 where
-    F: FnMut(A) -> K,
+    F: FnMut(A) -> K + ?Sized,
 {
     type Key = K;
     #[inline]
@@ -370,10 +370,12 @@ where
 ///
 /// See [`.group_by()`](crate::Itertools::group_by) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-pub struct Groups<'a, K: 'a, I: 'a, F: 'a>
+pub struct Groups<'a, K, I, F>
 where
-    I: Iterator,
+    I: Iterator + 'a,
     I::Item: 'a,
+    K: 'a,
+    F: 'a,
 {
     parent: &'a GroupBy<K, I, F>,
 }
@@ -409,10 +411,12 @@ where
 /// An iterator for the elements in a single group.
 ///
 /// Iterator element type is `I::Item`.
-pub struct Group<'a, K: 'a, I: 'a, F: 'a>
+pub struct Group<'a, K, I, F>
 where
-    I: Iterator,
+    I: Iterator + 'a,
     I::Item: 'a,
+    K: 'a,
+    F: 'a,
 {
     parent: &'a GroupBy<K, I, F>,
     index: usize,
@@ -537,9 +541,9 @@ where
 /// See [`.chunks()`](crate::Itertools::chunks) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Clone)]
-pub struct Chunks<'a, I: 'a>
+pub struct Chunks<'a, I>
 where
-    I: Iterator,
+    I: Iterator + 'a,
     I::Item: 'a,
 {
     parent: &'a IntoChunks<I>,
@@ -568,9 +572,9 @@ where
 /// An iterator for the elements in a single chunk.
 ///
 /// Iterator element type is `I::Item`.
-pub struct Chunk<'a, I: 'a>
+pub struct Chunk<'a, I>
 where
-    I: Iterator,
+    I: Iterator + 'a,
     I::Item: 'a,
 {
     parent: &'a IntoChunks<I>,

--- a/src/groupbylazy.rs
+++ b/src/groupbylazy.rs
@@ -29,7 +29,7 @@ struct ChunkIndex {
 impl ChunkIndex {
     #[inline(always)]
     fn new(size: usize) -> Self {
-        ChunkIndex {
+        Self {
             size,
             index: 0,
             key: 0,

--- a/src/groupbylazy.rs
+++ b/src/groupbylazy.rs
@@ -112,7 +112,7 @@ where
         if client < self.oldest_buffered_group {
             return None;
         }
-        let elt = self.buffer.get_mut(bufidx).and_then(|queue| queue.next());
+        let elt = self.buffer.get_mut(bufidx).and_then(Iterator::next);
         if elt.is_none() && client == self.oldest_buffered_group {
             // FIXME: VecDeque is unfortunately not zero allocation when empty,
             // so we do this job manually.

--- a/src/kmerge_impl.rs
+++ b/src/kmerge_impl.rs
@@ -27,9 +27,9 @@ where
     I: Iterator,
 {
     /// Constructs a `HeadTail` from an `Iterator`. Returns `None` if the `Iterator` is empty.
-    fn new(mut it: I) -> Option<HeadTail<I>> {
+    fn new(mut it: I) -> Option<Self> {
         let head = it.next();
-        head.map(|h| HeadTail { head: h, tail: it })
+        head.map(|h| Self { head: h, tail: it })
     }
 
     /// Get the next element and update `head`, returning the old head in `Some`.

--- a/src/kmerge_impl.rs
+++ b/src/kmerge_impl.rs
@@ -226,7 +226,7 @@ where
         #[allow(deprecated)] //TODO: once msrv hits 1.51. replace `fold1` with `reduce`
         self.heap
             .iter()
-            .map(|i| i.size_hint())
+            .map(HeadTail::size_hint)
             .fold1(size_hint::add)
             .unwrap_or((0, Some(0)))
     }

--- a/src/lazy_buffer.rs
+++ b/src/lazy_buffer.rs
@@ -14,8 +14,8 @@ impl<I> LazyBuffer<I>
 where
     I: Iterator,
 {
-    pub fn new(it: I) -> LazyBuffer<I> {
-        LazyBuffer {
+    pub fn new(it: I) -> Self {
+        Self {
             it: it.fuse(),
             buffer: Vec::new(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1910,12 +1910,7 @@ pub trait Itertools: Iterator {
     where
         P: FnMut(&Self::Item) -> bool,
     {
-        for (index, elt) in self.enumerate() {
-            if pred(&elt) {
-                return Some((index, elt));
-            }
-        }
-        None
+        self.enumerate().find(|x| pred(&x.1))
     }
     /// Find the value of the first element satisfying a predicate or return the last element, if any.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4076,15 +4076,15 @@ impl<T> FoldWhile<T> {
     /// Return the value in the continue or done.
     pub fn into_inner(self) -> T {
         match self {
-            FoldWhile::Continue(x) | FoldWhile::Done(x) => x,
+            Self::Continue(x) | Self::Done(x) => x,
         }
     }
 
     /// Return true if `self` is `Done`, false if it is `Continue`.
     pub fn is_done(&self) -> bool {
         match *self {
-            FoldWhile::Continue(_) => false,
-            FoldWhile::Done(_) => true,
+            Self::Continue(_) => false,
+            Self::Done(_) => true,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2124,8 +2124,7 @@ pub trait Itertools: Iterator {
     /// ```
     fn dropping_back(mut self, n: usize) -> Self
     where
-        Self: Sized,
-        Self: DoubleEndedIterator,
+        Self: Sized + DoubleEndedIterator,
     {
         if n > 0 {
             (&mut self).rev().nth(n - 1);
@@ -3962,7 +3961,7 @@ pub trait Itertools: Iterator {
     }
 }
 
-impl<T: ?Sized> Itertools for T where T: Iterator {}
+impl<T> Itertools for T where T: Iterator + ?Sized {}
 
 /// Return `true` if both iterables produce equal sequences
 /// (elements pairwise equal and sequences of the same length),

--- a/src/minmax.rs
+++ b/src/minmax.rs
@@ -37,9 +37,9 @@ impl<T: Clone> MinMaxResult<T> {
     /// ```
     pub fn into_option(self) -> Option<(T, T)> {
         match self {
-            MinMaxResult::NoElements => None,
-            MinMaxResult::OneElement(x) => Some((x.clone(), x)),
-            MinMaxResult::MinMax(x, y) => Some((x, y)),
+            Self::NoElements => None,
+            Self::OneElement(x) => Some((x.clone(), x)),
+            Self::MinMax(x, y) => Some((x, y)),
         }
     }
 }

--- a/src/minmax.rs
+++ b/src/minmax.rs
@@ -1,7 +1,7 @@
 /// `MinMaxResult` is an enum returned by `minmax`.
 ///
 /// See [`.minmax()`](crate::Itertools::minmax) for more detail.
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum MinMaxResult<T> {
     /// Empty iterator
     NoElements,

--- a/src/minmax.rs
+++ b/src/minmax.rs
@@ -91,16 +91,7 @@ where
         };
         let first_key = key_for(&first);
         let second_key = key_for(&second);
-        if !lt(&second, &first, &second_key, &first_key) {
-            if lt(&first, &min, &first_key, &min_key) {
-                min = first;
-                min_key = first_key;
-            }
-            if !lt(&second, &max, &second_key, &max_key) {
-                max = second;
-                max_key = second_key;
-            }
-        } else {
+        if lt(&second, &first, &second_key, &first_key) {
             if lt(&second, &min, &second_key, &min_key) {
                 min = second;
                 min_key = second_key;
@@ -108,6 +99,15 @@ where
             if !lt(&first, &max, &first_key, &max_key) {
                 max = first;
                 max_key = first_key;
+            }
+        } else {
+            if lt(&first, &min, &first_key, &min_key) {
+                min = first;
+                min_key = first_key;
+            }
+            if !lt(&second, &max, &second_key, &max_key) {
+                max = second;
+                max_key = second_key;
             }
         }
     }

--- a/src/peeking_take_while.rs
+++ b/src/peeking_take_while.rs
@@ -96,17 +96,17 @@ where
 /// See [`.peeking_take_while()`](crate::Itertools::peeking_take_while)
 /// for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-pub struct PeekingTakeWhile<'a, I: 'a, F>
+pub struct PeekingTakeWhile<'a, I, F>
 where
-    I: Iterator,
+    I: Iterator + 'a,
 {
     iter: &'a mut I,
     f: F,
 }
 
-impl<'a, I: 'a, F> std::fmt::Debug for PeekingTakeWhile<'a, I, F>
+impl<'a, I, F> std::fmt::Debug for PeekingTakeWhile<'a, I, F>
 where
-    I: Iterator + std::fmt::Debug,
+    I: Iterator + std::fmt::Debug + 'a,
 {
     debug_fmt_fields!(PeekingTakeWhile, iter);
 }

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -54,6 +54,7 @@ where
         }
     }
 
+    #[allow(clippy::unnecessary_lazy_evaluations)] // buffer.len is more complex than usual
     fn size_hint(&self) -> (usize, Option<usize>) {
         let buffer = &self.buf.as_ref()[self.cur..];
         let len = if buffer.is_empty() {

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -34,7 +34,7 @@ where
     T: HomogeneousTuple,
 {
     fn new(buf: T::Buffer) -> Self {
-        TupleBuffer { cur: 0, buf }
+        Self { cur: 0, buf }
     }
 }
 

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -245,7 +245,7 @@ where
 /// information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 #[derive(Debug, Clone)]
-pub struct CircularTupleWindows<I, T: Clone>
+pub struct CircularTupleWindows<I, T>
 where
     I: Iterator<Item = T::Item> + Clone,
     T: TupleCollect + Clone,

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -110,9 +110,10 @@ where
             if let Entry::Vacant(entry) = used.entry(v) {
                 let elt = entry.key().clone();
                 entry.insert(());
-                return Some(elt);
+                Some(elt)
+            } else {
+                None
             }
-            None
         })
     }
 

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -1,3 +1,8 @@
+// Use a Hashmap for the entry API in order to prevent hashing twice.
+// This can maybe be replaced with e a HashSet once `get_or_insert_with`
+// // or a proper Entry API for Hashset is stable and meets the msrv
+#![allow(clippy::zero_sized_map_values)]
+
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fmt;
@@ -11,9 +16,7 @@ use std::iter::FusedIterator;
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct UniqueBy<I: Iterator, V, F> {
     iter: I,
-    // Use a Hashmap for the Entry API in order to prevent hashing twice.
-    // This can maybe be replaced with a HashSet once `get_or_insert_with`
-    // or a proper Entry API for Hashset is stable and meets this msrv
+    // see comment for `allow(clippy::zero_sized_map_values)` for reasoning
     used: HashMap<V, ()>,
     f: F,
 }

--- a/src/with_position.rs
+++ b/src/with_position.rs
@@ -55,7 +55,14 @@ impl<I: Iterator> Iterator for WithPosition<I> {
     fn next(&mut self) -> Option<Self::Item> {
         match self.peekable.next() {
             Some(item) => {
-                if !self.handled_first {
+                if self.handled_first {
+                    // Have seen the first item, and there's something left.
+                    // Peek to see if this is the last item.
+                    match self.peekable.peek() {
+                        Some(_) => Some((Position::Middle, item)),
+                        None => Some((Position::Last, item)),
+                    }
+                } else {
                     // Haven't seen the first item yet, and there is one to give.
                     self.handled_first = true;
                     // Peek to see if this is also the last item,
@@ -63,13 +70,6 @@ impl<I: Iterator> Iterator for WithPosition<I> {
                     match self.peekable.peek() {
                         Some(_) => Some((Position::First, item)),
                         None => Some((Position::Only, item)),
-                    }
-                } else {
-                    // Have seen the first item, and there's something left.
-                    // Peek to see if this is the last item.
-                    match self.peekable.peek() {
-                        Some(_) => Some((Position::Middle, item)),
-                        None => Some((Position::Last, item)),
                     }
                 }
             }

--- a/src/zip_longest.rs
+++ b/src/zip_longest.rs
@@ -59,7 +59,7 @@ where
         Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
-        let ZipLongest { a, mut b } = self;
+        let Self { a, mut b } = self;
         init = a.fold(init, |init, a| match b.next() {
             Some(b) => f(init, EitherOrBoth::Both(a, b)),
             None => f(init, EitherOrBoth::Left(a)),

--- a/src/ziptuple.rs
+++ b/src/ziptuple.rs
@@ -39,8 +39,7 @@ pub struct Zip<T> {
 /// [`izip!()`]: crate::izip
 pub fn multizip<T, U>(t: U) -> Zip<T>
 where
-    Zip<T>: From<U>,
-    Zip<T>: Iterator,
+    Zip<T>: From<U> + Iterator,
 {
     Zip::from(t)
 }

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -38,7 +38,7 @@ impl HintKind for Exact {
 
 impl qc::Arbitrary for Exact {
     fn arbitrary<G: qc::Gen>(_: &mut G) -> Self {
-        Exact {}
+        Self {}
     }
 }
 
@@ -69,7 +69,7 @@ impl qc::Arbitrary for Inexact {
         // Compensate for quickcheck using extreme values too rarely
         let ue_choices = &[0, ue_value, usize::max_value()];
         let oe_choices = &[0, oe_value, usize::max_value()];
-        Inexact {
+        Self {
             underestimate: *ue_choices.choose(g).unwrap(),
             overestimate: *oe_choices.choose(g).unwrap(),
         }
@@ -79,7 +79,7 @@ impl qc::Arbitrary for Inexact {
         let underestimate_value = self.underestimate;
         let overestimate_value = self.overestimate;
         Box::new(underestimate_value.shrink().flat_map(move |ue_value| {
-            overestimate_value.shrink().map(move |oe_value| Inexact {
+            overestimate_value.shrink().map(move |oe_value| Self {
                 underestimate: ue_value,
                 overestimate: oe_value,
             })
@@ -108,7 +108,7 @@ where
     HK: HintKind,
 {
     fn new(it: Range<T>, hint_kind: HK) -> Self {
-        Iter {
+        Self {
             iterator: it,
             fuse_flag: 0,
             hint_kind,
@@ -166,16 +166,16 @@ where
     HK: HintKind,
 {
     fn arbitrary<G: qc::Gen>(g: &mut G) -> Self {
-        Iter::new(T::arbitrary(g)..T::arbitrary(g), HK::arbitrary(g))
+        Self::new(T::arbitrary(g)..T::arbitrary(g), HK::arbitrary(g))
     }
 
-    fn shrink(&self) -> Box<dyn Iterator<Item = Iter<T, HK>>> {
+    fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
         let r = self.iterator.clone();
         let hint_kind = self.hint_kind;
         Box::new(r.start.shrink().flat_map(move |a| {
             r.end
                 .shrink()
-                .map(move |b| Iter::new(a.clone()..b, hint_kind))
+                .map(move |b| Self::new(a.clone()..b, hint_kind))
         }))
     }
 }
@@ -231,7 +231,7 @@ where
         let iter_count = g.gen_range(0, MAX_ITER_COUNT + 1);
         let hint_kind = qc::Arbitrary::arbitrary(g);
 
-        ShiftRange {
+        Self {
             range_start,
             range_end,
             start_step,
@@ -1307,14 +1307,14 @@ quickcheck! {
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct Val(u32, u32);
 
-impl PartialOrd<Val> for Val {
-    fn partial_cmp(&self, other: &Val) -> Option<Ordering> {
+impl PartialOrd<Self> for Val {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl Ord for Val {
-    fn cmp(&self, other: &Val) -> Ordering {
+    fn cmp(&self, other: &Self) -> Ordering {
         self.0.cmp(&other.0)
     }
 }
@@ -1322,10 +1322,10 @@ impl Ord for Val {
 impl qc::Arbitrary for Val {
     fn arbitrary<G: qc::Gen>(g: &mut G) -> Self {
         let (x, y) = <(u32, u32)>::arbitrary(g);
-        Val(x, y)
+        Self(x, y)
     }
     fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
-        Box::new((self.0, self.1).shrink().map(|(x, y)| Val(x, y)))
+        Box::new((self.0, self.1).shrink().map(|(x, y)| Self(x, y)))
     }
 }
 

--- a/tests/test_core.rs
+++ b/tests/test_core.rs
@@ -228,7 +228,7 @@ fn count_clones() {
     // Check that RepeatN only clones N - 1 times.
 
     use core::cell::Cell;
-    #[derive(PartialEq, Debug)]
+    #[derive(PartialEq, Eq, Debug)]
     struct Foo {
         n: Cell<usize>,
     }

--- a/tests/test_core.rs
+++ b/tests/test_core.rs
@@ -237,7 +237,7 @@ fn count_clones() {
         fn clone(&self) -> Self {
             let n = self.n.get();
             self.n.set(n + 1);
-            Foo {
+            Self {
                 n: Cell::new(n + 1),
             }
         }

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -540,7 +540,7 @@ where
 
 impl<T: Clone + Send, R: Clone + Rng + SeedableRng + Send> qc::Arbitrary for RandIter<T, R> {
     fn arbitrary<G: qc::Gen>(g: &mut G) -> Self {
-        RandIter {
+        Self {
             idx: 0,
             len: g.size(),
             rng: R::seed_from_u64(g.next_u64()),
@@ -1263,14 +1263,14 @@ fn extrema_set() {
     #[derive(Clone, Debug, PartialEq, Eq)]
     struct Val(u32, u32);
 
-    impl PartialOrd<Val> for Val {
-        fn partial_cmp(&self, other: &Val) -> Option<Ordering> {
+    impl PartialOrd<Self> for Val {
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
             Some(self.cmp(other))
         }
     }
 
     impl Ord for Val {
-        fn cmp(&self, other: &Val) -> Ordering {
+        fn cmp(&self, other: &Self) -> Ordering {
             self.0.cmp(&other.0)
         }
     }
@@ -1312,14 +1312,14 @@ fn minmax() {
     #[derive(Clone, Debug, PartialEq, Eq)]
     struct Val(u32, u32);
 
-    impl PartialOrd<Val> for Val {
-        fn partial_cmp(&self, other: &Val) -> Option<Ordering> {
+    impl PartialOrd<Self> for Val {
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
             Some(self.cmp(other))
         }
     }
 
     impl Ord for Val {
-        fn cmp(&self, other: &Val) -> Ordering {
+        fn cmp(&self, other: &Self) -> Ordering {
             self.0.cmp(&other.0)
         }
     }


### PR DESCRIPTION
This commit is quite a mouth full and I'm can understand if you want me to split this into smaller chunks.

Let me start explain it commit by commit.

First I created a clippy toml with the msrv set to 1.36.0, which is the version used in the [github workflow](https://github.com/rust-itertools/itertools/blob/1f0a8c1c9cd43f45764fb387386ccdce49aeb535/.github/workflows/ci.yml#L16).

Next I either fixed all the linted lines, or added a allow with a comment to it.  
I did the same for all the tests.

Next I saw, that there is currently a rustfmt which skips the complete source base, based on a commit two years ago: https://github.com/rust-itertools/itertools/commit/641671e8b8b8737a38039d572022e38b9b43b8d5

*"Temporarily disable"* 😉 

I then reformatted the whole codebase, which might break some PRs but they should be able to rebase it but just using `cargo fmt` easily.

Next, I fixed two warnings. One stray \`\`\` and the other one being changed in https://github.com/rust-lang/rust/pull/96676 where you have to specify a macro link.

Last, but not least, I added `rustfmt` `rustdoc` and `clippy` to the `ci.yml` to enable them by default on PRs.

---

Feel free to comment whatever you think. I try to answer or change it :)

Thanks for the awesome crate :)