### PR TITLE
fix: take_while_inclusive takes iterator by value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1519,7 +1519,7 @@ pub trait Itertools : Iterator {
     ///     .collect();
     /// let expected: Vec<_> = vec![1, 2, 3].into_iter().map(NoCloneImpl).collect();
     /// assert_eq!(filtered, expected);
-    fn take_while_inclusive<F>(&mut self, accept: F) -> TakeWhileInclusive<Self, F>
+    fn take_while_inclusive<F>(self, accept: F) -> TakeWhileInclusive<Self, F>
     where
         Self: Sized,
         F: FnMut(&Self::Item) -> bool,
@@ -2650,7 +2650,7 @@ pub trait Itertools : Iterator {
     /// **Note:** This consumes the entire iterator, uses the
     /// [`slice::sort_unstable`] method and returns the result as a new
     /// iterator that owns its elements.
-    /// 
+    ///
     /// This sort is unstable (i.e., may reorder equal elements).
     ///
     /// The sorted iterator, if directly collected to a `Vec`, is converted
@@ -2681,7 +2681,7 @@ pub trait Itertools : Iterator {
     /// **Note:** This consumes the entire iterator, uses the
     /// [`slice::sort_unstable_by`] method and returns the result as a new
     /// iterator that owns its elements.
-    /// 
+    ///
     /// This sort is unstable (i.e., may reorder equal elements).
     ///
     /// The sorted iterator, if directly collected to a `Vec`, is converted
@@ -2716,7 +2716,7 @@ pub trait Itertools : Iterator {
     /// **Note:** This consumes the entire iterator, uses the
     /// [`slice::sort_unstable_by_key`] method and returns the result as a new
     /// iterator that owns its elements.
-    /// 
+    ///
     /// This sort is unstable (i.e., may reorder equal elements).
     ///
     /// The sorted iterator, if directly collected to a `Vec`, is converted
@@ -2752,7 +2752,7 @@ pub trait Itertools : Iterator {
     /// **Note:** This consumes the entire iterator, uses the
     /// [`slice::sort`] method and returns the result as a new
     /// iterator that owns its elements.
-    /// 
+    ///
     /// This sort is stable (i.e., does not reorder equal elements).
     ///
     /// The sorted iterator, if directly collected to a `Vec`, is converted
@@ -2783,7 +2783,7 @@ pub trait Itertools : Iterator {
     /// **Note:** This consumes the entire iterator, uses the
     /// [`slice::sort_by`] method and returns the result as a new
     /// iterator that owns its elements.
-    /// 
+    ///
     /// This sort is stable (i.e., does not reorder equal elements).
     ///
     /// The sorted iterator, if directly collected to a `Vec`, is converted
@@ -2818,7 +2818,7 @@ pub trait Itertools : Iterator {
     /// **Note:** This consumes the entire iterator, uses the
     /// [`slice::sort_by_key`] method and returns the result as a new
     /// iterator that owns its elements.
-    /// 
+    ///
     /// This sort is stable (i.e., does not reorder equal elements).
     ///
     /// The sorted iterator, if directly collected to a `Vec`, is converted
@@ -2855,7 +2855,7 @@ pub trait Itertools : Iterator {
     /// **Note:** This consumes the entire iterator, uses the
     /// [`slice::sort_by_cached_key`] method and returns the result as a new
     /// iterator that owns its elements.
-    /// 
+    ///
     /// This sort is stable (i.e., does not reorder equal elements).
     ///
     /// The sorted iterator, if directly collected to a `Vec`, is converted

--- a/src/take_while_inclusive.rs
+++ b/src/take_while_inclusive.rs
@@ -8,30 +8,30 @@ use std::fmt;
 /// See [`.take_while_inclusive()`](crate::Itertools::take_while_inclusive)
 /// for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-pub struct TakeWhileInclusive<'a, I: 'a, F> {
-    iter: &'a mut I,
+pub struct TakeWhileInclusive<I, F> {
+    iter: I,
     predicate: F,
     done: bool,
 }
 
-impl<'a, I, F> TakeWhileInclusive<'a, I, F>
+impl<I, F> TakeWhileInclusive<I, F>
 where
     I: Iterator,
     F: FnMut(&I::Item) -> bool,
 {
     /// Create a new [`TakeWhileInclusive`] from an iterator and a predicate.
-    pub fn new(iter: &'a mut I, predicate: F) -> Self {
+    pub fn new(iter: I, predicate: F) -> Self {
         Self { iter, predicate, done: false}
     }
 }
 
-impl<'a, I, F> fmt::Debug for TakeWhileInclusive<'a, I, F>
+impl<I, F> fmt::Debug for TakeWhileInclusive<I, F>
     where I: Iterator + fmt::Debug,
 {
     debug_fmt_fields!(TakeWhileInclusive, iter);
 }
 
-impl<'a, I, F> Iterator for TakeWhileInclusive<'a, I, F>
+impl<I, F> Iterator for TakeWhileInclusive<I, F>
 where
     I: Iterator,
     F: FnMut(&I::Item) -> bool
@@ -60,7 +60,7 @@ where
     }
 }
 
-impl<I, F> FusedIterator for TakeWhileInclusive<'_, I, F>
+impl<I, F> FusedIterator for TakeWhileInclusive<I, F>
 where
     I: Iterator,
     F: FnMut(&I::Item) -> bool


### PR DESCRIPTION
this helps in case `TakeWhileInclusive` is returned from a function, as otherwise we would be returning a struct which takes a reference from a locally created iterator.

example code which breaks, but shouldn't:

```rust
use itertools::Itertools;

struct Entry {
    constraint: bool,
}

struct List {
    entries: Vec<Entry>,
}

impl List {
    fn special(&self) -> impl Iterator<Item = &Entry> {
        self
            .entries
            .iter()
            .take_while_inclusive(|entry| entry.constraint)
    }
}
```

Rust Playground: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=f602ba3c6e7c2ab2f5132a0b40b80ceb