### PR TITLE
Implement custom fold for `WhileSome`

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -448,6 +448,24 @@ fn group_by_lazy_2(c: &mut Criterion) {
     });
 }
 
+fn while_some(c: &mut Criterion) {
+    c.bench_function("while_some", |b| {
+        b.iter(|| {
+            let data = black_box(
+                (0..)
+                    .fuse()
+                    .map(|i| std::char::from_digit(i, 16))
+                    .while_some(),
+            );
+            let result: String = data.fold(String::new(), |acc, ch| acc + &ch.to_string());
+            assert_eq!(
+                result.chars().collect::<Vec<_>>(),
+                "0123456789abcdef".chars().collect::<Vec<_>>()
+            );
+        });
+    });
+}
+
 fn slice_chunks(c: &mut Criterion) {
     let data = vec![0; 1024];
 
@@ -884,5 +902,6 @@ criterion_group!(
     permutations_range,
     permutations_slice,
     with_position_fold,
+    while_some,
 );
 criterion_main!(benches);

--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -457,11 +457,12 @@ fn while_some(c: &mut Criterion) {
                     .map(|i| std::char::from_digit(i, 16))
                     .while_some(),
             );
-            let result: String = data.fold(String::new(), |acc, ch| acc + &ch.to_string());
-            assert_eq!(
-                result.chars().collect::<Vec<_>>(),
-                "0123456789abcdef".chars().collect::<Vec<_>>()
-            );
+            // let result: String = data.fold(String::new(), |acc, ch| acc + &ch.to_string());
+            let result = data.fold(String::new(), |mut acc, ch| {
+                acc.push(ch);
+                acc
+            });
+            assert_eq!(result.as_str(), "0123456789abcdef");
         });
     });
 }

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -582,15 +582,17 @@ where
         (0, self.iter.size_hint().1)
     }
 
-    fn fold<B, F>(self, acc: B, f: F) -> B
+    fn fold<B, F>(mut self, acc: B, mut f: F) -> B
     where
         Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
-        self.iter
-            .take_while(|opt| opt.is_some())
-            .map(|item| item.unwrap())
-            .fold(acc, f)
+        let res = self.iter.try_fold(acc, |acc, item| match item {
+            Some(item) => Ok(f(acc, item)),
+            None => Err(acc),
+        });
+        let (Err(res) | Ok(res)) = res;
+        res
     }
 }
 

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -581,6 +581,17 @@ where
     fn size_hint(&self) -> (usize, Option<usize>) {
         (0, self.iter.size_hint().1)
     }
+
+    fn fold<B, F>(self, acc: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.iter
+            .take_while(|opt| opt.is_some())
+            .map(|item| item.unwrap())
+            .fold(acc, f)
+    }
 }
 
 /// An iterator to iterate through all combinations in a `Clone`-able iterator that produces tuples

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -591,7 +591,10 @@ where
             Some(item) => Ok(f(acc, item)),
             None => Err(acc),
         });
-        let (Err(res) | Ok(res)) = res;
+        let res = match res {
+            Ok(val) => val,
+            Err(val) => val,
+        };
         res
     }
 }


### PR DESCRIPTION
#755 

This PR introduces a custom fold method for `WhileSome`. The optimization hinges on the underlying iterator's `fold`:

With Custom `fold`: If the underlying iterator provides its own specialized `fold`, the performance gain depends on its implementation.
Without Custom `fold`: In the absence of a specialized fold for the underlying iterator, the performance remains on par with the default.

Benchmark Results:

Default fold: time: [497.09 ns 497.45 ns 497.82 ns]
Custom fold: time: [456.09 ns 458.15 ns 460.80 ns]