### PR TITLE
docs: fixup docs of `tree_fold1`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2499,7 +2499,8 @@ pub trait Itertools: Iterator {
     /// └─f─f─f─f─f─f
     /// ```
     ///
-    /// If `f` is associative, prefer the normal [`Iterator::reduce`] instead.
+    /// If `f` is non-associative, prefer the normal [`Iterator::reduce`] instead to prevent
+    /// unexpected behavior unless you know what you're doing.
     ///
     /// ```
     /// use itertools::Itertools;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2499,8 +2499,18 @@ pub trait Itertools: Iterator {
     /// └─f─f─f─f─f─f
     /// ```
     ///
-    /// If `f` is non-associative, prefer the normal [`Iterator::reduce`] instead to prevent
-    /// unexpected behavior unless you know what you're doing.
+    /// If `f` is associative you should also decide carefully:
+    ///
+    /// - if `f` is a trivial operation like `u32::wrapping_add`, prefer the normal
+    /// [`Iterator::reduce`] instead since it will most likely result in the generation of simpler
+    /// code because the compiler is able to optimize it
+    /// - otherwise if `f` is non-trivial like `format!`, you should use `tree_fold1` since it
+    /// reduces the number of operations from `O(n)` to `O(ln(n))`
+    ///
+    /// Here "non-trivial" means:
+    ///
+    /// - any allocating operation
+    /// - any function that is a composition of many operations
     ///
     /// ```
     /// use itertools::Itertools;


### PR DESCRIPTION
I was just reading through the docs when I noticed something odd. It's probably just a typo:

There is a recommendation to use `reduce` instead of `tree_fold1` when `f` is associative. Since `tree_fold1` won't really work as expected (unless you know what you're doing) in non-associative cases, this would imply that we don't recommend the use of `tree_fold1` at all?

I just took a guess and adjusted that part of the docs to what it most likely was supposed to be. Feel free to close this PR if I'm completely wrong here 🙈 