### PR TITLE
Do not sum options

### DIFF
--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -208,9 +208,6 @@ fn remaining_for(n: usize, first: bool, indices: &[usize]) -> Option<usize> {
         indices
             .iter()
             .enumerate()
-            // TODO: Once the MSRV hits 1.37.0, we can sum options instead:
-            // .map(|(i, n0)| checked_binomial(n - 1 - *n0, k - i))
-            // .sum()
             .fold(Some(0), |sum, (i, n0)| {
                 sum.and_then(|s| s.checked_add(checked_binomial(n - 1 - *n0, k - i)?))
             })

--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -157,9 +157,6 @@ fn remaining_for(n: usize, first: bool, indices: &[usize]) -> Option<usize> {
         indices
             .iter()
             .enumerate()
-            // TODO: Once the MSRV hits 1.37.0, we can sum options instead:
-            // .map(|(i, n0)| count(n - 1 - *n0, k - i))
-            // .sum()
             .fold(Some(0), |sum, (i, n0)| {
                 sum.and_then(|s| s.checked_add(count(n - 1 - *n0, k - i)?))
             })


### PR DESCRIPTION
A mistake on my part, discovered in time as code is still commented out. Note that it passed tests.
It only returns None if the iterator yields None. But it would overflow whenever an addition does.

Do not product options either, as multiplications could overflow the same way. That's how I found out.

I guess `checked_sum` and `checked_product` methods would be nice.
EDIT: ~Would you be interested?~ Related: https://github.com/rust-lang/rust/pull/95485