### PR TITLE
`CircularTupleWindows` does not need phantom data

### DIFF
--- a/src/tuple_impl.rs
+++ b/src/tuple_impl.rs
@@ -3,7 +3,6 @@
 use std::iter::Cycle;
 use std::iter::Fuse;
 use std::iter::FusedIterator;
-use std::marker::PhantomData;
 
 use crate::size_hint;
 
@@ -252,7 +251,6 @@ where
 {
     iter: TupleWindows<Cycle<I>, T>,
     len: usize,
-    phantom_data: PhantomData<T>,
 }
 
 pub fn circular_tuple_windows<I, T>(iter: I) -> CircularTupleWindows<I, T>
@@ -264,11 +262,7 @@ where
     let len = iter.len();
     let iter = tuple_windows(iter.cycle());
 
-    CircularTupleWindows {
-        iter,
-        len,
-        phantom_data: PhantomData {},
-    }
+    CircularTupleWindows { iter, len }
 }
 
 impl<I, T> Iterator for CircularTupleWindows<I, T>


### PR DESCRIPTION
Quick fix.

After I randomly took a look at this, I realized this field never was needed because `iter` type owns a `T`.
I should have realized that last time I updated this struct.

I checked other phantom data fields in the library but that's the only useless one.