### PR TITLE
Minimize features

### DIFF
--- a/src/extrema_set.rs
+++ b/src/extrema_set.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "use_alloc")]
+use alloc::{vec, vec::Vec};
 use std::cmp::Ordering;
 
 /// Implementation guts for `min_set`, `min_set_by`, and `min_set_by_key`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,6 @@ use std::hash::Hash;
 use std::iter::{once, IntoIterator};
 #[cfg(feature = "use_alloc")]
 type VecIntoIter<T> = alloc::vec::IntoIter<T>;
-#[cfg(feature = "use_alloc")]
 use std::iter::FromIterator;
 
 #[macro_use]
@@ -2214,7 +2213,6 @@ pub trait Itertools: Iterator {
     ///     Ok(())
     /// }
     /// ```
-    #[cfg(feature = "use_alloc")]
     fn try_collect<T, U, E>(self) -> Result<U, E>
     where
         Self: Sized + Iterator<Item = Result<T, E>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ mod diff;
 #[cfg(feature = "use_std")]
 mod duplicates_impl;
 mod exactly_one_err;
-#[cfg(feature = "use_std")]
+#[cfg(feature = "use_alloc")]
 mod extrema_set;
 mod flatten_ok;
 mod format;
@@ -3169,7 +3169,7 @@ pub trait Itertools: Iterator {
     ///
     /// The elements can be floats but no particular result is guaranteed
     /// if an element is NaN.
-    #[cfg(feature = "use_std")]
+    #[cfg(feature = "use_alloc")]
     fn min_set(self) -> Vec<Self::Item>
     where
         Self: Sized,
@@ -3202,7 +3202,7 @@ pub trait Itertools: Iterator {
     ///
     /// The elements can be floats but no particular result is guaranteed
     /// if an element is NaN.
-    #[cfg(feature = "use_std")]
+    #[cfg(feature = "use_alloc")]
     fn min_set_by<F>(self, mut compare: F) -> Vec<Self::Item>
     where
         Self: Sized,
@@ -3234,7 +3234,7 @@ pub trait Itertools: Iterator {
     ///
     /// The elements can be floats but no particular result is guaranteed
     /// if an element is NaN.
-    #[cfg(feature = "use_std")]
+    #[cfg(feature = "use_alloc")]
     fn min_set_by_key<K, F>(self, key: F) -> Vec<Self::Item>
     where
         Self: Sized,
@@ -3266,7 +3266,7 @@ pub trait Itertools: Iterator {
     ///
     /// The elements can be floats but no particular result is guaranteed
     /// if an element is NaN.
-    #[cfg(feature = "use_std")]
+    #[cfg(feature = "use_alloc")]
     fn max_set(self) -> Vec<Self::Item>
     where
         Self: Sized,
@@ -3299,7 +3299,7 @@ pub trait Itertools: Iterator {
     ///
     /// The elements can be floats but no particular result is guaranteed
     /// if an element is NaN.
-    #[cfg(feature = "use_std")]
+    #[cfg(feature = "use_alloc")]
     fn max_set_by<F>(self, mut compare: F) -> Vec<Self::Item>
     where
         Self: Sized,
@@ -3331,7 +3331,7 @@ pub trait Itertools: Iterator {
     ///
     /// The elements can be floats but no particular result is guaranteed
     /// if an element is NaN.
-    #[cfg(feature = "use_std")]
+    #[cfg(feature = "use_alloc")]
     fn max_set_by_key<K, F>(self, key: F) -> Vec<Self::Item>
     where
         Self: Sized,


### PR DESCRIPTION
Somehow, I looked at `try_collect` and ticked seeing that it needs `use_alloc`. It sure does in most common cases but we can collect to `arrayvec` for example.
Because of that, I looked at each adaptor/method to find another unrequired features and found only the ones based on `extrema_set` which only needs to allocate to vectors.