### PR TITLE
if use_std is enabled, also enable either/use_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ version = "0.2"
 
 [features]
 default = ["use_std"]
-use_std = ["use_alloc"]
+use_std = ["use_alloc", "either/use_std"]
 use_alloc = []
 
 [profile]


### PR DESCRIPTION
I've been using either through itertools, and I'd love to have `either/use_std` enabled if `use_std` is enabled.