### PR TITLE
Make `CoalesceBy` lazy

### DIFF
--- a/src/adaptors/coalesce.rs
+++ b/src/adaptors/coalesce.rs
@@ -10,6 +10,9 @@ where
     C: CountItem<I::Item>,
 {
     iter: I,
+    /// `last` is `None` while no item have been taken out of `iter` (at definition).
+    /// Then `last` will be `Some(Some(item))` until `iter` is exhausted,
+    /// in which case `last` will be `Some(None)`.
     last: Option<Option<C::CItem>>,
     f: F,
 }


### PR DESCRIPTION
Related to #792
To make the `CoalesceBy` adaptor lazy, I use a nested option again.
This would make methods `coalesce` and `dedup[_by][_with_count]` all lazy.

But it required some preliminary adaptation because of `last: iter.next().map(|v| (1, v)),` in `dedup_by_with_count` function. Make this lazy required to delay `|v| (1, v)`. And I therefore created structs `NoCount` and `WithCount` sharing a same behavior with the new `CountItem` trait.
Let me know what you think about it.