### PR TITLE
Specialize `Multipeek::fold`

### DIFF
--- a/src/multipeek_impl.rs
+++ b/src/multipeek_impl.rs
@@ -102,6 +102,14 @@ where
     fn size_hint(&self) -> (usize, Option<usize>) {
         size_hint::add_scalar(self.iter.size_hint(), self.buf.len())
     }
+
+    fn fold<B, F>(self, mut init: B, mut f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        init = self.buf.into_iter().fold(init, &mut f);
+        self.iter.fold(init, f)
+    }
 }
 
 // Same size


### PR DESCRIPTION
Related to #755

    cargo bench --bench specializations "multipeek/fold"

    multipeek/fold          time:   [1.3502 µs 1.3519 µs 1.3541 µs]
    multipeek/fold          time:   [580.87 ns 582.37 ns 584.50 ns]
                            change: [-56.635% -56.096% -55.316%]