### PR TITLE
`try_len` method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3840,6 +3840,22 @@ pub trait Itertools : Iterator {
     {
         MultiUnzip::multiunzip(self)
     }
+
+    /// Returns the length of the iterator if one exists.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    ///
+    /// assert_eq!([0; 10].into_iter().try_len(), Some(10));
+    /// assert_eq!((10..15).try_len(), Some(5));
+    /// assert_eq!((15..10).try_len(), Some(0));
+    /// assert_eq!((10..).try_len(), None);
+    /// ```
+    fn try_len(self) -> Option<usize>
+    where Self: Sized
+    {
+        size_hint::try_len(self)
+    }
 }
 
 impl<T: ?Sized> Itertools for T where T: Iterator { }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3857,10 +3857,12 @@ pub trait Itertools : Iterator {
     /// assert_eq!((10..).try_len(), Err((usize::MAX, None)));
     /// assert_eq!((10..15).filter(|x| x % 2 == 0).try_len(), Err((0, Some(5))));
     /// ```
-    #[inline]
-    fn try_len(&self) -> Result<usize, size_hint::SizeHint>
-    {
-        size_hint::try_len(self.size_hint())
+    fn try_len(&self) -> Result<usize, size_hint::SizeHint> {
+        let sh = self.size_hint();
+        match sh {
+            (lo, Some(hi)) if lo == hi => Ok(lo),
+            _ => Err(sh),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3851,7 +3851,7 @@ pub trait Itertools : Iterator {
     /// assert_eq!((15..10).try_len(), Some(0));
     /// assert_eq!((10..).try_len(), None);
     /// ```
-    fn try_len(self) -> Option<usize>
+    fn try_len(&self) -> Option<usize>
     where Self: Sized
     {
         size_hint::try_len(self)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3842,6 +3842,7 @@ pub trait Itertools : Iterator {
     }
 
     /// Returns the length of the iterator if one exists.
+    /// Relies on the [`size_hint`] of the iterator being correct.
     ///
     /// ```
     /// use itertools::Itertools;
@@ -3854,7 +3855,7 @@ pub trait Itertools : Iterator {
     fn try_len(&self) -> Option<usize>
     where Self: Sized
     {
-        size_hint::try_len(self)
+        size_hint::try_len(self.size_hint())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3842,18 +3842,23 @@ pub trait Itertools : Iterator {
     }
 
     /// Returns the length of the iterator if one exists.
-    /// Relies on the [`size_hint`] of the iterator being correct.
+    /// Otherwise return `self.size_hint()`.
+    ///
+    /// Fallible [`ExactSizeIterator::len`].
+    ///
+    /// Inherits guarantees and restrictions from [`Iterator::size_hint`].
     ///
     /// ```
     /// use itertools::Itertools;
     ///
-    /// assert_eq!([0; 10].into_iter().try_len(), Some(10));
-    /// assert_eq!((10..15).try_len(), Some(5));
-    /// assert_eq!((15..10).try_len(), Some(0));
-    /// assert_eq!((10..).try_len(), None);
+    /// assert_eq!([0; 10].iter().try_len(), Ok(10));
+    /// assert_eq!((10..15).try_len(), Ok(5));
+    /// assert_eq!((15..10).try_len(), Ok(0));
+    /// assert_eq!((10..).try_len(), Err((usize::MAX, None)));
+    /// assert_eq!((10..15).filter(|x| x % 2 == 0).try_len(), Err((0, Some(5))));
     /// ```
-    fn try_len(&self) -> Option<usize>
-    where Self: Sized
+    #[inline]
+    fn try_len(&self) -> Result<usize, size_hint::SizeHint>
     {
         size_hint::try_len(self.size_hint())
     }

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -117,3 +117,12 @@ pub fn min(a: SizeHint, b: SizeHint) -> SizeHint {
     };
     (lower, upper)
 }
+
+/// Returns the length of the iterator if one exists.
+#[inline]
+pub fn try_len(it: impl Iterator) -> Option<usize> {
+    match it.size_hint() {
+        (lo, Some(hi)) if lo == hi => Some(lo),
+        _ => None
+    }
+}

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -117,12 +117,3 @@ pub fn min(a: SizeHint, b: SizeHint) -> SizeHint {
     };
     (lower, upper)
 }
-
-/// Returns the length of the iterator if one exists.
-#[inline]
-pub fn try_len(sh: SizeHint) -> Result<usize, SizeHint> {
-    match sh {
-        (lo, Some(hi)) if lo == hi => Ok(lo),
-        _ => Err(sh)
-    }
-}

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -120,7 +120,7 @@ pub fn min(a: SizeHint, b: SizeHint) -> SizeHint {
 
 /// Returns the length of the iterator if one exists.
 #[inline]
-pub fn try_len(it: impl Iterator) -> Option<usize> {
+pub fn try_len(it: &impl Iterator) -> Option<usize> {
     match it.size_hint() {
         (lo, Some(hi)) if lo == hi => Some(lo),
         _ => None

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -120,9 +120,9 @@ pub fn min(a: SizeHint, b: SizeHint) -> SizeHint {
 
 /// Returns the length of the iterator if one exists.
 #[inline]
-pub fn try_len(sh: SizeHint) -> Option<usize> {
+pub fn try_len(sh: SizeHint) -> Result<usize, SizeHint> {
     match sh {
-        (lo, Some(hi)) if lo == hi => Some(lo),
-        _ => None
+        (lo, Some(hi)) if lo == hi => Ok(lo),
+        _ => Err(sh)
     }
 }

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -120,8 +120,8 @@ pub fn min(a: SizeHint, b: SizeHint) -> SizeHint {
 
 /// Returns the length of the iterator if one exists.
 #[inline]
-pub fn try_len(it: &impl Iterator) -> Option<usize> {
-    match it.size_hint() {
+pub fn try_len(sh: SizeHint) -> Option<usize> {
+    match sh {
         (lo, Some(hi)) if lo == hi => Some(lo),
         _ => None
     }


### PR DESCRIPTION
Add method to get the length of an iterator if the `size_hint` is consistent.
Reasons why this would be useful:
1. It makes it more obvious when getting the length with `it.try_len().unwrap()` than with the match statement.
2. Iterator adapters that increase the length of iteration are not supposed to implement `ExactSizeIter` as indicated [here](https://doc.rust-lang.org/std/iter/trait.ExactSizeIterator.html#when-shouldnt-an-adapter-be-exactsizeiterator). This could be used in those cases.
