### PR TITLE
Fix max_set_by_key documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3127,7 +3127,7 @@ pub trait Itertools : Iterator {
         )
     }
 
-    /// Return all minimum elements of an iterator, as determined by
+    /// Return all maximum elements of an iterator, as determined by
     /// the specified function.
     ///
     /// # Examples


### PR DESCRIPTION
The `max_set_by_key` method has little error in the documentation, it says the method returns all mininum elements, when it should say it returns all maximum elements.