### PR TITLE
Test specializations

### DIFF
--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -24,12 +24,17 @@ where
 {
     macro_rules! check_specialized {
         ($src:expr, |$it:pat| $closure:expr) => {
-            let $it = $src.clone();
-            let v1 = $closure;
-            let $it = Unspecialized($src.clone());
-            let v2 = $closure;
-            assert_eq!(v1, v2);
-        };
+            // Many iterators special-case the first elements, so we test specializations for iterators that have already been advanced.
+            let mut src = $src.clone();
+            for _ in 0..5 {
+                let $it = src.clone();
+                let v1 = $closure;
+                let $it = Unspecialized(src.clone());
+                let v2 = $closure;
+                assert_eq!(v1, v2);
+                src.next();
+            }
+        }
     }
     check_specialized!(it, |i| i.count());
     check_specialized!(it, |i| i.last());

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -129,6 +129,7 @@ quickcheck! {
 }
 
 quickcheck! {
+    // TODO Replace this function by a normal call to test_specializations
     fn process_results(v: Vec<Result<u8, u8>>) -> () {
         helper(v.iter().copied());
         helper(v.iter().copied().filter(Result::is_ok));

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -17,23 +17,20 @@ where
     }
 }
 
-macro_rules! check_specialized {
-    ($src:expr, |$it:pat| $closure:expr) => {
-        let $it = $src.clone();
-        let v1 = $closure;
-
-        let $it = Unspecialized($src.clone());
-        let v2 = $closure;
-
-        assert_eq!(v1, v2);
-    };
-}
-
 fn test_specializations<IterItem, Iter>(it: &Iter)
 where
     IterItem: Eq + Debug + Clone,
     Iter: Iterator<Item = IterItem> + Clone,
 {
+    macro_rules! check_specialized {
+        ($src:expr, |$it:pat| $closure:expr) => {
+            let $it = $src.clone();
+            let v1 = $closure;
+            let $it = Unspecialized($src.clone());
+            let v2 = $closure;
+            assert_eq!(v1, v2);
+        };
+    }
     check_specialized!(it, |i| i.count());
     check_specialized!(it, |i| i.last());
     check_specialized!(it, |i| i.collect::<Vec<_>>());


### PR DESCRIPTION
We have more and more specializations, but so far they are not vastly tested for iterators that have already been advanced. This PR alters `test_specializations`.