### PR TITLE
combinations: `count` and `size_hint`

### DIFF
--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -185,6 +185,9 @@ fn remaining_for(n: usize, first: bool, indices: &[usize]) -> Option<usize> {
         indices
             .iter()
             .enumerate()
+            // TODO: Once the MSRV hits 1.37.0, we can sum options instead:
+            // .map(|(i, n0)| checked_binomial(n - 1 - *n0, k - i))
+            // .sum()
             .fold(Some(0), |sum, (i, n0)| {
                 sum.and_then(|s| s.checked_add(checked_binomial(n - 1 - *n0, k - i)?))
             })

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -158,7 +158,9 @@ pub(crate) fn checked_binomial(mut n: usize, mut k: usize) -> Option<usize> {
 /// For a given size `n`, return the count of remaining combinations or None if it would overflow.
 fn remaining_for(n: usize, first: bool, indices: &[usize]) -> Option<usize> {
     let k = indices.len();
-    if first {
+    if n < k {
+        Some(0)
+    } else if first {
         checked_binomial(n, k)
     } else {
         indices

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -130,8 +130,9 @@ impl<I> Iterator for Combinations<I>
 
     fn count(self) -> usize {
         let Self { indices, pool, first } = self;
+        // TODO: make `pool.it` private
         let n = pool.len() + pool.it.count();
-        remaining_for(n, first, &indices).expect("Iterator count greater than usize::MAX")
+        remaining_for(n, first, &indices).unwrap()
     }
 }
 

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -135,6 +135,11 @@ impl<I> Iterator for Combinations<I>
         // Create result vector based on the indices
         Some(self.indices.iter().map(|i| self.pool[*i].clone()).collect())
     }
+
+    fn count(mut self) -> usize {
+        self.pool.fill();
+        self.remaining_for(self.n()).expect("Iterator count greater than usize::MAX")
+    }
 }
 
 impl<I> FusedIterator for Combinations<I>

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -136,6 +136,13 @@ impl<I> Iterator for Combinations<I>
         Some(self.indices.iter().map(|i| self.pool[*i].clone()).collect())
     }
 
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (mut low, mut upp) = self.pool.size_hint();
+        low = self.remaining_for(low).unwrap_or(usize::MAX);
+        upp = upp.and_then(|upp| self.remaining_for(upp));
+        (low, upp)
+    }
+
     fn count(mut self) -> usize {
         self.pool.fill();
         self.remaining_for(self.n()).expect("Iterator count greater than usize::MAX")

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -126,3 +126,17 @@ impl<I> FusedIterator for Combinations<I>
     where I: Iterator,
           I::Item: Clone
 {}
+
+pub(crate) fn checked_binomial(mut n: usize, mut k: usize) -> Option<usize> {
+    if n < k {
+        return Some(0);
+    }
+    // `factorial(n) / factorial(n - k) / factorial(k)` but trying to avoid it overflows:
+    k = (n - k).min(k); // symmetry
+    let mut c = 1;
+    for i in 1..=k {
+        c = (c / i).checked_mul(n)?.checked_add((c % i).checked_mul(n)? / i)?;
+        n -= 1;
+    }
+    Some(c)
+}

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -156,6 +156,25 @@ pub(crate) fn checked_binomial(mut n: usize, mut k: usize) -> Option<usize> {
     Some(c)
 }
 
+#[test]
+fn test_checked_binomial() {
+    // With the first row: [1, 0, 0, ...] and the first column full of 1s, we check
+    // row by row the recurrence relation of binomials (which is an equivalent definition).
+    // For n >= 1 and k >= 1 we have:
+    //   binomial(n, k) == binomial(n - 1, k - 1) + binomial(n - 1, k)
+    const LIMIT: usize = 500;
+    let mut row = vec![Some(0); LIMIT + 1];
+    row[0] = Some(1);
+    for n in 0..=LIMIT {
+        for k in 0..=LIMIT {
+            assert_eq!(row[k], checked_binomial(n, k));
+        }
+        row = std::iter::once(Some(1))
+            .chain((1..=LIMIT).map(|k| row[k - 1]?.checked_add(row[k]?)))
+            .collect();
+    }
+}
+
 /// For a given size `n`, return the count of remaining combinations or None if it would overflow.
 fn remaining_for(n: usize, first: bool, indices: &[usize]) -> Option<usize> {
     let k = indices.len();

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -77,6 +77,21 @@ impl<I: Iterator> Combinations<I> {
             self.pool.prefill(k);
         }
     }
+
+    /// For a given size `n`, return the count of remaining elements or None if it would overflow.
+    fn remaining_for(&self, n: usize) -> Option<usize> {
+        let k = self.k();
+        if self.first {
+            checked_binomial(n, k)
+        } else {
+            self.indices
+                .iter()
+                .enumerate()
+                .fold(Some(0), |sum, (k0, n0)| {
+                    sum.and_then(|s| s.checked_add(checked_binomial(n - 1 - *n0, k - k0)?))
+                })
+        }
+    }
 }
 
 impl<I> Iterator for Combinations<I>

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -164,11 +164,29 @@ fn remaining_for(n: usize, first: bool, indices: &[usize]) -> Option<usize> {
     } else if first {
         checked_binomial(n, k)
     } else {
+        // https://en.wikipedia.org/wiki/Combinatorial_number_system
+        // http://www.site.uottawa.ca/~lucia/courses/5165-09/GenCombObj.pdf
+
+        // The combinations generated after the current one can be counted by counting as follows:
+        // - The subsequent combinations that differ in indices[0]:
+        //   If subsequent combinations differ in indices[0], then their value for indices[0]
+        //   must be at least 1 greater than the current indices[0].
+        //   As indices is strictly monotonically sorted, this means we can effectively choose k values
+        //   from (n - 1 - indices[0]), leading to binomial(n - 1 - indices[0], k) possibilities.
+        // - The subsequent combinations with same indices[0], but differing indices[1]:
+        //   Here we can choose k - 1 values from (n - 1 - indices[1]) values,
+        //   leading to binomial(n - 1 - indices[1], k - 1) possibilities.
+        // - (...)
+        // - The subsequent combinations with same indices[0..=i], but differing indices[i]:
+        //   Here we can choose k - i values from (n - 1 - indices[i]) values: binomial(n - 1 - indices[i], k - i).
+        //   Since subsequent combinations can in any index, we must sum up the aforementioned binomial coefficients.
+
+        // Below, `n0` resembles indices[i].
         indices
             .iter()
             .enumerate()
-            .fold(Some(0), |sum, (k0, n0)| {
-                sum.and_then(|s| s.checked_add(checked_binomial(n - 1 - *n0, k - k0)?))
+            .fold(Some(0), |sum, (i, n0)| {
+                sum.and_then(|s| s.checked_add(checked_binomial(n - 1 - *n0, k - i)?))
             })
     }
 }

--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -140,6 +140,7 @@ impl<I> FusedIterator for Combinations<I>
           I::Item: Clone
 {}
 
+// https://en.wikipedia.org/wiki/Binomial_coefficient#In_programming_languages
 pub(crate) fn checked_binomial(mut n: usize, mut k: usize) -> Option<usize> {
     if n < k {
         return Some(0);

--- a/src/lazy_buffer.rs
+++ b/src/lazy_buffer.rs
@@ -45,6 +45,10 @@ where
             self.buffer.extend(self.it.by_ref().take(delta));
         }
     }
+
+    pub fn fill(&mut self) {
+        self.buffer.extend(self.it.by_ref());
+    }
 }
 
 impl<I, J> Index<J> for LazyBuffer<I>

--- a/src/lazy_buffer.rs
+++ b/src/lazy_buffer.rs
@@ -2,6 +2,8 @@ use std::iter::Fuse;
 use std::ops::Index;
 use alloc::vec::Vec;
 
+use crate::size_hint::{self, SizeHint};
+
 #[derive(Debug, Clone)]
 pub struct LazyBuffer<I: Iterator> {
     pub it: Fuse<I>,
@@ -21,6 +23,10 @@ where
 
     pub fn len(&self) -> usize {
         self.buffer.len()
+    }
+
+    pub fn size_hint(&self) -> SizeHint {
+        size_hint::add_scalar(self.it.size_hint(), self.len())
     }
 
     pub fn get_next(&mut self) -> bool {

--- a/src/lazy_buffer.rs
+++ b/src/lazy_buffer.rs
@@ -45,10 +45,6 @@ where
             self.buffer.extend(self.it.by_ref().take(delta));
         }
     }
-
-    pub fn fill(&mut self) {
-        self.buffer.extend(self.it.by_ref());
-    }
 }
 
 impl<I, J> Index<J> for LazyBuffer<I>

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -916,6 +916,7 @@ fn combinations_range_count() {
             let len = (n - k + 1..=n).product::<usize>() / (1..=k).product::<usize>();
             let mut it = (0..n).combinations(k);
             for count in (0..=len).rev() {
+                assert_eq!(it.size_hint(), (count, Some(count)));
                 assert_eq!(it.clone().count(), count);
                 assert_eq!(it.next().is_none(), count == 0);
             }

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -910,6 +910,20 @@ fn combinations_zero() {
 }
 
 #[test]
+fn combinations_range_count() {
+    for n in 0..6 {
+        for k in 0..=n {
+            let len = (n - k + 1..=n).product::<usize>() / (1..=k).product::<usize>();
+            let mut it = (0..n).combinations(k);
+            for count in (0..=len).rev() {
+                assert_eq!(it.clone().count(), count);
+                assert_eq!(it.next().is_none(), count == 0);
+            }
+        }
+    }
+}
+
+#[test]
 fn permutations_zero() {
     it::assert_equal((1..3).permutations(0), vec![vec![]]);
     it::assert_equal((0..0).permutations(0), vec![vec![]]);

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -911,15 +911,22 @@ fn combinations_zero() {
 
 #[test]
 fn combinations_range_count() {
-    for n in 0..6 {
+    for n in 0..=10 {
         for k in 0..=n {
             let len = (n - k + 1..=n).product::<usize>() / (1..=k).product::<usize>();
             let mut it = (0..n).combinations(k);
-            for count in (0..=len).rev() {
-                assert_eq!(it.size_hint(), (count, Some(count)));
-                assert_eq!(it.clone().count(), count);
-                assert_eq!(it.next().is_none(), count == 0);
+            assert_eq!(len, it.clone().count());
+            assert_eq!(len, it.size_hint().0);
+            assert_eq!(Some(len), it.size_hint().1);
+            for count in (0..len).rev() {
+                let elem = it.next();
+                assert!(elem.is_some());
+                assert_eq!(count, it.clone().count());
+                assert_eq!(count, it.size_hint().0);
+                assert_eq!(Some(count), it.size_hint().1);
             }
+            let should_be_none = it.next();
+            assert!(should_be_none.is_none());
         }
     }
 }


### PR DESCRIPTION
The indices we track (to give combinations in the lexicographic order) can help us count the remaining combinations.

@phimuemue That's all for combinations. Each commit is as small as possible. Similar work for other iterators to come, but this should be the biggest as it prepares work for `powerset` and `combinations_with_replacement`.