### PR TITLE
Specialize `TupleCombinations::fold`

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -855,6 +855,17 @@ fn with_position_fold(c: &mut Criterion) {
     });
 }
 
+fn tuple_combinations_fold(c: &mut Criterion) {
+    let v = black_box((0..64).collect_vec());
+    c.bench_function("tuple_combinations fold", move |b| {
+        b.iter(|| {
+            v.iter()
+                .tuple_combinations()
+                .fold(0, |acc, (a, b, c, d)| acc + *a * *c - *b * *d)
+        })
+    });
+}
+
 criterion_group!(
     benches,
     slice_iter,
@@ -903,6 +914,7 @@ criterion_group!(
     permutations_range,
     permutations_slice,
     with_position_fold,
+    tuple_combinations_fold,
     while_some,
 );
 criterion_main!(benches);

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -736,14 +736,14 @@ macro_rules! impl_tuple_combination {
             type Item = (A, $(ignore_ident!($X, A)),*);
 
             fn next(&mut self) -> Option<Self::Item> {
-                if let Some(($($X),*,)) = self.c.next() {
+                if let Some(($($X,)*)) = self.c.next() {
                     let z = self.item.clone().unwrap();
                     Some((z, $($X),*))
                 } else {
                     self.item = self.iter.next();
                     self.item.clone().and_then(|z| {
                         self.c = self.iter.clone().into();
-                        self.c.next().map(|($($X),*,)| (z, $($X),*))
+                        self.c.next().map(|($($X,)*)| (z, $($X),*))
                     })
                 }
             }
@@ -769,13 +769,13 @@ macro_rules! impl_tuple_combination {
                 let Self { c, item, mut iter } = self;
                 if let Some(z) = item.as_ref() {
                     init = c
-                        .map(|($($X),*,)| (z.clone(), $($X),*))
+                        .map(|($($X,)*)| (z.clone(), $($X),*))
                         .fold(init, &mut f);
                 }
                 while let Some(z) = iter.next() {
                     let c: $P<I> = iter.clone().into();
                     init = c
-                        .map(|($($X),*,)| (z.clone(), $($X),*))
+                        .map(|($($X,)*)| (z.clone(), $($X),*))
                         .fold(init, &mut f);
                 }
                 init

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -691,6 +691,13 @@ impl<I: Iterator> Iterator for Tuple1Combination<I> {
     fn count(self) -> usize {
         self.iter.count()
     }
+
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.iter.map(|x| (x,)).fold(init, f)
+    }
 }
 
 impl<I: Iterator> HasCombination<I> for (I::Item,) {

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -650,6 +650,13 @@ where
     fn count(self) -> usize {
         self.iter.count()
     }
+
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.iter.fold(init, f)
+    }
 }
 
 impl<I, T> FusedIterator for TupleCombinations<I, T>

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -767,12 +767,11 @@ macro_rules! impl_tuple_combination {
                 F: FnMut(B, Self::Item) -> B,
             {
                 let Self { c, item, mut iter } = self;
-                init = c
-                    .map(|($($X),*,)| {
-                        let z = item.clone().unwrap();
-                        (z, $($X),*)
-                    })
-                    .fold(init, &mut f);
+                if let Some(z) = item.as_ref() {
+                    init = c
+                        .map(|($($X),*,)| (z.clone(), $($X),*))
+                        .fold(init, &mut f);
+                }
                 while let Some(z) = iter.next() {
                     let c: $P<I> = iter.clone().into();
                     init = c


### PR DESCRIPTION
Related to #755.

    [8.2569 ms 8.2733 ms 8.2907 ms]             // Benchmark `TupleCombinations::fold`
    [3.2749 ms 3.2875 ms 3.3007 ms]             // `TupleCombinations::fold`
    [3.3237 ms 3.3439 ms 3.3661 ms] (same perf) // `Tuple1Combinations::fold`
    [237.52 µs 238.81 µs 240.59 µs]             // `Tuple*Combinations::fold` (macro)

This is so much faster that I'm wandering if I'm missing something here!

I previously added the specialization test: https://github.com/rust-itertools/itertools/commit/a9aaeb4cbacee3f4e83df56b3bb45d35d9167fa9

I'm unsure we can **fold the `while let` loop** as we need to clone `iter` at every step of it.
Both attempts below successfully pass the tests but are not faster.

Maybe there is a solution involving `std::cell::???` but I'm not familiar enough with this, are you?
I tried with `itertools::rciter` but it was 60% slower (and `Rc` means the `use_alloc` feature). And with a basic `RcIter::fold` specialization, I even had an (expected) error at runtime.

    let iter = $crate::rciter(iter);
    iter.clone().fold(init, |acc, z| {
        let iter_ref = iter.rciter.borrow();
        <$P<I>>::from(iter_ref.clone())
            .map(|($($X),*,)| (z.clone(), $($X),*))
            .fold(acc, &mut f)
    })

I eventually found a way to rely on `iter.fold` using `unsafe` only (to hold `&mut I` and `&I` at the same time) but it's the same performance as the current `fold` specialization.
I'm not familiar with unsafe Rust so it might just be dumb in the first place.

    let iter_mut = &mut iter;
    let iter_ref: &I = unsafe {
        std::mem::transmute_copy(&iter_mut)
    };
    iter_mut.fold(init, |acc, z| {
        let c: $P<I> = iter_ref.clone().into();
        c.map(|($($X),*,)| (z.clone(), $($X),*))
            .fold(acc, &mut f)
    })