### PR TITLE
Fix "bench1" in debug mode

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -581,7 +581,7 @@ fn kmerge_tenway(c: &mut Criterion) {
 
     let mut state = 1729u16;
     fn rng(state: &mut u16) -> u16 {
-        let new = state.wrapping_mul(31421) + 6927;
+        let new = state.wrapping_mul(31421).wrapping_add(6927);
         *state = new;
         new
     }


### PR DESCRIPTION
Closes #768 

Benches use the `release` profile so this was silently ignored.
But `cargo test --all-targets` uses the `debug` profile so it does not ignore it.

`wrapping_add` is the default behavior so I just call it explicitely.

Then `cargo test --all-targets` passes.