### PR TITLE
Fix spelling error in documentation.

### DIFF
--- a/src/exactly_one_err.rs
+++ b/src/exactly_one_err.rs
@@ -8,7 +8,7 @@ use either::Either;
 
 use crate::size_hint;
 
-/// Iterator returned for the error case of `IterTools::exactly_one()`
+/// Iterator returned for the error case of `Itertools::exactly_one()`
 /// This iterator yields exactly the same elements as the input iterator.
 ///
 /// During the execution of `exactly_one` the iterator must be mutated.  This wrapper


### PR DESCRIPTION
The primary trait in this crate is called `Itertools`, not `IterTools`.

(This actually confused me - by sheer bad luck, `exactly_one` was the first itertools method I ever tried to use, so that docs comment was the very first one I found in my search, so I spelled it `IterTools` in my source code, and got a compile error!)