### PR TITLE
Add all_equal_value method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -904,7 +904,7 @@ pub trait Itertools : Iterator {
 
     /// Return an iterator adaptor that flattens every `Result::Ok` value into
     /// a series of `Result::Ok` values. `Result::Err` values are unchanged.
-    /// 
+    ///
     /// This is useful when you have some common error type for your crate and
     /// need to propagate it upwards, but the `Result::Ok` case needs to be flattened.
     ///
@@ -914,7 +914,7 @@ pub trait Itertools : Iterator {
     /// let input = vec![Ok(0..2), Err(false), Ok(2..4)];
     /// let it = input.iter().cloned().flatten_ok();
     /// itertools::assert_equal(it.clone(), vec![Ok(0), Ok(1), Err(false), Ok(2), Ok(3)]);
-    /// 
+    ///
     /// // This can also be used to propagate errors when collecting.
     /// let output_result: Result<Vec<i32>, bool> = it.collect();
     /// assert_eq!(output_result, Err(false));
@@ -1810,14 +1810,14 @@ pub trait Itertools : Iterator {
     ///
     /// #[derive(PartialEq, Debug)]
     /// enum Enum { A, B, C, D, E, }
-    /// 
+    ///
     /// let mut iter = vec![Enum::A, Enum::B, Enum::C, Enum::D].into_iter();
-    /// 
+    ///
     /// // search `iter` for `B`
     /// assert_eq!(iter.contains(&Enum::B), true);
     /// // `B` was found, so the iterator now rests at the item after `B` (i.e, `C`).
     /// assert_eq!(iter.next(), Some(Enum::C));
-    /// 
+    ///
     /// // search `iter` for `E`
     /// assert_eq!(iter.contains(&Enum::E), false);
     /// // `E` wasn't found, so `iter` is now exhausted
@@ -1855,6 +1855,33 @@ pub trait Itertools : Iterator {
         match self.next() {
             None => true,
             Some(a) => self.all(|x| a == x),
+        }
+    }
+
+    /// Returns the value of the first element if it exists and all elements are equal.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let data = vec![1, 1, 1, 2, 2, 3, 3, 3, 4, 5, 5];
+    /// assert_eq!(data.iter().all_equal_value(), None);
+    /// assert_eq!(data[0..3].iter().all_equal_value(), Some(&1));
+    /// assert_eq!(data[3..5].iter().all_equal_value(), Some(&2));
+    /// assert_eq!(data[5..8].iter().all_equal_value(), Some(&3));
+    ///
+    /// let data : Option<usize> = None;
+    /// assert_eq!(data.into_iter().all_equal_value(), None);
+    /// ```
+    fn all_equal_value(&mut self) -> Option<Self::Item>
+        where Self: Sized,
+              Self::Item: PartialEq,
+    {
+        let first = self.next()?;
+
+        if self.all(|item| first == item) {
+            Some(first)
+        } else {
+            None
         }
     }
 
@@ -2867,13 +2894,13 @@ pub trait Itertools : Iterator {
         group_map::into_group_map_by(self, f)
     }
 
-    /// Constructs a `GroupingMap` to be used later with one of the efficient 
+    /// Constructs a `GroupingMap` to be used later with one of the efficient
     /// group-and-fold operations it allows to perform.
-    /// 
+    ///
     /// The input iterator must yield item in the form of `(K, V)` where the
     /// value of type `K` will be used as key to identify the groups and the
     /// value of type `V` as value for the folding operation.
-    /// 
+    ///
     /// See [`GroupingMap`] for more informations
     /// on what operations are available.
     #[cfg(feature = "use_std")]
@@ -2884,12 +2911,12 @@ pub trait Itertools : Iterator {
         grouping_map::new(self)
     }
 
-    /// Constructs a `GroupingMap` to be used later with one of the efficient 
+    /// Constructs a `GroupingMap` to be used later with one of the efficient
     /// group-and-fold operations it allows to perform.
-    /// 
+    ///
     /// The values from this iterator will be used as values for the folding operation
     /// while the keys will be obtained from the values by calling `key_mapper`.
-    /// 
+    ///
     /// See [`GroupingMap`] for more informations
     /// on what operations are available.
     #[cfg(feature = "use_std")]
@@ -3600,7 +3627,7 @@ pub trait Itertools : Iterator {
     ///   first_name: &'static str,
     ///   last_name:  &'static str,
     /// }
-    /// 
+    ///
     /// let characters =
     ///     vec![
     ///         Character { first_name: "Amy",   last_name: "Pond"      },
@@ -3611,12 +3638,12 @@ pub trait Itertools : Iterator {
     ///         Character { first_name: "James", last_name: "Norington" },
     ///         Character { first_name: "James", last_name: "Kirk"      },
     ///     ];
-    /// 
-    /// let first_name_frequency = 
+    ///
+    /// let first_name_frequency =
     ///     characters
     ///         .into_iter()
     ///         .counts_by(|c| c.first_name);
-    ///     
+    ///
     /// assert_eq!(first_name_frequency["Amy"], 3);
     /// assert_eq!(first_name_frequency["James"], 4);
     /// assert_eq!(first_name_frequency.contains_key("Asha"), false);
@@ -3637,7 +3664,7 @@ pub trait Itertools : Iterator {
     /// column.
     ///
     /// This function is, in some sense, the opposite of [`multizip`].
-    /// 
+    ///
     /// ```
     /// use itertools::Itertools;
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1858,30 +1858,34 @@ pub trait Itertools : Iterator {
         }
     }
 
-    /// Returns the value of the first element if it exists and all elements are equal.
+    /// If there are elements and they are all equal, return a single copy of that element.
+    /// If there are no elements, return an Error containing None.
+    /// If there are elements and they are not all equal, return a tuple containing the first
+    /// two non-equal elements found.
     ///
     /// ```
     /// use itertools::Itertools;
     ///
     /// let data = vec![1, 1, 1, 2, 2, 3, 3, 3, 4, 5, 5];
-    /// assert_eq!(data.iter().all_equal_value(), None);
-    /// assert_eq!(data[0..3].iter().all_equal_value(), Some(&1));
-    /// assert_eq!(data[3..5].iter().all_equal_value(), Some(&2));
-    /// assert_eq!(data[5..8].iter().all_equal_value(), Some(&3));
+    /// assert_eq!(data.iter().all_equal_value(), Err(Some((&1, &2))));
+    /// assert_eq!(data[0..3].iter().all_equal_value(), Ok(&1));
+    /// assert_eq!(data[3..5].iter().all_equal_value(), Ok(&2));
+    /// assert_eq!(data[5..8].iter().all_equal_value(), Ok(&3));
     ///
     /// let data : Option<usize> = None;
-    /// assert_eq!(data.into_iter().all_equal_value(), None);
+    /// assert_eq!(data.into_iter().all_equal_value(), Err(None));
     /// ```
-    fn all_equal_value(&mut self) -> Option<Self::Item>
-        where Self: Sized,
-              Self::Item: PartialEq,
+    fn all_equal_value(&mut self) -> Result<Self::Item, Option<(Self::Item, Self::Item)>>
+        where
+            Self: Sized,
+            Self::Item: PartialEq
     {
-        let first = self.next()?;
-
-        if self.all(|item| first == item) {
-            Some(first)
+        let first = self.next().ok_or(None)?;
+        let other = self.find(|x| !(x == &first));
+        if let Some(other) = other {
+            Err(Some((first, other)))
         } else {
-            None
+            Ok(first)
         }
     }
 

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -221,6 +221,14 @@ fn all_equal() {
 }
 
 #[test]
+fn all_equal_value() {
+    assert!("".chars().all_equal_value().is_none());
+    assert_eq!("A".chars().all_equal_value(), Some('A'));
+    assert!("AABBCCC".chars().all_equal_value().is_none());
+    assert_eq!("AAAAAAA".chars().all_equal_value(), Some('A'));
+}
+
+#[test]
 fn all_unique() {
     assert!("ABCDEFGH".chars().all_unique());
     assert!(!"ABCDEFGA".chars().all_unique());
@@ -1160,9 +1168,9 @@ fn exactly_one_question_mark_return() -> Result<(), ExactlyOneError<std::slice::
 
 #[test]
 fn multiunzip() {
-    let (a, b, c): (Vec<_>, Vec<_>, Vec<_>) = [(0, 1, 2), (3, 4, 5), (6, 7, 8)].iter().cloned().multiunzip();    
+    let (a, b, c): (Vec<_>, Vec<_>, Vec<_>) = [(0, 1, 2), (3, 4, 5), (6, 7, 8)].iter().cloned().multiunzip();
     assert_eq!((a, b, c), (vec![0, 3, 6], vec![1, 4, 7], vec![2, 5, 8]));
     let (): () = [(), (), ()].iter().cloned().multiunzip();
-    let t: (Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>) = [(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)].iter().cloned().multiunzip();    
+    let t: (Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>, Vec<_>) = [(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)].iter().cloned().multiunzip();
     assert_eq!(t, (vec![0], vec![1], vec![2], vec![3], vec![4], vec![5], vec![6], vec![7], vec![8], vec![9], vec![10], vec![11]));
 }

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -222,10 +222,10 @@ fn all_equal() {
 
 #[test]
 fn all_equal_value() {
-    assert!("".chars().all_equal_value().is_none());
-    assert_eq!("A".chars().all_equal_value(), Some('A'));
-    assert!("AABBCCC".chars().all_equal_value().is_none());
-    assert_eq!("AAAAAAA".chars().all_equal_value(), Some('A'));
+    assert_eq!("".chars().all_equal_value(), Err(None));
+    assert_eq!("A".chars().all_equal_value(), Ok('A'));
+    assert_eq!("AABBCCC".chars().all_equal_value(), Err(Some(('A', 'B'))));
+    assert_eq!("AAAAAAA".chars().all_equal_value(), Ok('A'));
 }
 
 #[test]


### PR DESCRIPTION
This resolves https://github.com/rust-itertools/itertools/issues/495 by adding an `all_equal_value` method.

(I'm not certain it's valuable enough to add, but thought I might as well submit a PR to find out.)