### PR TITLE
Update rust/itertools versions in the doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,8 @@
 //!
 //! ## Rust Version
 //!
-//! This version of itertools requires Rust 1.32 or later.
-#![doc(html_root_url="https://docs.rs/itertools/0.8/")]
+//! This version of itertools requires Rust 1.36 or later.
+#![doc(html_root_url="https://docs.rs/itertools/0.11/")]
 
 #[cfg(not(feature = "use_std"))]
 extern crate core as std;


### PR DESCRIPTION
Rust 1.36 according to `Cargo.toml`.
And the fixed `html_root_url` updates all html links we might encounter. I personally do not use it very much but being redirect of `0.8` felt weird.