### PR TITLE
Implement `PeekingNext` for `PeekingTakeWhile`.

### DIFF
--- a/src/peeking_take_while.rs
+++ b/src/peeking_take_while.rs
@@ -115,6 +115,18 @@ impl<'a, I, F> Iterator for PeekingTakeWhile<'a, I, F>
     }
 }
 
+impl<'a, I, F> PeekingNext for PeekingTakeWhile<'a, I, F>
+    where I: PeekingNext,
+          F: FnMut(&I::Item) -> bool,
+{
+    fn peeking_next<G>(&mut self, g: G) -> Option<Self::Item>
+        where G: FnOnce(&Self::Item) -> bool,
+    {
+        let f = &mut self.f;
+        self.iter.peeking_next(|r| f(r) && g(r))
+    }
+}
+
 // Some iterators are so lightweight we can simply clone them to save their
 // state and use that for peeking.
 macro_rules! peeking_next_by_clone {

--- a/tests/peeking_take_while.rs
+++ b/tests/peeking_take_while.rs
@@ -48,3 +48,22 @@ fn peeking_take_while_slice_iter_rev() {
     r.peeking_take_while(|_| true).count();
     assert_eq!(r.next(), None);
 }
+
+#[test]
+fn peeking_take_while_nested() {
+    let mut xs = (0..10).peekable();
+    let ys: Vec<_> = xs
+        .peeking_take_while(|x| *x < 6)
+        .peeking_take_while(|x| *x != 3)
+        .collect();
+    assert_eq!(ys, vec![0, 1, 2]);
+    assert_eq!(xs.next(), Some(3));
+
+    let mut xs = (4..10).peekable();
+    let ys: Vec<_> = xs
+        .peeking_take_while(|x| *x != 3)
+        .peeking_take_while(|x| *x < 6)
+        .collect();
+    assert_eq!(ys, vec![4, 5]);
+    assert_eq!(xs.next(), Some(6));
+}


### PR DESCRIPTION
This PR implements `PeekingNext` for `PeekingTakeWhile` by composing its predicate with the predicate given to `PeekingNext::peeking_next`. This allows `Itertools::peeking_take_while` to be chained and for subsequent calls, including those across function boundaries, to function as expected while restoring items in the originating iterator.

See also #643, which implements `PeekingNext` for mutable references. In combination, these changes allow code to generically accept types implementing `PeekingNext` where `Itertools::peeking_take_while` can be used by the caller to prepare an iterator and subsequently by a function where restoring items in the originating iterator is important (i.e., the function cannot simply use `Iterator::peekable` etc., because `Iterator::next` would unconditionally be called on the originating iterator).