### PR TITLE
Specialize `PeekNth::fold`

### DIFF
--- a/src/peek_nth.rs
+++ b/src/peek_nth.rs
@@ -152,6 +152,14 @@ where
     fn size_hint(&self) -> (usize, Option<usize>) {
         size_hint::add_scalar(self.iter.size_hint(), self.buf.len())
     }
+
+    fn fold<B, F>(self, mut init: B, mut f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        init = self.buf.into_iter().fold(init, &mut f);
+        self.iter.fold(init, f)
+    }
 }
 
 impl<I> ExactSizeIterator for PeekNth<I> where I: ExactSizeIterator {}


### PR DESCRIPTION
Related to #755

    cargo bench --bench specializations "peek_nth/fold"

    peek_nth/fold           [664.89 ns 667.75 ns 670.62 ns]
    peek_nth/fold           [366.23 ns 367.20 ns 368.19 ns]
                            [-44.876% -44.069% -42.914%]