### PR TITLE
Specialize `ExactlyOneError::fold`

### DIFF
--- a/src/exactly_one_err.rs
+++ b/src/exactly_one_err.rs
@@ -63,6 +63,21 @@ where
     fn size_hint(&self) -> (usize, Option<usize>) {
         size_hint::add_scalar(self.inner.size_hint(), self.additional_len())
     }
+
+    fn fold<B, F>(self, mut init: B, mut f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        match self.first_two {
+            Some(Either::Left([first, second])) => {
+                init = f(init, first);
+                init = f(init, second);
+            }
+            Some(Either::Right(second)) => init = f(init, second),
+            None => {}
+        }
+        self.inner.fold(init, f)
+    }
 }
 
 impl<I> ExactSizeIterator for ExactlyOneError<I> where I: ExactSizeIterator {}

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -330,6 +330,17 @@ quickcheck! {
         test_specializations(&it);
         test_double_ended_specializations(&it);
     }
+
+    fn exactly_one_error(v: Vec<u8>) -> TestResult {
+        // Use `at_most_one` would be similar.
+        match v.iter().exactly_one() {
+            Ok(_) => TestResult::discard(),
+            Err(it) => {
+                test_specializations(&it);
+                TestResult::passed()
+            }
+        }
+    }
 }
 
 quickcheck! {


### PR DESCRIPTION
Related to #755

    cargo bench --bench specializations "exactly_one_error/fold"

    exactly_one_error/fold  [568.69 ns 570.74 ns 572.99 ns]
    exactly_one_error/fold  [268.29 ns 268.52 ns 268.78 ns]
                            [-52.687% -52.402% -52.141%]

EDIT: Apparently, I previously forgot the specialization test.