### PR TITLE
Specialize `WithPosition::fold`

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -1,6 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use itertools::free::cloned;
 use itertools::Itertools;
+use itertools::Position;
 use itertools::{iproduct, EitherOrBoth};
 
 use std::cmp;
@@ -819,6 +820,22 @@ fn permutations_slice(c: &mut Criterion) {
     });
 }
 
+fn with_position_fold(c: &mut Criterion) {
+    let v = black_box((0..10240).collect_vec());
+    c.bench_function("with_position fold", move |b| {
+        b.iter(|| {
+            v.iter()
+                .with_position()
+                .fold(0, |acc, (pos, &item)| match pos {
+                    Position::Middle => acc + item,
+                    Position::First => acc - 2 * item,
+                    Position::Last => acc + 2 * item,
+                    Position::Only => acc + 5 * item,
+                })
+        })
+    });
+}
+
 criterion_group!(
     benches,
     slice_iter,
@@ -866,5 +883,6 @@ criterion_group!(
     permutations_iter,
     permutations_range,
     permutations_slice,
+    with_position_fold,
 );
 criterion_main!(benches);

--- a/src/with_position.rs
+++ b/src/with_position.rs
@@ -37,7 +37,7 @@ where
 /// Indicates the position of this element in the iterator results.
 ///
 /// See [`.with_position()`](crate::Itertools::with_position) for more information.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Position {
     /// This is the first element.
     First,

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -74,6 +74,10 @@ where
 }
 
 quickcheck! {
+    fn with_position(v: Vec<u8>) -> () {
+        test_specializations(&v.iter().with_position());
+    }
+
     fn tuple_combinations(v: Vec<u8>) -> () {
         let mut v = v;
         v.truncate(10);


### PR DESCRIPTION
Each call to `f` is done with a `Position` variant known at compile time so I think it might be optimized away in some cases?

    Without specialization: [5.3231 µs 5.3487 µs 5.3806 µs]
    With specialization:    [2.6974 µs 2.7042 µs 2.7132 µs]

We should mention #755 in PRs that specialize `fold` (such as this one) to help keep track of the advancement of the TODO list I'm gonna make there.