### PR TITLE
Specialize `PutBackN::fold`

### DIFF
--- a/src/put_back_n_impl.rs
+++ b/src/put_back_n_impl.rs
@@ -59,4 +59,12 @@ impl<I: Iterator> Iterator for PutBackN<I> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         size_hint::add_scalar(self.iter.size_hint(), self.top.len())
     }
+
+    fn fold<B, F>(self, mut init: B, mut f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        init = self.top.into_iter().rfold(init, &mut f);
+        self.iter.fold(init, f)
+    }
 }


### PR DESCRIPTION
Related to #755

    cargo bench --bench specializations "put_back_n/fold"

    put_back_n/fold         [835.27 ns 839.61 ns 845.09 ns]
    put_back_n/fold         [558.25 ns 561.05 ns 564.06 ns]
                            [-34.464% -33.644% -32.913%]