### PR TITLE
Add missing `must_use` attributes on adaptors

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -185,6 +185,7 @@ where
 /// item to the front of the iterator.
 ///
 /// Iterator element type is `I::Item`.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct PutBack<I>
 where
     I: Iterator,

--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -10,6 +10,7 @@ use crate::adaptors::checked_binomial;
 /// See [`.combinations_with_replacement()`](crate::Itertools::combinations_with_replacement)
 /// for more information.
 #[derive(Clone)]
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct CombinationsWithReplacement<I>
 where
     I: Iterator,

--- a/src/multipeek_impl.rs
+++ b/src/multipeek_impl.rs
@@ -7,6 +7,7 @@ use std::iter::Fuse;
 
 /// See [`multipeek()`] for more information.
 #[derive(Clone, Debug)]
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct MultiPeek<I>
 where
     I: Iterator,

--- a/src/peek_nth.rs
+++ b/src/peek_nth.rs
@@ -5,6 +5,7 @@ use std::iter::Fuse;
 
 /// See [`peek_nth()`] for more information.
 #[derive(Clone, Debug)]
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct PeekNth<I>
 where
     I: Iterator,

--- a/src/put_back_n_impl.rs
+++ b/src/put_back_n_impl.rs
@@ -7,6 +7,7 @@ use crate::size_hint;
 ///
 /// Iterator element type is `I::Item`.
 #[derive(Debug, Clone)]
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct PutBackN<I: Iterator> {
     top: Vec<I::Item>,
     iter: I,

--- a/src/rciter_impl.rs
+++ b/src/rciter_impl.rs
@@ -4,6 +4,7 @@ use std::iter::{FusedIterator, IntoIterator};
 
 /// A wrapper for `Rc<RefCell<I>>`, that implements the `Iterator` trait.
 #[derive(Debug)]
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
 pub struct RcIter<I> {
     /// The boxed iterator.
     pub rciter: Rc<RefCell<I>>,


### PR DESCRIPTION
Related to #791 and #792

Those six adaptors are (already) lazy, only the `must_use` attribute is missing.