### PR TITLE
Fix ignored doctests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2373,7 +2373,9 @@ pub trait Itertools: Iterator {
     /// For example the sequence *Ok(1), Ok(2), Ok(3)* will result in a
     /// computation like this:
     ///
-    /// ```ignore
+    /// ```no_run
+    /// # let start = 0;
+    /// # let f = |x, y| x + y;
     /// let mut accum = start;
     /// accum = f(accum, 1);
     /// accum = f(accum, 2);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3981,9 +3981,10 @@ where
 /// **Panics** on assertion failure with a message that shows the
 /// two iteration elements.
 ///
-/// ```ignore
+/// ```should_panic
+/// # use itertools::assert_equal;
 /// assert_equal("exceed".split('c'), "excess".split('c'));
-/// // ^PANIC: panicked at 'Failed assertion Some("eed") == Some("ess") for iteration 1',
+/// // ^PANIC: panicked at 'Failed assertion Some("eed") == Some("ess") for iteration 1'.
 /// ```
 pub fn assert_equal<I, J>(a: I, b: J)
 where

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -38,20 +38,6 @@ pub fn sub_scalar(sh: SizeHint, x: usize) -> SizeHint {
 }
 
 /// Multiply `SizeHint` correctly
-///
-/// ```ignore
-/// use std::usize;
-/// use itertools::size_hint;
-///
-/// assert_eq!(size_hint::mul((3, Some(4)), (3, Some(4))),
-///            (9, Some(16)));
-///
-/// assert_eq!(size_hint::mul((3, Some(4)), (usize::MAX, None)),
-///            (usize::MAX, None));
-///
-/// assert_eq!(size_hint::mul((3, None), (0, Some(0))),
-///            (0, Some(0)));
-/// ```
 #[inline]
 pub fn mul(a: SizeHint, b: SizeHint) -> SizeHint {
     let low = a.0.saturating_mul(b.0);
@@ -99,4 +85,11 @@ pub fn min(a: SizeHint, b: SizeHint) -> SizeHint {
         _ => a_upper.or(b_upper),
     };
     (lower, upper)
+}
+
+#[test]
+fn mul_size_hints() {
+    assert_eq!(mul((3, Some(4)), (3, Some(4))), (9, Some(16)));
+    assert_eq!(mul((3, Some(4)), (usize::MAX, None)), (usize::MAX, None));
+    assert_eq!(mul((3, None), (0, Some(0))), (0, Some(0)));
 }


### PR DESCRIPTION
[Doctest attribute](https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#attributes) | What it means
----------------- | -------------
text         | Not code.
ignore       | It is ignored by default but might run, e.g. `cargo test -- --ignored`.
should_panic | It must compile but panic at runtime.
no_run       | It must compile but is not run.
compile_fail | It must not compile.
edition2018  | Only runs on the given edition.

Personally, I annotate with "ignore" when it's slow and I don't want to run it every time.
Otherwise, I think another attribute should be used.