### PR TITLE
`TupleCombinations`: `size_hint` and `count`

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -631,6 +631,10 @@ where
     fn size_hint(&self) -> SizeHint {
         self.iter.size_hint()
     }
+
+    fn count(self) -> usize {
+        self.iter.count()
+    }
 }
 
 impl<I, T> FusedIterator for TupleCombinations<I, T>
@@ -660,6 +664,10 @@ impl<I: Iterator> Iterator for Tuple1Combination<I> {
 
     fn size_hint(&self) -> SizeHint {
         self.iter.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.iter.count()
     }
 }
 
@@ -717,6 +725,12 @@ macro_rules! impl_tuple_combination {
                 n_min = checked_binomial(n_min, K).unwrap_or(usize::MAX);
                 n_max = n_max.and_then(|n| checked_binomial(n, K));
                 size_hint::add(self.c.size_hint(), (n_min, n_max))
+            }
+
+            fn count(self) -> usize {
+                const K: usize = 1 + count_ident!($($X,)*);
+                let n = self.iter.count();
+                checked_binomial(n, K).unwrap() + self.c.count()
             }
         }
 

--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::iter::FusedIterator;
 
 use super::lazy_buffer::LazyBuffer;
-use crate::combinations::checked_binomial;
+use crate::adaptors::checked_binomial;
 
 /// An iterator to iterate through all the `n`-length combinations in an iterator, with replacement.
 ///

--- a/src/impl_macros.rs
+++ b/src/impl_macros.rs
@@ -27,3 +27,8 @@ macro_rules! clone_fields {
 macro_rules! ignore_ident{
     ($id:ident, $($t:tt)*) => {$($t)*};
 }
+
+macro_rules! count_ident {
+    () => {0};
+    ($i0:ident, $($i:ident,)*) => {1 + count_ident!($($i,)*)};
+}

--- a/src/powerset.rs
+++ b/src/powerset.rs
@@ -3,7 +3,8 @@ use std::fmt;
 use std::iter::FusedIterator;
 use std::usize;
 
-use super::combinations::{checked_binomial, combinations, Combinations};
+use super::combinations::{combinations, Combinations};
+use crate::adaptors::checked_binomial;
 use crate::size_hint::{self, SizeHint};
 
 /// An iterator to iterate through the powerset of the elements from an iterator.

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -297,10 +297,6 @@ pub trait TupleCollect: Sized {
     fn left_shift_push(&mut self, item: Self::Item);
 }
 
-macro_rules! count_ident{
-    () => {0};
-    ($i0:ident, $($i:ident,)*) => {1 + count_ident!($($i,)*)};
-}
 macro_rules! rev_for_each_ident{
     ($m:ident, ) => {};
     ($m:ident, $i0:ident, $($i:ident,)*) => {

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -901,8 +901,31 @@ quickcheck! {
 }
 
 quickcheck! {
-    fn size_combinations(it: Iter<i16>) -> bool {
-        correct_size_hint(it.tuple_combinations::<(_, _)>())
+    fn size_combinations(a: Iter<i16>) -> bool {
+        let it = a.clone().tuple_combinations::<(_, _)>();
+        correct_size_hint(it.clone()) && it.count() == binomial(a.count(), 2)
+    }
+
+    fn exact_size_combinations_1(a: Vec<u8>) -> bool {
+        let it = a.iter().tuple_combinations::<(_,)>();
+        exact_size_for_this(it.clone()) && it.count() == binomial(a.len(), 1)
+    }
+    fn exact_size_combinations_2(a: Vec<u8>) -> bool {
+        let it = a.iter().tuple_combinations::<(_, _)>();
+        exact_size_for_this(it.clone()) && it.count() == binomial(a.len(), 2)
+    }
+    fn exact_size_combinations_3(mut a: Vec<u8>) -> bool {
+        a.truncate(15);
+        let it = a.iter().tuple_combinations::<(_, _, _)>();
+        exact_size_for_this(it.clone()) && it.count() == binomial(a.len(), 3)
+    }
+}
+
+fn binomial(n: usize, k: usize) -> usize {
+    if k > n {
+        0
+    } else {
+        (n - k + 1..=n).product::<usize>() / (1..=k).product::<usize>()
     }
 }
 

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -72,6 +72,12 @@ where
 }
 
 quickcheck! {
+    fn tuple_combinations(v: Vec<u8>) -> () {
+        let mut v = v;
+        v.truncate(10);
+        test_specializations(&v.iter().tuple_combinations::<(_, _, _)>());
+    }
+
     fn intersperse(v: Vec<u8>) -> () {
         test_specializations(&v.into_iter().intersperse(0));
     }


### PR DESCRIPTION
This was definitely simpler to implement than it was for `Combinations` (with vector items). The only difficulty is that it's recursive with a macro.

According to my notes, all iterators that should have a `size_hint` specialization now have. I like that.

The `count_ident` macro is moved to be available library-wide.