### PR TITLE
tidy Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,15 +28,10 @@ either = { version = "1.0", default-features = false }
 
 [dev-dependencies]
 rand = "0.7"
-criterion = "=0" # TODO how could this work with our minimum supported Rust version?
-paste = "1.0.0" # Used in test_std to instantiate generic tests
-
-[dev-dependencies.quickcheck]
-version = "0.9"
-default-features = false
-
-[dev-dependencies.permutohedron]
-version = "0.2"
+criterion = "0.4.0"
+paste = "1.0.0"  # Used in test_std to instantiate generic tests
+permutohedron = "0.2"
+quickcheck = { version = "0.9", default_features = false }
 
 [features]
 default = ["use_std"]


### PR DESCRIPTION
tidies `Cargo.toml` (especially the dev-dependencies)

Also bumps the dev dependencies

Note that there's no impact on the MSRV since the MSRV check in CI is currently not checking dev targets