### PR TITLE
Forward implementation of `PeekingNext` for `PeekingTakeWhile`.

### DIFF
--- a/src/peeking_take_while.rs
+++ b/src/peeking_take_while.rs
@@ -115,6 +115,17 @@ impl<'a, I, F> Iterator for PeekingTakeWhile<'a, I, F>
     }
 }
 
+impl<'a, I, F> PeekingNext for PeekingTakeWhile<'a, I, F>
+    where I: PeekingNext,
+          F: FnMut(&I::Item) -> bool,
+{
+    fn peeking_next<G>(&mut self, accept: G) -> Option<Self::Item>
+        where G: FnOnce(&Self::Item) -> bool,
+    {
+        self.iter.peeking_next(accept)
+    }
+}
+
 // Some iterators are so lightweight we can simply clone them to save their
 // state and use that for peeking.
 macro_rules! peeking_next_by_clone {


### PR DESCRIPTION
This change transitively implements `PeekingNext` for `PeekingTakeWhile`. This allows calls to `Itertools::peeking_take_while` to be chained and, similarly, for code that accepts `PeekingTakeWhile` to continue to peek without advancing the originating `Iterator`.