### PR TITLE
Make `Product` lazy

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -308,6 +308,9 @@ where
     I: Iterator,
 {
     a: I,
+    /// `a_cur` is `None` while no item have been taken out of `a` (at definition).
+    /// Then `a_cur` will be `Some(Some(item))` until `a` is exhausted,
+    /// in which case `a_cur` will be `Some(None)`.
     a_cur: Option<Option<I::Item>>,
     b: J,
     b_orig: J,

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -365,15 +365,13 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let has_cur = matches!(self.a_cur, Some(Some(_))) as usize;
         // Not ExactSizeIterator because size may be larger than usize
-        let (b_min, b_max) = self.b.size_hint();
-
         // Compute a * b_orig + b for both lower and upper bound
-        size_hint::add(
-            size_hint::mul(self.a.size_hint(), self.b_orig.size_hint()),
-            (b_min * has_cur, b_max.map(move |x| x * has_cur)),
-        )
+        let mut sh = size_hint::mul(self.a.size_hint(), self.b_orig.size_hint());
+        if matches!(self.a_cur, Some(Some(_))) {
+            sh = size_hint::add(sh, self.b.size_hint());
+        }
+        sh
     }
 
     fn fold<Acc, G>(self, mut accum: Acc, mut f: G) -> Acc


### PR DESCRIPTION
Related to #792.
To make the `Product` adaptor lazy, I use a nested option, just like I did in #797.
Then the method `cartesian_product` and the macro `iproduct` will be lazy.