### PR TITLE
Remove `html_root_url` setting.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,6 @@
 //! ## Rust Version
 //!
 //! This version of itertools requires Rust 1.43.1 or later.
-#![doc(html_root_url = "https://docs.rs/itertools/0.11/")]
 
 #[cfg(not(feature = "use_std"))]
 extern crate core as std;


### PR DESCRIPTION
As far as I can tell, setting it serves no purpose. Removing it eliminates a place where we need to remember to update teh crate version.