### PR TITLE
Specialize `RepeatN::[r]fold`

### DIFF
--- a/src/repeatn.rs
+++ b/src/repeatn.rs
@@ -44,6 +44,20 @@ where
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.n, Some(self.n))
     }
+
+    fn fold<B, F>(self, mut init: B, mut f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        match self {
+            Self { elt: Some(elt), n } => {
+                debug_assert!(n > 0);
+                init = (1..n).map(|_| elt.clone()).fold(init, &mut f);
+                f(init, elt)
+            }
+            _ => init,
+        }
+    }
 }
 
 impl<A> DoubleEndedIterator for RepeatN<A>

--- a/src/repeatn.rs
+++ b/src/repeatn.rs
@@ -68,6 +68,14 @@ where
     fn next_back(&mut self) -> Option<Self::Item> {
         self.next()
     }
+
+    #[inline]
+    fn rfold<B, F>(self, init: B, f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.fold(init, f)
+    }
 }
 
 impl<A> ExactSizeIterator for RepeatN<A> where A: Clone {}


### PR DESCRIPTION
Related to #755

    cargo bench --bench specializations "repeat_n/r?fold"

    repeat_n/fold           time:   [550.53 ns 553.84 ns 557.21 ns]
    repeat_n/fold           time:   [267.32 ns 268.75 ns 270.78 ns]
                            change: [-52.797% -51.769% -50.705%]

    repeat_n/rfold          time:   [546.41 ns 547.81 ns 549.27 ns]
    repeat_n/rfold          time:   [268.31 ns 269.45 ns 271.03 ns]
                            change: [-51.214% -50.990% -50.727%]