### PR TITLE
Simplify `Permutations`

### DIFF
--- a/src/permutations.rs
+++ b/src/permutations.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 use std::fmt;
 use std::iter::once;
+use std::iter::FusedIterator;
 
 use super::lazy_buffer::LazyBuffer;
 use crate::size_hint::{self, SizeHint};
@@ -129,6 +130,13 @@ where
         upp = upp.and_then(|n| self.state.size_hint_for(n).1);
         (low, upp)
     }
+}
+
+impl<I> FusedIterator for Permutations<I>
+where
+    I: Iterator,
+    I::Item: Clone,
+{
 }
 
 fn advance(indices: &mut [usize], cycles: &mut [usize]) -> bool {

--- a/src/permutations.rs
+++ b/src/permutations.rs
@@ -78,16 +78,16 @@ where
             }
             &mut PermutationState::Start { k } => {
                 *state = PermutationState::Buffered { k, min_n: k };
-                let latest_idx = k - 1;
-                let indices = (0..(k - 1)).chain(once(latest_idx));
-                Some(indices.map(|i| vals[i].clone()).collect())
+                Some(vals[0..k].to_vec())
             }
             PermutationState::Buffered { ref k, min_n } => {
                 if vals.get_next() {
+                    let item = (0..*k - 1)
+                        .chain(once(*min_n))
+                        .map(|i| vals[i].clone())
+                        .collect();
                     *min_n += 1;
-                    let latest_idx = *min_n - 1;
-                    let indices = (0..*k - 1).chain(once(latest_idx));
-                    Some(indices.map(|i| vals[i].clone()).collect())
+                    Some(item)
                 } else {
                     let n = *min_n;
                     let prev_iteration_count = n - *k + 1;


### PR DESCRIPTION
Fixes #747

This is quite a rewrite, very little is untouched.
`count` and `size_hint` are really simplified with the new `PermutationState::size_hint_for`.

    cargo bench permutation
    // Before this PR
    permutations iter       [62.130 µs 62.355 µs 62.620 µs]
    permutations range      [61.637 µs 61.850 µs 62.104 µs]
    permutations slice      [64.177 µs 64.314 µs 64.459 µs]
    // Now
    permutations iter       [57.280 µs 57.478 µs 57.702 µs]    -8.4%
    permutations range      [59.714 µs 59.914 µs 60.138 µs]    -4.7%
    permutations slice      [59.584 µs 59.720 µs 59.868 µs]    -7.1%
I did not expect any performance improvement, but nice to have a little one.