### PR TITLE
Implement `ExactSizeIterator` for `Tuples`

### DIFF
--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -105,6 +105,14 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         T::collect_from_iter(&mut self.iter, &mut self.buf)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let buf_len = T::buffer_len(&self.buf);
+        let (mut low, mut hi) = self.iter.size_hint();
+        low = add_then_div(low, buf_len, T::num_items()).unwrap_or(usize::MAX);
+        hi = hi.and_then(|elt| add_then_div(elt, buf_len, T::num_items()));
+        (low, hi)
+    }
 }
 
 /// `(n + a) / d` avoiding overflow when possible, returns `None` if it overflows.

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -107,6 +107,12 @@ where
     }
 }
 
+/// `(n + a) / d` avoiding overflow when possible, returns `None` if it overflows.
+fn add_then_div(n: usize, a: usize, d: usize) -> Option<usize> {
+    debug_assert_ne!(d, 0);
+    (n / d).checked_add(a / d)?.checked_add((n % d + a % d) / d)
+}
+
 impl<I, T> Tuples<I, T>
 where
     I: Iterator<Item = T::Item>,

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -290,6 +290,11 @@ pub trait TupleCollect: Sized {
     type Item;
     type Buffer: Default + AsRef<[Option<Self::Item>]> + AsMut<[Option<Self::Item>]>;
 
+    fn buffer_len(buf: &Self::Buffer) -> usize {
+        let s = buf.as_ref();
+        s.iter().position(Option::is_none).unwrap_or(s.len())
+    }
+
     fn collect_from_iter<I>(iter: I, buf: &mut Self::Buffer) -> Option<Self>
     where
         I: IntoIterator<Item = Self::Item>;

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -121,6 +121,13 @@ fn add_then_div(n: usize, a: usize, d: usize) -> Option<usize> {
     (n / d).checked_add(a / d)?.checked_add((n % d + a % d) / d)
 }
 
+impl<I, T> ExactSizeIterator for Tuples<I, T>
+where
+    I: ExactSizeIterator<Item = T::Item>,
+    T: HomogeneousTuple,
+{
+}
+
 impl<I, T> Tuples<I, T>
 where
     I: Iterator<Item = T::Item>,

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -1184,6 +1184,18 @@ quickcheck! {
         assert_eq!(buffer.len(), a.len() % 4);
         exact_size(buffer)
     }
+
+    fn tuples_size_hint_inexact(a: Iter<u8>) -> bool {
+        correct_size_hint(a.clone().tuples::<(_,)>())
+            && correct_size_hint(a.clone().tuples::<(_, _)>())
+            && correct_size_hint(a.tuples::<(_, _, _, _)>())
+    }
+
+    fn tuples_size_hint_exact(a: Iter<u8, Exact>) -> bool {
+        exact_size(a.clone().tuples::<(_,)>())
+            && exact_size(a.clone().tuples::<(_, _)>())
+            && exact_size(a.tuples::<(_, _, _, _)>())
+    }
 }
 
 // with_position


### PR DESCRIPTION
I was hunting missing `size_hint` specializations for a few weeks now and from my notes, `Tuples` is apparently the last one.
(Apart from `TupleCombinations` but I'm quite unsure it's reasonably possible.)