### PR TITLE
use 'cargo-hack' to run MSRV check without dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,9 @@ on:
 
 jobs:
   check:
-    name: check
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        build: [msrv, stable]
         features:
           [
             "",
@@ -21,24 +19,22 @@ jobs:
             "--no-default-features --features use_alloc",
             "--all-targets --all-features",
           ]
-        include:
-          - build: msrv
-            rust: 1.62.1
-          - build: stable
-            rust: stable
-        exclude:
-          - build: msrv
-            # we only care about the MSRV with respect to the lib target
-            features: "--all-targets --all-features"
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.rust }}
+      - uses: dtolnay/rust-toolchain@stable
       - run: cargo check ${{ matrix.features }}
 
+  msrv:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-no-dev-deps
+      - uses: dtolnay/rust-toolchain@1.43.1
+      - run: cargo no-dev-deps check
+
   test:
-    name: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -62,7 +58,6 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     needs: [check, test]
-
     steps:
       - name: Mark the job as successful
         run: exit 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["/bors.toml"]
 
 edition = "2018"
 
-rust-version = "1.36.0"
+rust-version = "1.43.1"
 
 [lib]
 bench = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //!
 //! ## Rust Version
 //!
-//! This version of itertools requires Rust 1.36 or later.
+//! This version of itertools requires Rust 1.43.1 or later.
 #![doc(html_root_url = "https://docs.rs/itertools/0.11/")]
 
 #[cfg(not(feature = "use_std"))]


### PR DESCRIPTION
decouple the MSRV check from the dev dependencies using `cargo-hack`

this allows dev dependencies to be updated without impacting downstream users.

note that the MSRV used in this PR was found using the following command-

`cargo msrv -- cargo no-dev-deps check`

(which requires installing `cargo-msrv` and `cargo-no-dev-deps`)