### PR TITLE
Specialize "loops of next"

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use itertools::free::cloned;
 use itertools::iproduct;
 use itertools::Itertools;
@@ -648,6 +648,22 @@ fn step_range_10(c: &mut Criterion) {
     });
 }
 
+fn vec_iter_mut_partition(c: &mut Criterion) {
+    let data = std::iter::repeat(-1024i32..1024)
+        .take(256)
+        .flatten()
+        .collect_vec();
+    c.bench_function("vec iter mut partition", move |b| {
+        b.iter_batched(
+            || data.clone(),
+            |mut data| {
+                black_box(itertools::partition(black_box(&mut data), |n| *n >= 0));
+            },
+            BatchSize::LargeInput,
+        )
+    });
+}
+
 fn cartesian_product_iterator(c: &mut Criterion) {
     let xs = vec![0; 16];
 
@@ -803,6 +819,7 @@ criterion_group!(
     step_vec_10,
     step_range_2,
     step_range_10,
+    vec_iter_mut_partition,
     cartesian_product_iterator,
     multi_cartesian_product_iterator,
     cartesian_product_nested_for,

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -901,17 +901,11 @@ where
     type Item = Result<T, E>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            match self.iter.next() {
-                Some(Ok(v)) => {
-                    if (self.f)(&v) {
-                        return Some(Ok(v));
-                    }
-                }
-                Some(Err(e)) => return Some(Err(e)),
-                None => return None,
-            }
-        }
+        let f = &mut self.f;
+        self.iter.find(|res| match res {
+            Ok(t) => f(t),
+            _ => true,
+        })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -982,17 +982,11 @@ where
     type Item = Result<U, E>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            match self.iter.next() {
-                Some(Ok(v)) => {
-                    if let Some(v) = (self.f)(v) {
-                        return Some(Ok(v));
-                    }
-                }
-                Some(Err(e)) => return Some(Err(e)),
-                None => return None,
-            }
-        }
+        let f = &mut self.f;
+        self.iter.find_map(|res| match res {
+            Ok(t) => f(t).map(Ok),
+            Err(e) => Some(Err(e)),
+        })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4054,18 +4054,11 @@ where
 {
     let mut split_index = 0;
     let mut iter = iter.into_iter();
-    'main: while let Some(front) = iter.next() {
+    while let Some(front) = iter.next() {
         if !pred(front) {
-            loop {
-                match iter.next_back() {
-                    Some(back) => {
-                        if pred(back) {
-                            std::mem::swap(front, back);
-                            break;
-                        }
-                    }
-                    None => break 'main,
-                }
+            match iter.rfind(|back| pred(back)) {
+                Some(back) => std::mem::swap(front, back),
+                None => break,
             }
         }
         split_index += 1;

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -133,14 +133,15 @@ where
     I::Item: Eq + Hash + Clone,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        while let Some(v) = self.iter.iter.next_back() {
-            if let Entry::Vacant(entry) = self.iter.used.entry(v) {
+        let UniqueBy { iter, used, .. } = &mut self.iter;
+        iter.rev().find_map(|v| {
+            if let Entry::Vacant(entry) = used.entry(v) {
                 let elt = entry.key().clone();
                 entry.insert(());
                 return Some(elt);
             }
-        }
-        None
+            None
+        })
     }
 }
 

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -105,14 +105,15 @@ where
     type Item = I::Item;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(v) = self.iter.iter.next() {
-            if let Entry::Vacant(entry) = self.iter.used.entry(v) {
+        let UniqueBy { iter, used, .. } = &mut self.iter;
+        iter.find_map(|v| {
+            if let Entry::Vacant(entry) = used.entry(v) {
                 let elt = entry.key().clone();
                 entry.insert(());
                 return Some(elt);
             }
-        }
-        None
+            None
+        })
     }
 
     #[inline]

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -84,13 +84,8 @@ where
     F: FnMut(&I::Item) -> V,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        while let Some(v) = self.iter.next_back() {
-            let key = (self.f)(&v);
-            if self.used.insert(key, ()).is_none() {
-                return Some(v);
-            }
-        }
-        None
+        let Self { iter, used, f } = self;
+        iter.rfind(|v| used.insert(f(v), ()).is_none())
     }
 }
 

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -61,13 +61,8 @@ where
     type Item = I::Item;
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(v) = self.iter.next() {
-            let key = (self.f)(&v);
-            if self.used.insert(key, ()).is_none() {
-                return Some(v);
-            }
-        }
-        None
+        let Self { iter, used, f } = self;
+        iter.find(|v| used.insert(f(v), ()).is_none())
     }
 
     #[inline]


### PR DESCRIPTION
There are some cases where `next/next_back` is repeatedly called in a loop, where a specialized method would do the same job, except it might be faster if the iterator they adapt has some specialized faster method.
It was the case in #816.

    cargo bench --bench specializations "(filter_ok|filter_map_ok|unique|unique_by)/next"

    unique/next             time:   [18.728 µs 18.779 µs 18.843 µs]
    unique/next             time:   [14.166 µs 14.274 µs 14.406 µs]
                            change: [-26.223% -25.048% -23.941%]

    unique/next_back        time:   [18.523 µs 18.599 µs 18.698 µs]
    unique/next_back        time:   [14.189 µs 14.259 µs 14.344 µs]
                            change: [-25.116% -24.300% -23.568%]

    unique_by/next          time:   [20.766 µs 20.798 µs 20.833 µs]
    unique_by/next          time:   [19.123 µs 19.174 µs 19.230 µs]
                            change: [-8.9607% -7.5864% -6.1789%]

    unique_by/next_back     time:   [20.852 µs 20.915 µs 20.979 µs]
    unique_by/next_back     time:   [20.740 µs 20.825 µs 20.919 µs]
                            change: [-1.1273% -0.6647% -0.1885%]

    filter_ok/next          time:   [910.82 ns 915.08 ns 920.18 ns]
    filter_ok/next          time:   [880.88 ns 883.96 ns 887.81 ns]
                            change: [-5.5278% -4.1578% -2.4871%]

    filter_map_ok/next      time:   [863.55 ns 865.77 ns 868.14 ns]
    filter_map_ok/next      time:   [849.20 ns 852.26 ns 855.36 ns]
                            change: [-5.0466% -3.7661% -2.6449%]

Those benchmarks are not that impressive, they are based on slices that roughly reimplement the while loop themselves. But if the iterator they adapt have a specialized `try_[r]fold` on which `find/find_map/rfind` usually rely, then it should be faster.

The code is shorter in multiple cases and I believe clearer.

The `partition` function did not have any benchmark, there is now one and there are no difference, both 330µs.