### PR TITLE
Specialize `Positions::[r]fold`

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -1111,6 +1111,21 @@ where
         }
         None
     }
+
+    fn rfold<B, G>(self, init: B, mut func: G) -> B
+    where
+        G: FnMut(B, Self::Item) -> B,
+    {
+        let mut count = self.count + self.iter.len();
+        let mut f = self.f;
+        self.iter.rfold(init, |mut acc, val| {
+            count -= 1;
+            if f(val) {
+                acc = func(acc, count);
+            }
+            acc
+        })
+    }
 }
 
 impl<I, F> FusedIterator for Positions<I, F>

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -1081,6 +1081,21 @@ where
     fn size_hint(&self) -> (usize, Option<usize>) {
         (0, self.iter.size_hint().1)
     }
+
+    fn fold<B, G>(self, init: B, mut func: G) -> B
+    where
+        G: FnMut(B, Self::Item) -> B,
+    {
+        let mut count = self.count;
+        let mut f = self.f;
+        self.iter.fold(init, |mut acc, val| {
+            if f(val) {
+                acc = func(acc, count);
+            }
+            count += 1;
+            acc
+        })
+    }
 }
 
 impl<I, F> DoubleEndedIterator for Positions<I, F>


### PR DESCRIPTION
Related to #755

First, I have to say that after adding many benchmarks in #806, _building_ specialization benchmarks is now **slower**: 1mn53s hence more than 4mn to run this benchmarking command twice:

    cargo bench --bench specializations "positions/r?fold"

    positions/fold          time:   [908.94 ns 911.83 ns 914.93 ns]
    positions/fold          time:   [440.01 ns 442.34 ns 445.05 ns]
                            change: [-52.042% -51.081% -49.844%]

    positions/rfold         time:   [580.24 ns 581.23 ns 582.15 ns]
    positions/rfold         time:   [612.87 ns 614.28 ns 615.81 ns]
                            change: [+5.5346% +6.7070% +7.8680%]

Benchmarks all rely on `core::slice::Iter` which does not specialize `rfold` but I did not thought it would be slower.
It's not by much but still. _What do you think?_