### PR TITLE
More `size_hint` and `count` methods

### DIFF
--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::iter::FusedIterator;
+use std::iter::{Fuse, FusedIterator};
 
 use super::lazy_buffer::LazyBuffer;
 use super::size_hint::{self, SizeHint};
@@ -61,7 +61,7 @@ impl<I: Iterator> Combinations<I> {
 
     /// Returns a reference to the source iterator.
     #[inline]
-    pub(crate) fn src(&self) -> &I { &self.pool.it }
+    pub(crate) fn src(&self) -> &Fuse<I> { &self.pool.it }
 
     /// Resets this `Combinations` back to an initial state for combinations of length
     /// `k` over the same pool data source. If `k` is larger than the current length

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -144,11 +144,16 @@ impl<I> FusedIterator for Combinations<I>
           I::Item: Clone
 {}
 
-pub(crate) fn binomial(n: usize, k: usize) -> Option<usize> {
+pub(crate) fn binomial(mut n: usize, mut k: usize) -> Option<usize> {
     if n < k {
         return Some(0);
     }
     // n! / (n - k)! / k! but trying to avoid it overflows:
-    let k = (n - k).min(k);
-    (1..=k).fold(Some(1), |res, i| res.and_then(|x| x.checked_mul(n - i + 1).map(|x| x / i)))
+    k = (n - k).min(k);
+    let mut c = 1;
+    for i in 1..=k {
+        c = (c / i).checked_mul(n)? + c % i * n / i;
+        n -= 1;
+    }
+    Some(c)
 }

--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use std::fmt;
 use std::iter::FusedIterator;
 
+use super::combinations::binomial;
 use super::lazy_buffer::LazyBuffer;
 use super::size_hint::{self, SizeHint};
 
@@ -103,14 +104,6 @@ where
     }
 
     fn size_hint(&self) -> SizeHint {
-        fn binomial(n: usize, k: usize) -> Option<usize> {
-            if n < k {
-                return Some(0);
-            }
-            // n! / (n - k)! / k! but trying to avoid it overflows:
-            let k = (n - k).min(k);
-            (1..=k).fold(Some(1), |res, i| res.and_then(|x| x.checked_mul(n - i + 1).map(|x| x / i)))
-        }
         let k_perms = |n: usize, k: usize| binomial((n + k).saturating_sub(1), k);
         let k = self.indices.len();
         size_hint::try_map(self.pool.size_hint(), |n| {

--- a/src/lazy_buffer.rs
+++ b/src/lazy_buffer.rs
@@ -1,6 +1,8 @@
 use std::ops::Index;
 use alloc::vec::Vec;
 
+use crate::size_hint::{self, SizeHint};
+
 #[derive(Debug, Clone)]
 pub struct LazyBuffer<I: Iterator> {
     pub it: I,
@@ -22,6 +24,15 @@ where
 
     pub fn len(&self) -> usize {
         self.buffer.len()
+    }
+
+    pub fn size_hint(&self) -> SizeHint {
+        let len = self.len();
+        if self.done {
+            (len, Some(len))
+        } else {
+            size_hint::add_scalar(self.it.size_hint(), len)
+        }
     }
 
     pub fn get_next(&mut self) -> bool {

--- a/src/powerset.rs
+++ b/src/powerset.rs
@@ -3,7 +3,7 @@ use std::iter::FusedIterator;
 use std::usize;
 use alloc::vec::Vec;
 
-use super::combinations::{Combinations, combinations};
+use super::combinations::{Combinations, binomial, combinations};
 use super::size_hint;
 
 /// An iterator to iterate through the powerset of the elements from an iterator.
@@ -80,6 +80,13 @@ impl<I> Iterator for Powerset<I>
             // Fallback: self.pos is saturated and no longer reliable.
             (0, self_total.1)
         }
+    }
+
+    fn count(mut self) -> usize {
+        let k = self.combs.k();
+        let n = self.combs.real_n();
+        // It could be `(1 << n) - self.pos` but `1 << n` might overflow.
+        self.combs.count() + (k + 1..=n).map(|k| binomial(n, k).unwrap()).sum::<usize>()
     }
 }
 

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -119,6 +119,8 @@ pub fn min(a: SizeHint, b: SizeHint) -> SizeHint {
 }
 
 /// Try to apply a function `f` on both bounds of a `SizeHint`, failure means overflow.
+///
+/// For the resulting size hint to be correct, `f` must be increasing.
 #[inline]
 pub fn try_map<F>(sh: SizeHint, mut f: F) -> SizeHint
 where

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -117,3 +117,15 @@ pub fn min(a: SizeHint, b: SizeHint) -> SizeHint {
     };
     (lower, upper)
 }
+
+/// Try to apply a function `f` on both bounds of a `SizeHint`, failure means overflow.
+#[inline]
+pub fn try_map<F>(sh: SizeHint, mut f: F) -> SizeHint
+where
+    F: FnMut(usize) -> Option<usize>,
+{
+    let (mut low, mut hi) = sh;
+    low = f(low).unwrap_or(usize::MAX);
+    hi = hi.and_then(f);
+    (low, hi)
+}

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -910,6 +910,20 @@ fn combinations_zero() {
 }
 
 #[test]
+fn combinations_range_size_hint() {
+    for n in 0..6 {
+        for k in 0..=n {
+            let len = (n - k + 1..=n).product::<usize>() / (1..=k).product::<usize>();
+            let mut it = (0..n).combinations(k);
+            for count in (0..=len).rev() {
+                assert_eq!(it.size_hint(), (count, Some(count)));
+                assert_eq!(it.next().is_none(), count == 0);
+            }
+        }
+    }
+}
+
+#[test]
 fn permutations_zero() {
     it::assert_equal((1..3).permutations(0), vec![vec![]]);
     it::assert_equal((0..0).permutations(0), vec![vec![]]);

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -916,6 +916,20 @@ fn permutations_zero() {
 }
 
 #[test]
+fn permutations_range_size_hint() {
+    for n in 0..6 {
+        for k in 0..=n {
+            let len: usize = (n - k + 1..=n).product();
+            let mut it = (0..n).permutations(k);
+            for count in (0..=len).rev() {
+                assert_eq!(it.size_hint(), (count, Some(count)));
+                it.next();
+            }
+        }
+    }
+}
+
+#[test]
 fn combinations_with_replacement() {
     // Pool smaller than n
     it::assert_equal((0..1).combinations_with_replacement(2), vec![vec![0, 0]]);

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -910,13 +910,14 @@ fn combinations_zero() {
 }
 
 #[test]
-fn combinations_range_size_hint() {
+fn combinations_range_count() {
     for n in 0..6 {
         for k in 0..=n {
             let len = (n - k + 1..=n).product::<usize>() / (1..=k).product::<usize>();
             let mut it = (0..n).combinations(k);
             for count in (0..=len).rev() {
                 assert_eq!(it.size_hint(), (count, Some(count)));
+                assert_eq!(it.clone().count(), count);
                 assert_eq!(it.next().is_none(), count == 0);
             }
         }
@@ -930,13 +931,14 @@ fn permutations_zero() {
 }
 
 #[test]
-fn permutations_range_size_hint() {
+fn permutations_range_count() {
     for n in 0..6 {
         for k in 0..=n {
             let len: usize = (n - k + 1..=n).product();
             let mut it = (0..n).permutations(k);
             for count in (0..=len).rev() {
                 assert_eq!(it.size_hint(), (count, Some(count)));
+                assert_eq!(it.clone().count(), count);
                 assert_eq!(it.next().is_none(), count == 0);
             }
         }
@@ -977,13 +979,14 @@ fn combinations_with_replacement() {
 }
 
 #[test]
-fn combinations_with_replacement_range_size_hint() {
+fn combinations_with_replacement_range_count() {
     for n in 0..6 {
         for k in 0..=n {
             let len = (n..n + k).product::<usize>() / (1..=k).product::<usize>();
             let mut it = (0..n).combinations_with_replacement(k);
             for count in (0..=len).rev() {
                 assert_eq!(it.size_hint(), (count, Some(count)));
+                assert_eq!(it.clone().count(), count);
                 assert_eq!(it.next().is_none(), count == 0);
             }
         }
@@ -1005,6 +1008,11 @@ fn powerset() {
     assert_eq!((0..4).powerset().count(), 1 << 4);
     assert_eq!((0..8).powerset().count(), 1 << 8);
     assert_eq!((0..16).powerset().count(), 1 << 16);
+    let mut it = (0..8).powerset();
+    for count in (0..=(1 << 8)).rev() {
+        assert_eq!(it.clone().count(), count);
+        assert_eq!(it.next().is_none(), count == 0);
+    }
 }
 
 #[test]

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -923,7 +923,7 @@ fn permutations_range_size_hint() {
             let mut it = (0..n).permutations(k);
             for count in (0..=len).rev() {
                 assert_eq!(it.size_hint(), (count, Some(count)));
-                it.next();
+                assert_eq!(it.next().is_none(), count == 0);
             }
         }
     }
@@ -960,6 +960,20 @@ fn combinations_with_replacement() {
         (0..0).combinations_with_replacement(2),
         <Vec<Vec<_>>>::new(),
     );
+}
+
+#[test]
+fn combinations_with_replacement_range_size_hint() {
+    for n in 0..6 {
+        for k in 0..=n {
+            let len = (n..n + k).product::<usize>() / (1..=k).product::<usize>();
+            let mut it = (0..n).combinations_with_replacement(k);
+            for count in (0..=len).rev() {
+                assert_eq!(it.size_hint(), (count, Some(count)));
+                assert_eq!(it.next().is_none(), count == 0);
+            }
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
As I intend to improve the `permutations` algorithm (related to #722), I first wanted to simplify a few things:
- `CompleteStateRemaining` basically stands for `Option<usize>` without its usuability. A doc comment seems enough.
- `prefill` is way clearer to see if there are enough values.
- `CompleteState::count` method rather than an one-off function.
- `0..=x` instead of `0..(x+1)` ; one more fold.

Then I encountered a TODO that I fixed:
It makes sense to have a `LazyBuffer::size_hint` method which greatly helps in fixing `Permutations::size_hint` and therefore correctly allocate the memory for codes like `(0..n).permutations(k).map(...).collect_vec()`.
I think we need to be able to apply a function to both bounds of a `SizeHint`. Here, it avoids repetition and therefore readability.
Then permutations' size hints are tested.