### PR TITLE
`Positions` based on `Enumerate`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1806,7 +1806,7 @@ pub trait Itertools: Iterator {
     /// Return an iterator adaptor that yields the indices of all elements
     /// satisfying a predicate, counted from the start of the iterator.
     ///
-    /// Equivalent to `iter.enumerate().filter(|(_, v)| predicate(v)).map(|(i, _)| i)`.
+    /// Equivalent to `iter.enumerate().filter(|(_, v)| predicate(*v)).map(|(i, _)| i)`.
     ///
     /// ```
     /// use itertools::Itertools;

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -604,6 +604,12 @@ quickcheck! {
         let b = &b[..len];
         itertools::equal(zip_eq(a, b), zip(a, b))
     }
+    fn equal_positions(a: Vec<i32>) -> bool {
+        let with_pos = a.iter().positions(|v| v % 2 == 0);
+        let without = a.iter().enumerate().filter(|(_, v)| *v % 2 == 0).map(|(i, _)| i);
+        itertools::equal(with_pos.clone(), without.clone())
+            && itertools::equal(with_pos.rev(), without.rev())
+    }
     fn size_zip_longest(a: Iter<i16, Exact>, b: Iter<i16, Exact>) -> bool {
         let filt = a.clone().dedup();
         let filt2 = b.clone().dedup();


### PR DESCRIPTION
Following https://github.com/rust-itertools/itertools/pull/813#issuecomment-1847585114, with this PR, `Positions` now uses `Enumerate` internally.

- `next` and `next_back` are now based on `find_map` instead of "while-next" loops. It would be useful performance-wise for iterators specializing `try_[r]fold`. I intend to do the same for other while-next loops (where benchmarks show times decrease, up to -20%).
- Stable benchmarks here.
- Doing this, I first made a silly mistake. I therefore add a test that would have helped me, and fix a little error in the documentation (it could alternatively use `filter_map` to avoid `*` copy).