### PR TITLE
`count_ident` macro without any comma

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -735,7 +735,7 @@ macro_rules! impl_tuple_combination {
             }
 
             fn size_hint(&self) -> SizeHint {
-                const K: usize = 1 + count_ident!($($X,)*);
+                const K: usize = 1 + count_ident!($($X)*);
                 let (mut n_min, mut n_max) = self.iter.size_hint();
                 n_min = checked_binomial(n_min, K).unwrap_or(usize::MAX);
                 n_max = n_max.and_then(|n| checked_binomial(n, K));
@@ -743,7 +743,7 @@ macro_rules! impl_tuple_combination {
             }
 
             fn count(self) -> usize {
-                const K: usize = 1 + count_ident!($($X,)*);
+                const K: usize = 1 + count_ident!($($X)*);
                 let n = self.iter.count();
                 checked_binomial(n, K).unwrap() + self.c.count()
             }

--- a/src/impl_macros.rs
+++ b/src/impl_macros.rs
@@ -30,5 +30,5 @@ macro_rules! ignore_ident{
 
 macro_rules! count_ident {
     () => {0};
-    ($i0:ident, $($i:ident,)*) => {1 + count_ident!($($i,)*)};
+    ($i0:ident $($i:ident)*) => {1 + count_ident!($($i)*)};
 }

--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -345,7 +345,7 @@ macro_rules! impl_tuple_collect {
         impl_tuple_collect!($($Y,)*);
         impl<A> TupleCollect for ($(ignore_ident!($Y, A),)*) {
             type Item = A;
-            type Buffer = [Option<A>; count_ident!($($Y,)*) - 1];
+            type Buffer = [Option<A>; count_ident!($($Y)*) - 1];
 
             #[allow(unused_assignments, unused_mut)]
             fn collect_from_iter<I>(iter: I, buf: &mut Self::Buffer) -> Option<Self>
@@ -388,7 +388,7 @@ macro_rules! impl_tuple_collect {
             }
 
             fn num_items() -> usize {
-                count_ident!($($Y,)*)
+                count_ident!($($Y)*)
             }
 
             fn left_shift_push(&mut self, mut item: A) {


### PR DESCRIPTION
@phimuemue I remove the (annoying) commas in `count_ident` macros.