### PR TITLE
run tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,19 @@ on:
       - trying
 
 jobs:
-
   check:
     name: check
     runs-on: ubuntu-latest
     strategy:
       matrix:
         build: [msrv, stable]
-        features: ["", "--no-default-features", "--no-default-features --features use_alloc",  "--all-targets --all-features"]
+        features:
+          [
+            "",
+            "--no-default-features",
+            "--no-default-features --features use_alloc",
+            "--all-targets --all-features",
+          ]
         include:
           - build: msrv
             rust: 1.62.1
@@ -40,13 +45,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --all-features
 
-
   # https://github.com/rust-lang/crater/blob/9ab6f9697c901c4a44025cf0a39b73ad5b37d198/.github/workflows/bors.yml#L125-L149
   end-success:
     name: bors build finished
     if: success()
     runs-on: ubuntu-latest
-    needs: [msrv,stable]
+    needs: [check, test]
 
     steps:
       - name: Mark the job as successful

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,25 +8,38 @@ on:
       - trying
 
 jobs:
-  msrv:
-    name: Rust MSRV
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: dtolnay/rust-toolchain@1.36.0
-      - run: cargo check --no-default-features
-      - run: cargo check --no-default-features --features "use_alloc"
-      - run: cargo check
 
-  stable:
-    name: Rust Stable
+  check:
+    name: check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build: [msrv, stable]
+        features: ["", "--no-default-features", "--no-default-features --features use_alloc",  "--all-targets --all-features"]
+        include:
+          - build: msrv
+            rust: 1.62.1
+          - build: stable
+            rust: stable
+        exclude:
+          - build: msrv
+            # we only care about the MSRV with respect to the lib target
+            features: "--all-targets --all-features"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo check ${{ matrix.features }}
+
+  test:
+    name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo check --no-default-features
-      - run: cargo check --no-default-features --features "use_alloc"
-      - run: cargo test
+      - run: cargo test --all-features
+
 
   # https://github.com/rust-lang/crater/blob/9ab6f9697c901c4a44025cf0a39b73ad5b37d198/.github/workflows/bors.yml#L125-L149
   end-success:


### PR DESCRIPTION
- refactors the CI workflow to group targets by action (check or test) rather than by toolchain
- converts the 'check' targets into a unified matrix target
- adds a 'test' target to run the tests in CI
- runs the checks in parallel instead of in sequence
- adds an '--all-targets' check on stable to check the bench and test targets

outstanding questions-

- are all of these matrix targets needed, or can this be trimmed down further?

I believe merging this will unblock adding configuration to allow dependabot to bump rust deps in this repo, since the CI will catch breaking changes in dev dependencies with these changes. see #674 