### PR TITLE
Add conversion into (Option<A>,Option<B>) to EitherOrBoth

### DIFF
--- a/src/either_or_both.rs
+++ b/src/either_or_both.rs
@@ -507,6 +507,7 @@ impl<A, B> Into<Option<Either<A, B>>> for EitherOrBoth<A, B> {
 }
 
 impl<A, B> From<EitherOrBoth<A, B>> for (Option<A>, Option<B>) {
+    #[inline(always)]
     fn from(val: EitherOrBoth<A, B>) -> Self {
         val.left_and_right()
     }

--- a/src/either_or_both.rs
+++ b/src/either_or_both.rs
@@ -494,9 +494,9 @@ impl<A, B> Into<Option<Either<A, B>>> for EitherOrBoth<A, B> {
     }
 }
 
-impl<A, B> Into<(Option<A>, Option<B>)> for EitherOrBoth<A, B> {
-    fn into(self) -> (Option<A>, Option<B>) {
-        match self.map_any(Some, Some) {
+impl<A, B> From<EitherOrBoth<A, B>> for (Option<A>, Option<B>) {
+    fn from(val: EitherOrBoth<A, B>) -> Self {
+        match val.map_any(Some, Some) {
             EitherOrBoth::Left(l) => (l, None),
             EitherOrBoth::Right(r) => (None, r),
             EitherOrBoth::Both(l, r) => (l, r),

--- a/src/either_or_both.rs
+++ b/src/either_or_both.rs
@@ -65,7 +65,7 @@ impl<A, B> EitherOrBoth<A, B> {
         }
     }
 
-    /// Return tupel of options corresponding to the left and right value respectively
+    /// Return tuple of options corresponding to the left and right value respectively
     ///
     /// If `Left` return `(Some(..), None)`, if `Right` return `(None,Some(..))`, else return
     /// `(Some(..),Some(..))`

--- a/src/either_or_both.rs
+++ b/src/either_or_both.rs
@@ -464,7 +464,7 @@ impl<A, B> EitherOrBoth<A, B> {
 impl<T> EitherOrBoth<T, T> {
     /// Return either value of left, right, or apply a function `f` to both values if both are present.
     /// The input function has to return the same type as both Right and Left carry.
-    /// 
+    ///
     /// # Examples
     /// ```
     /// # use itertools::EitherOrBoth;
@@ -490,6 +490,16 @@ impl<A, B> Into<Option<Either<A, B>>> for EitherOrBoth<A, B> {
             EitherOrBoth::Left(l) => Some(Either::Left(l)),
             EitherOrBoth::Right(r) => Some(Either::Right(r)),
             _ => None,
+        }
+    }
+}
+
+impl<A, B> Into<(Option<A>, Option<B>)> for EitherOrBoth<A, B> {
+    fn into(self) -> (Option<A>, Option<B>) {
+        match self.map_any(Some, Some) {
+            EitherOrBoth::Left(l) => (l, None),
+            EitherOrBoth::Right(r) => (None, r),
+            EitherOrBoth::Both(l, r) => (l, r),
         }
     }
 }

--- a/src/either_or_both.rs
+++ b/src/either_or_both.rs
@@ -70,11 +70,7 @@ impl<A, B> EitherOrBoth<A, B> {
     /// If `Left` return `(Some(..), None)`, if `Right` return `(None,Some(..))`, else return
     /// `(Some(..),Some(..))`
     pub fn left_and_right(self) -> (Option<A>, Option<B>) {
-        match self.map_any(Some, Some) {
-            EitherOrBoth::Left(l) => (l, None),
-            EitherOrBoth::Right(r) => (None, r),
-            EitherOrBoth::Both(l, r) => (l, r),
-        }
+        self.map_any(Some, Some).or_default()
     }
 
     /// If `Left`, return `Some` with the left value. If `Right` or `Both`, return `None`.
@@ -503,12 +499,5 @@ impl<A, B> Into<Option<Either<A, B>>> for EitherOrBoth<A, B> {
             EitherOrBoth::Right(r) => Some(Either::Right(r)),
             _ => None,
         }
-    }
-}
-
-impl<A, B> From<EitherOrBoth<A, B>> for (Option<A>, Option<B>) {
-    #[inline(always)]
-    fn from(val: EitherOrBoth<A, B>) -> Self {
-        val.left_and_right()
     }
 }

--- a/src/either_or_both.rs
+++ b/src/either_or_both.rs
@@ -65,6 +65,18 @@ impl<A, B> EitherOrBoth<A, B> {
         }
     }
 
+    /// Return tupel of options corresponding to the left and right value respectively
+    ///
+    /// If `Left` return `(Some(..), None)`, if `Right` return `(None,Some(..))`, else return
+    /// `(Some(..),Some(..))`
+    pub fn left_and_right(self) -> (Option<A>, Option<B>) {
+        match self.map_any(Some, Some) {
+            EitherOrBoth::Left(l) => (l, None),
+            EitherOrBoth::Right(r) => (None, r),
+            EitherOrBoth::Both(l, r) => (l, r),
+        }
+    }
+
     /// If `Left`, return `Some` with the left value. If `Right` or `Both`, return `None`.
     ///
     /// # Examples
@@ -496,10 +508,6 @@ impl<A, B> Into<Option<Either<A, B>>> for EitherOrBoth<A, B> {
 
 impl<A, B> From<EitherOrBoth<A, B>> for (Option<A>, Option<B>) {
     fn from(val: EitherOrBoth<A, B>) -> Self {
-        match val.map_any(Some, Some) {
-            EitherOrBoth::Left(l) => (l, None),
-            EitherOrBoth::Right(r) => (None, r),
-            EitherOrBoth::Both(l, r) => (l, r),
-        }
+        val.left_and_right()
     }
 }


### PR DESCRIPTION
Hey!

I recently found a conversion into `(Option<A>,Option<B>)` quite useful. Just wondered if there was any interest adding this directly to upstream here. If not, just close this pr :)

Thanks