### PR TITLE
Add cargo-semver-check as part of the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
     name: All checks succeeded
     if: success()
     runs-on: ubuntu-latest
-    needs: [check, msrv, test, check-format, doc, semver-checks]
+    needs: [check, msrv, test, check-format, doc]
     steps:
       - name: Mark the job as successful
         run: exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,21 @@ jobs:
           components: rustfmt
       - run: cargo fmt --check
 
+  semver-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: obi1kenobi/cargo-semver-checks-action@v2.1
+        with:
+          rust-toolchain: stable
+          feature-group: all-features
+
   # Used to signal to branch protections that all other jobs have succeeded.
   all-jobs-succeed:
     name: All checks succeeded
     if: success()
     runs-on: ubuntu-latest
-    needs: [check, msrv, test, check-format, doc]
+    needs: [check, msrv, test, check-format, doc, semver-checks]
     steps:
       - name: Mark the job as successful
         run: exit 0


### PR DESCRIPTION
fixes #757 

This PR introduces a new CI job `cargo-semver-check` to lint the API against the latest release version and see if there're any breaking changes