### PR TITLE
Use `try_fold` instead of `fold(Some(...), )`

### DIFF
--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -208,8 +208,8 @@ fn remaining_for(n: usize, first: bool, indices: &[usize]) -> Option<usize> {
         indices
             .iter()
             .enumerate()
-            .fold(Some(0), |sum, (i, n0)| {
-                sum.and_then(|s| s.checked_add(checked_binomial(n - 1 - *n0, k - i)?))
+            .try_fold(0usize, |sum, (i, n0)| {
+                sum.checked_add(checked_binomial(n - 1 - *n0, k - i)?)
             })
     }
 }

--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -157,8 +157,8 @@ fn remaining_for(n: usize, first: bool, indices: &[usize]) -> Option<usize> {
         indices
             .iter()
             .enumerate()
-            .fold(Some(0), |sum, (i, n0)| {
-                sum.and_then(|s| s.checked_add(count(n - 1 - *n0, k - i)?))
+            .try_fold(0usize, |sum, (i, n0)| {
+                sum.checked_add(count(n - 1 - *n0, k - i)?)
             })
     }
 }

--- a/src/permutations.rs
+++ b/src/permutations.rs
@@ -240,20 +240,16 @@ impl CompleteState {
                 if n < k {
                     return Some(0);
                 }
-                (n - k + 1..=n).fold(Some(1), |acc, i| {
-                    acc.and_then(|acc| acc.checked_mul(i))
-                })
+                (n - k + 1..=n).try_fold(1usize, |acc, i| acc.checked_mul(i))
             }
             CompleteState::Ongoing { ref indices, ref cycles } => {
-                let mut count: usize = 0;
-
-                for (i, &c) in cycles.iter().enumerate() {
-                    let radix = indices.len() - i;
-                    count = count.checked_mul(radix)
-                        .and_then(|count| count.checked_add(c))?;
-                }
-
-                Some(count)
+                cycles
+                    .iter()
+                    .enumerate()
+                    .try_fold(0usize, |acc, (i, &c)| {
+                        acc.checked_mul(indices.len() - i)
+                            .and_then(|count| count.checked_add(c))
+                    })
             }
         }
     }

--- a/src/powerset.rs
+++ b/src/powerset.rs
@@ -82,7 +82,7 @@ impl<I> FusedIterator for Powerset<I>
 {}
 
 fn remaining_for(n: usize, k: usize) -> Option<usize> {
-    (k + 1..=n).fold(Some(0), |sum, i| {
-        sum.and_then(|s| s.checked_add(checked_binomial(n, i)?))
+    (k + 1..=n).try_fold(0usize, |sum, i| {
+        sum.checked_add(checked_binomial(n, i)?)
     })
 }


### PR DESCRIPTION
I used `.fold(Some(...), ...)` pattern three times because it was used in `permutations.rs` (where I started a series of changes) but it leads to a lot of unnecessary `.and_then` if we have `None` early.
I previously thought it could be better replaced by something like `.map(...).sum::<Option<_>>()` with MSRV 1.37+ but no because it does not prevent the underlying operation to overflow. And there is no `checked_sum`/`checked_product`. Related to #745
After looking at `Itertools::fold_while`, I found out that `Iterator::try_fold` is the right method for the job.

**PS:** I was gonna suggest to deprecate `Itertools::fold_while` in favor of `Iterator::try_fold` but I see there was quite some discussion about this in #469. Not sure to understand the whole thing though.