### PR TITLE
Implement custom fold for ZipSlice

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -169,6 +169,20 @@ fn zipdot_i32_zipslices(c: &mut Criterion) {
     });
 }
 
+fn zipdot_i32_zipslices_fold(c: &mut Criterion) {
+    let xs = vec![2; 1024];
+    let ys = vec![2; 768];
+    let xs = black_box(xs);
+    let ys = black_box(ys);
+    // output is 3072
+    c.bench_function("zipdot i32 zipslices fold", move |b| {
+        b.iter(|| {
+            let sum = ZipSlices::new(&xs, &ys).fold(0i32, |acc, (&x, &y)| acc + (x * y));
+            sum
+        })
+    });
+}
+
 fn zipdot_f32_zipslices(c: &mut Criterion) {
     let xs = vec![2f32; 1024];
     let ys = vec![2f32; 768];
@@ -812,6 +826,7 @@ criterion_group!(
     zipslices,
     zipslices_mut,
     zipdot_i32_zipslices,
+    zipdot_i32_zipslices_fold,
     zipdot_f32_zipslices,
     zip_checked_counted_loop,
     zipdot_i32_checked_counted_loop,

--- a/benches/extra/zipslices.rs
+++ b/benches/extra/zipslices.rs
@@ -92,6 +92,21 @@ where
         let len = self.len - self.index;
         (len, Some(len))
     }
+
+    #[inline(always)]
+    fn fold<B, F>(mut self, acc: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        let mut accum = acc;
+        for i in self.index..self.len {
+            unsafe {
+                accum = f(accum, (self.t.get_unchecked(i), self.u.get_unchecked(i)));
+            }
+        }
+        accum
+    }
 }
 
 impl<T, U> DoubleEndedIterator for ZipSlices<T, U>


### PR DESCRIPTION
As per discussion in #755 , this PR implements custom `fold` logic for `ZipSlices<T, U>` and create benchmark test to measure the performance gain compared with the default `fold`. 

Running the `zipdot i32 zipslices fold` benchmark using the default `fold` logic, the time was `time:   [42.749 ns 43.163 ns 43.782 ns]`

Running the `zipdot i32 zipslices fold` benchmark using the custom `fold` logic, the time was `time:   [42.523 ns 42.621 ns 42.737 ns]`