### PR TITLE
Implement ExactSizeIterator for (Circular)TupleWindows

### DIFF
--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -184,6 +184,12 @@ where
         }
         None
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // At definition, `T::num_items() - 1` are collected
+        // so each remaining item in `iter` will lead to an item.
+        self.iter.size_hint()
+    }
 }
 
 impl<I, T> FusedIterator for TupleWindows<I, T>

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -3,7 +3,6 @@
 use std::iter::Cycle;
 use std::iter::Fuse;
 use std::iter::FusedIterator;
-use std::iter::Take;
 use std::marker::PhantomData;
 
 // `HomogeneousTuple` is a public facade for `TupleCollect`, allowing
@@ -208,7 +207,7 @@ where
     I: Iterator<Item = T::Item> + Clone,
     T: TupleCollect + Clone,
 {
-    iter: Take<TupleWindows<Cycle<I>, T>>,
+    iter: TupleWindows<Cycle<I>, T>,
     len: usize,
     phantom_data: PhantomData<T>,
 }
@@ -220,7 +219,7 @@ where
     T::Item: Clone,
 {
     let len = iter.len();
-    let iter = tuple_windows(iter.cycle()).take(len);
+    let iter = tuple_windows(iter.cycle());
 
     CircularTupleWindows {
         iter,
@@ -238,8 +237,12 @@ where
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.len = self.len.saturating_sub(1);
-        self.iter.next()
+        if self.len != 0 {
+            self.len -= 1;
+            self.iter.next()
+        } else {
+            None
+        }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -209,6 +209,7 @@ where
     T: TupleCollect + Clone,
 {
     iter: Take<TupleWindows<Cycle<I>, T>>,
+    len: usize,
     phantom_data: PhantomData<T>,
 }
 
@@ -223,6 +224,7 @@ where
 
     CircularTupleWindows {
         iter,
+        len,
         phantom_data: PhantomData {},
     }
 }
@@ -236,7 +238,12 @@ where
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
+        self.len = self.len.saturating_sub(1);
         self.iter.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len, Some(self.len))
     }
 }
 

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -255,6 +255,14 @@ where
 {
 }
 
+impl<I, T> FusedIterator for CircularTupleWindows<I, T>
+where
+    I: Iterator<Item = T::Item> + Clone,
+    T: TupleCollect + Clone,
+    T::Item: Clone,
+{
+}
+
 pub trait TupleCollect: Sized {
     type Item;
     type Buffer: Default + AsRef<[Option<Self::Item>]> + AsMut<[Option<Self::Item>]>;

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -192,6 +192,14 @@ where
     }
 }
 
+impl<I, T> ExactSizeIterator for TupleWindows<I, T>
+where
+    I: ExactSizeIterator<Item = T::Item>,
+    T: HomogeneousTuple + Clone,
+    T::Item: Clone,
+{
+}
+
 impl<I, T> FusedIterator for TupleWindows<I, T>
 where
     I: FusedIterator<Item = T::Item>,

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -247,6 +247,14 @@ where
     }
 }
 
+impl<I, T> ExactSizeIterator for CircularTupleWindows<I, T>
+where
+    I: Iterator<Item = T::Item> + Clone,
+    T: TupleCollect + Clone,
+    T::Item: Clone,
+{
+}
+
 pub trait TupleCollect: Sized {
     type Item;
     type Buffer: Default + AsRef<[Option<Self::Item>]> + AsMut<[Option<Self::Item>]>;

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -1117,6 +1117,10 @@ quickcheck! {
         true
     }
 
+    fn circular_tuple_windows_exact_size(a: Vec<u8>) -> bool {
+        exact_size(a.iter().circular_tuple_windows::<(_, _, _, _)>())
+    }
+
     fn equal_tuple_windows_1(a: Vec<u8>) -> bool {
         let x = a.windows(1).map(|s| (&s[0], ));
         let y = a.iter().tuple_windows::<(_,)>();

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -1145,6 +1145,14 @@ quickcheck! {
         itertools::equal(x, y)
     }
 
+    fn tuple_windows_exact_size_1(a: Vec<u8>) -> bool {
+        exact_size(a.iter().tuple_windows::<(_,)>())
+    }
+
+    fn tuple_windows_exact_size_4(a: Vec<u8>) -> bool {
+        exact_size(a.iter().tuple_windows::<(_, _, _, _)>())
+    }
+
     fn equal_tuples_1(a: Vec<u8>) -> bool {
         let x = a.chunks(1).map(|s| (&s[0], ));
         let y = a.iter().tuples::<(_,)>();


### PR DESCRIPTION
Closes #660 
Implement `ExactSizeIterator` ~at the cost of storing/updating the length~ without any additional cost. I just flatten `struct Take<I> { iter: I, n: usize }` from `iter: Take<TupleWindows<Cycle<I>, T>>` into `iter: TupleWindows<Cycle<I>, T>, len: usize`.
It has the same length as the input iterator.