### PR TITLE
Fuse the iterator in `LazyBuffer`

### DIFF
--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::iter::FusedIterator;
+use std::iter::{Fuse, FusedIterator};
 
 use super::lazy_buffer::LazyBuffer;
 use alloc::vec::Vec;
@@ -54,7 +54,7 @@ impl<I: Iterator> Combinations<I> {
 
     /// Returns a reference to the source iterator.
     #[inline]
-    pub(crate) fn src(&self) -> &I { &self.pool.it }
+    pub(crate) fn src(&self) -> &Fuse<I> { &self.pool.it }
 
     /// Resets this `Combinations` back to an initial state for combinations of length
     /// `k` over the same pool data source. If `k` is larger than the current length

--- a/src/lazy_buffer.rs
+++ b/src/lazy_buffer.rs
@@ -1,10 +1,10 @@
+use std::iter::Fuse;
 use std::ops::Index;
 use alloc::vec::Vec;
 
 #[derive(Debug, Clone)]
 pub struct LazyBuffer<I: Iterator> {
-    pub it: I,
-    done: bool,
+    pub it: Fuse<I>,
     buffer: Vec<I::Item>,
 }
 
@@ -14,8 +14,7 @@ where
 {
     pub fn new(it: I) -> LazyBuffer<I> {
         LazyBuffer {
-            it,
-            done: false,
+            it: it.fuse(),
             buffer: Vec::new(),
         }
     }
@@ -25,26 +24,19 @@ where
     }
 
     pub fn get_next(&mut self) -> bool {
-        if self.done {
-            return false;
-        }
         if let Some(x) = self.it.next() {
             self.buffer.push(x);
             true
         } else {
-            self.done = true;
             false
         }
     }
 
     pub fn prefill(&mut self, len: usize) {
         let buffer_len = self.buffer.len();
-
-        if !self.done && len > buffer_len {
+        if len > buffer_len {
             let delta = len - buffer_len;
-
             self.buffer.extend(self.it.by_ref().take(delta));
-            self.done = self.buffer.len() < len;
         }
     }
 }


### PR DESCRIPTION
Fuse the iterator in `LazyBuffer`.
@phimuemue Do I push the new `LazyBuffer::size_hint` here?
EDIT: It could also have a "fill" method `pub fn fill(&mut self) { self.buffer.extend(self.it.by_ref()) }` that would later be better than `while self.get_next() {}`. I did not created it before but would have a use for it basically to then know the real length in "count" methods.