### PR TITLE
`Powerset::fold` specialization

### DIFF
--- a/benches/powerset.rs
+++ b/benches/powerset.rs
@@ -20,6 +20,17 @@ fn powerset_n(c: &mut Criterion, n: usize) {
     });
 }
 
+fn powerset_n_fold(c: &mut Criterion, n: usize) {
+    let id = format!("powerset {} fold", n);
+    c.bench_function(id.as_str(), move |b| {
+        b.iter(|| {
+            for _ in 0..calc_iters(n) {
+                (0..n).powerset().fold(0, |s, elt| s + black_box(elt).len());
+            }
+        })
+    });
+}
+
 fn powerset_0(c: &mut Criterion) {
     powerset_n(c, 0);
 }
@@ -44,6 +55,30 @@ fn powerset_12(c: &mut Criterion) {
     powerset_n(c, 12);
 }
 
+fn powerset_0_fold(c: &mut Criterion) {
+    powerset_n_fold(c, 0);
+}
+
+fn powerset_1_fold(c: &mut Criterion) {
+    powerset_n_fold(c, 1);
+}
+
+fn powerset_2_fold(c: &mut Criterion) {
+    powerset_n_fold(c, 2);
+}
+
+fn powerset_4_fold(c: &mut Criterion) {
+    powerset_n_fold(c, 4);
+}
+
+fn powerset_8_fold(c: &mut Criterion) {
+    powerset_n_fold(c, 8);
+}
+
+fn powerset_12_fold(c: &mut Criterion) {
+    powerset_n_fold(c, 12);
+}
+
 criterion_group!(
     benches,
     powerset_0,
@@ -52,5 +87,11 @@ criterion_group!(
     powerset_4,
     powerset_8,
     powerset_12,
+    powerset_0_fold,
+    powerset_1_fold,
+    powerset_2_fold,
+    powerset_4_fold,
+    powerset_8_fold,
+    powerset_12_fold,
 );
 criterion_main!(benches);

--- a/src/powerset.rs
+++ b/src/powerset.rs
@@ -74,6 +74,24 @@ where
         let (n, combs_count) = self.combs.n_and_count();
         combs_count + remaining_for(n, k).unwrap()
     }
+
+    fn fold<B, F>(self, mut init: B, mut f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        let mut it = self.combs;
+        if it.k() == 0 {
+            init = it.by_ref().fold(init, &mut f);
+            it.reset(1);
+        }
+        init = it.by_ref().fold(init, &mut f);
+        // n is now known for sure because k >= 1 and all k-combinations have been generated.
+        for k in it.k() + 1..=it.n() {
+            it.reset(k);
+            init = it.by_ref().fold(init, &mut f);
+        }
+        init
+    }
 }
 
 impl<I> FusedIterator for Powerset<I>

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -75,6 +75,12 @@ quickcheck! {
     fn intersperse(v: Vec<u8>) -> () {
         test_specializations(&v.into_iter().intersperse(0));
     }
+
+    fn powerset(a: Vec<u8>) -> () {
+        let mut a = a;
+        a.truncate(6);
+        test_specializations(&a.iter().powerset())
+    }
 }
 
 quickcheck! {


### PR DESCRIPTION
Rank  | Description           | `powerset_0_fold` (µs)   | `powerset_1_fold` (µs)   | `powerset_2_fold` (µs)   | `powerset_4_fold` (µs)   | `powerset_8_fold` (µs)   | `powerset_12_fold` (µs)
------|-----------------------|--------------------------|--------------------------|--------------------------|--------------------------|--------------------------|-------------------------
3     | no specialization     | `[321.26 322.12 323.18]` | `[395.73 396.62 397.61]` | `[353.65 355.59 357.87]` | `[333.72 334.66 335.72]` | `[321.30 321.79 322.31]` | `[318.88 319.67 320.71]`
1 wins| currently             | `[312.58 312.94 313.29]` | `[375.18 375.65 376.12]` | `[330.77 331.83 332.96]` | `[298.66 299.17 299.72]` | `[289.46 289.81 290.18]` | `[289.31 289.68 290.16]`
2     | With `(k+1..=n).fold` | `[320.78 322.00 323.43]` | `[383.65 384.39 385.30]` | `[349.08 350.11 351.12]` | `[315.60 316.55 317.63]` | `[304.82 305.70 306.59]` | `[296.88 297.81 299.03]`

So it's 10% faster than without specialization for `powerset_{4,8,12}_fold` (and 3% to 7% for `n=0,1,2`).
And `(it.k() + 1..=it.n()).fold` makes it (intermediary) slower (so it's not pushed here).

Once `Combinations::fold` is implemented, it should be even faster.

Remains to add a test.

EDIT: Sorry, the table does not render well.