### PR TITLE
Add `map_err` and `err_into` iterator adapters

### DIFF
--- a/src/adaptors/map.rs
+++ b/src/adaptors/map.rs
@@ -1,6 +1,8 @@
 use std::iter::FromIterator;
 use std::marker::PhantomData;
 
+use crate::traits::TryIterator;
+
 #[derive(Clone, Debug)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct MapSpecialCase<I, F> {
@@ -164,10 +166,10 @@ where
 pub type ErrInto<I, F> = MapSpecialCase<I, MapSpecialCaseFnErrInto<F>>;
 
 /// Create a new `ErrInto` iterator.
-pub(crate) fn err_into<I, F, T, E, E2>(iter: I) -> ErrInto<I, F>
+pub(crate) fn err_into<I, E>(iter: I) -> ErrInto<I, E>
 where
-    I: Iterator<Item = Result<T, E>>,
-    E: Into<E2>,
+    I: TryIterator,
+    <I as TryIterator>::Error: Into<E>,
 {
     MapSpecialCase {
         iter,

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -9,13 +9,13 @@ mod map;
 mod multi_product;
 
 pub use self::coalesce::*;
-pub use self::map::{map_into, map_ok, MapInto, MapOk, MapErr};
+pub use self::map::{map_into, map_ok, MapInto, MapOk, MapErr, ErrInto};
 #[allow(deprecated)]
 pub use self::map::MapResults;
 #[cfg(feature = "use_alloc")]
 pub use self::multi_product::*;
 
-pub(crate) use self::map::map_err;
+pub(crate) use self::map::{map_err, err_into};
 
 use std::fmt;
 use std::iter::{Fuse, Peekable, FromIterator, FusedIterator};

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -7,12 +7,15 @@
 mod coalesce;
 mod map;
 mod multi_product;
+
 pub use self::coalesce::*;
-pub use self::map::{map_into, map_ok, MapInto, MapOk};
+pub use self::map::{map_into, map_ok, MapInto, MapOk, MapErr};
 #[allow(deprecated)]
 pub use self::map::MapResults;
 #[cfg(feature = "use_alloc")]
 pub use self::multi_product::*;
+
+pub(crate) use self::map::map_err;
 
 use std::fmt;
 use std::iter::{Fuse, Peekable, FromIterator, FusedIterator};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,7 @@ pub mod structs {
 
 /// Traits helpful for using certain `Itertools` methods in generic contexts.
 pub mod traits {
+    pub use crate::try_iterator::TryIterator;
     pub use crate::tuple_impl::HomogeneousTuple;
 }
 
@@ -239,6 +240,7 @@ mod sources;
 mod take_while_inclusive;
 #[cfg(feature = "use_alloc")]
 mod tee;
+mod try_iterator;
 mod tuple_impl;
 #[cfg(feature = "use_std")]
 mod duplicates_impl;
@@ -959,13 +961,13 @@ pub trait Itertools : Iterator {
     /// use itertools::Itertools;
     ///
     /// let iterator = vec![Ok(()), Err(5i32)].into_iter();
-    /// let converted = iterator.err_into::<_, _, i64>();
+    /// let converted = iterator.err_into::<i64>();
     /// itertools::assert_equal(converted, vec![Ok(()), Err(5i64)]);
     /// ```
-    fn err_into<T, E, E2>(self) -> ErrInto<Self, E2>
+    fn err_into<E>(self) -> ErrInto<Self, E>
     where
-        Self: Iterator<Item = Result<T, E>> + Sized,
-        E: Into<E2>,
+        Self: traits::TryIterator + Sized,
+        <Self as traits::TryIterator>::Error: Into<E>,
     {
         adaptors::err_into(self)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@ pub mod structs {
         MapInto,
         MapOk,
         MapErr,
+        ErrInto,
         Merge,
         MergeBy,
         TakeWhileRef,
@@ -947,6 +948,26 @@ pub trait Itertools : Iterator {
         F: FnMut(E) -> E2,
     {
         adaptors::map_err(self, f)
+    }
+
+    /// Return an iterator adaptor that converts every [`Result::Err`] value
+    /// using the [`Into`] trait.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let iterator = vec![Ok(()), Err(5i32)].into_iter();
+    /// let converted = iterator.err_into::<_, _, i64>();
+    /// itertools::assert_equal(converted, vec![Ok(()), Err(5i64)]);
+    /// ```
+    fn err_into<T, E, E2>(self) -> ErrInto<Self, E2>
+    where
+        Self: Iterator<Item = Result<T, E>> + Sized,
+        E: Into<E2>,
+    {
+        adaptors::err_into(self)
     }
 
     /// “Lift” a function of the values of the current iterator so as to process

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ pub mod structs {
         Batching,
         MapInto,
         MapOk,
+        MapErr,
         Merge,
         MergeBy,
         TakeWhileRef,
@@ -926,6 +927,26 @@ pub trait Itertools : Iterator {
               T: IntoIterator
     {
         flatten_ok::flatten_ok(self)
+    }
+
+    /// Return an iterator adaptor that applies the provided closure to every
+    /// [`Result::Err`] value. [`Result::Ok`] values are unchanged.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// let iterator = vec![Ok(41), Err(0), Ok(11)].into_iter();
+    /// let mapped = iterator.map_err(|x| x + 2);
+    /// itertools::assert_equal(mapped, vec![Ok(41), Err(2), Ok(11)]);
+    /// ```
+    fn map_err<F, T, E, E2>(self, f: F) -> MapErr<Self, F>
+    where
+        Self: Iterator<Item = Result<T, E>> + Sized,
+        F: FnMut(E) -> E2,
+    {
+        adaptors::map_err(self, f)
     }
 
     /// “Lift” a function of the values of the current iterator so as to process

--- a/src/try_iterator.rs
+++ b/src/try_iterator.rs
@@ -1,0 +1,34 @@
+mod private {
+    pub trait Sealed {}
+    impl<I, T, E> Sealed for I where I: Iterator<Item = Result<T, E>> {}
+}
+
+/// Helper trait automatically implemented for [`Iterator`]s of [`Result`]s.
+///
+/// Can be useful for specifying certain trait bounds more concisely. Take
+/// [`.err_into()`][err_into] for example:
+///
+/// Without [`TryIterator`], [`err_into`][err_into] would have to be generic
+/// over 3 type parameters: the type of [`Result::Ok`] values, the type of
+/// [`Result::Err`] values, and the type to convert errors into. Usage would
+/// look like this: `my_iterator.err_into<_, _, E>()`.
+///
+/// Using [`TryIterator`], [`err_into`][err_into] can be generic over a single
+/// type parameter, and called like this: `my_iterator.err_into<E>()`.
+///
+/// [err_into]: crate::Itertools::err_into
+pub trait TryIterator: Iterator + private::Sealed {
+    /// The type of [`Result::Ok`] values yielded by this [`Iterator`].
+    type Ok;
+
+    /// The type of [`Result::Err`] values yielded by this [`Iterator`].
+    type Error;
+}
+
+impl<I, T, E> TryIterator for I
+where
+    I: Iterator<Item = Result<T, E>>,
+{
+    type Ok = T;
+    type Error = E;
+}

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -106,6 +106,12 @@ quickcheck! {
 }
 
 quickcheck! {
+    fn map_err(v: Vec<Result<char, u8>>) -> () {
+        test_specializations(&v.into_iter().map_err(|u| u.checked_add(1)));
+    }
+}
+
+quickcheck! {
     fn process_results(v: Vec<Result<u8, u8>>) -> () {
         helper(v.iter().copied());
         helper(v.iter().copied().filter(Result::is_ok));

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -112,6 +112,12 @@ quickcheck! {
 }
 
 quickcheck! {
+    fn err_into(v: Vec<Result<char, u8>>) -> () {
+        test_specializations(&v.into_iter().err_into::<_, _, u16>());
+    }
+}
+
+quickcheck! {
     fn process_results(v: Vec<Result<u8, u8>>) -> () {
         helper(v.iter().copied());
         helper(v.iter().copied().filter(Result::is_ok));

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -113,7 +113,7 @@ quickcheck! {
 
 quickcheck! {
     fn err_into(v: Vec<Result<char, u8>>) -> () {
-        test_specializations(&v.into_iter().err_into::<_, _, u16>());
+        test_specializations(&v.into_iter().err_into::<u16>());
     }
 }
 


### PR DESCRIPTION
This PR adds `map_err` and `err_into` methods to `Itertools`.
* `.map_err(f)` is just like `.map_ok(f)`, but it applies `f` to each _`Result::Err`_ value.
* `.err_into()` is simply `.map_err(Into::into)`.

These methods already exist on [`Stream`](https://docs.rs/futures/0.3.28/futures/stream/trait.Stream.html)s ("async iterators") in [`TryStreamExt`](https://docs.rs/futures/0.3.28/futures/stream/trait.TryStreamExt.html#method.err_into), and I think the ergonomics are quite pleasant. E.g., the following pattern becomes less cumbersome:
```rust
my_stream.map(|result| result.map_err(Into::into))
my_stream.map_err(Into::into) // nice
my_stream.err_into() // even nicer
```

---

I've included tests for iterator specialization, and doctests for both methods. Implementation details live in `crate::apaptors::map`, alongside `MapOk` and `MapInto`.

Let me know if there's any feedback or concerns; or if this feature is just not needed.

Thanks!