### PR TITLE
Specialize `PadUsing::[r]fold`

### DIFF
--- a/src/pad_tail.rs
+++ b/src/pad_tail.rs
@@ -67,6 +67,18 @@ where
         let tail = self.min.saturating_sub(self.pos);
         size_hint::max(self.iter.size_hint(), (tail, Some(tail)))
     }
+
+    fn fold<B, G>(self, mut init: B, mut f: G) -> B
+    where
+        G: FnMut(B, Self::Item) -> B,
+    {
+        let mut pos = self.pos;
+        init = self.iter.fold(init, |acc, item| {
+            pos += 1;
+            f(acc, item)
+        });
+        (pos..self.min).map(self.filler).fold(init, f)
+    }
 }
 
 impl<I, F> DoubleEndedIterator for PadUsing<I, F>

--- a/src/pad_tail.rs
+++ b/src/pad_tail.rs
@@ -97,6 +97,16 @@ where
             Some((self.filler)(self.min))
         }
     }
+
+    fn rfold<B, G>(self, mut init: B, mut f: G) -> B
+    where
+        G: FnMut(B, Self::Item) -> B,
+    {
+        init = (self.iter.len()..self.min)
+            .map(self.filler)
+            .rfold(init, &mut f);
+        self.iter.rfold(init, f)
+    }
 }
 
 impl<I, F> ExactSizeIterator for PadUsing<I, F>


### PR DESCRIPTION
Related to #755

    cargo bench --bench specializations "pad_using/r?fold"

    pad_using/fold          [1.2169 µs 1.2273 µs 1.2375 µs]
    pad_using/fold          [679.64 ns 683.21 ns 687.65 ns]
                            [-45.562% -44.840% -44.185%]

    pad_using/rfold         [1.3184 µs 1.3243 µs 1.3317 µs]
    pad_using/rfold         [692.28 ns 694.11 ns 695.98 ns]
                            [-47.743% -47.421% -47.084%]