### PR TITLE
add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily


### PR DESCRIPTION
adds dependabot config for bumping github action versions.

I've excluded rust dep updates for now, simply because the dev dependencies are out of date, but will require breaking changes to update. Doesn't look like there's anything in CI right now that would catch breaking changes in the dev dependencies, so best to park that for now.