### PR TITLE
More specialization tests

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -935,6 +935,7 @@ where
 ///
 /// See [`.filter_map_ok()`](crate::Itertools::filter_map_ok) for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[derive(Clone)]
 pub struct FilterMapOk<I, F> {
     iter: I,
     f: F,

--- a/src/duplicates_impl.rs
+++ b/src/duplicates_impl.rs
@@ -122,7 +122,7 @@ mod private {
     }
 
     /// Apply the identity function to elements before checking them for equality.
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub struct ById;
     impl<V> KeyMethod<V, V> for ById {
         type Container = JustValue<V>;
@@ -133,6 +133,7 @@ mod private {
     }
 
     /// Apply a user-supplied function to elements before checking them for equality.
+    #[derive(Clone)]
     pub struct ByFn<F>(pub(crate) F);
     impl<F> fmt::Debug for ByFn<F> {
         debug_fmt_fields!(ByFn,);

--- a/src/take_while_inclusive.rs
+++ b/src/take_while_inclusive.rs
@@ -8,6 +8,7 @@ use std::fmt;
 /// See [`.take_while_inclusive()`](crate::Itertools::take_while_inclusive)
 /// for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[derive(Clone)]
 pub struct TakeWhileInclusive<I, F> {
     iter: I,
     predicate: F,

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -175,12 +175,14 @@ quickcheck! {
         test_specializations(&v.iter().copied().update(|x| *x = x.wrapping_mul(7)));
     }
 
-    fn tuple_combinations(v: Vec<u8>) -> () {
-        let mut v = v;
-        v.truncate(10);
+    fn tuple_combinations(v: Vec<u8>) -> TestResult {
+        if v.len() > 10 {
+            return TestResult::discard();
+        }
         test_specializations(&v.iter().tuple_combinations::<(_,)>());
         test_specializations(&v.iter().tuple_combinations::<(_, _)>());
         test_specializations(&v.iter().tuple_combinations::<(_, _, _)>());
+        TestResult::passed()
     }
 
     fn intersperse(v: Vec<u8>) -> () {
@@ -215,10 +217,12 @@ quickcheck! {
         TestResult::passed()
     }
 
-    fn powerset(a: Vec<u8>) -> () {
-        let mut a = a;
-        a.truncate(6);
-        test_specializations(&a.iter().powerset())
+    fn powerset(a: Vec<u8>) -> TestResult {
+        if a.len() > 6 {
+            return TestResult::discard();
+        }
+        test_specializations(&a.iter().powerset());
+        TestResult::passed()
     }
 
     fn zip_longest(a: Vec<u8>, b: Vec<u8>) -> () {

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -114,6 +114,15 @@ quickcheck! {
         TestResult::passed()
     }
 
+    #[ignore] // It currently fails because `MultiProduct` is not fused.
+    fn multi_cartesian_product(a: Vec<u8>, b: Vec<u8>, c: Vec<u8>) -> TestResult {
+        if a.len() * b.len() * c.len() > 100 {
+            return TestResult::discard();
+        }
+        test_specializations(&vec![a, b, c].into_iter().multi_cartesian_product());
+        TestResult::passed()
+    }
+
     fn coalesce(v: Vec<u8>) -> () {
         test_specializations(&v.iter().coalesce(|x, y| if x == y { Ok(x) } else { Err((x, y)) }))
     }


### PR DESCRIPTION
- To do the next point, `test_specializations` need clonable iterators which helped find iterators that should be clonable but were not yet. 3 very small commits.
- I do not want to add specialization tests one by one in future pull requests so this is **_mostly done_**! 1 big but straightforward commit.
- For two tests I previously wrote, I now discard inputs (in the quickcheck-way) instead of truncating them. 1 small commit.

Now about **_mostly done_**... Not all of our iterators are tested here:
- `group_by`
- `chunks`
- `tee`
- `rciter` 
- `test_specializations` need clonable iterators but `&mut iterator` is not clonable, Therefore, we can't clone `PeekingTakeWhile` and `TakeWhileRef`. We need to find a way to test them too.

Finally a **bug**... **`multi_cartesian_product`** is not tested here because specializations of `last` and `count` **FAIL** sometimes, and I don't want this pull request to be blocked by it! It requires further investigation and will have a dedicated pull request.
**EDIT:** Apparently, the iterator is not fused even when all child iterators are, and this was the [intended behavior](https://github.com/rust-itertools/itertools/pull/235#issuecomment-347604290), that's confusing.