### PR TITLE
CI: no bors, no markdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - "**.md"
   merge_group:
+    paths-ignore:
+      - "**.md"
 
 jobs:
   check:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ description = "Extra iterator adaptors, iterator methods, free functions, and ma
 
 keywords = ["iterator", "data-structure", "zip", "product", "group-by"]
 categories = ["algorithms", "rust-patterns"]
-exclude = ["/bors.toml"]
 
 edition = "2018"
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,0 @@
-status = [
-"bors build finished"
-]


### PR DESCRIPTION
We do not use bors anymore.

There is no point in running CI only for markdown changes, such as #802 (prepare releases) and #767 (Contributing.md).