### PR TITLE
Rewrite `MultiProduct`

### DIFF
--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -9,7 +9,7 @@ use alloc::vec::Vec;
 /// An iterator adaptor that iterates over the cartesian product of
 /// multiple iterators of type `I`.
 ///
-/// An iterator element type is `Vec<I>`.
+/// An iterator element type is `Vec<I::Item>`.
 ///
 /// See [`.multi_cartesian_product()`](crate::Itertools::multi_cartesian_product)
 /// for more information.

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -13,18 +13,24 @@ use crate::size_hint;
 /// See [`.multi_cartesian_product()`](crate::Itertools::multi_cartesian_product)
 /// for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-pub struct MultiProduct<I>(Option<MultiProductInner<I>>)
+pub struct MultiProduct<I>(
+    /// `None` once the iterator has ended.
+    Option<MultiProductInner<I>>,
+)
 where
     I: Iterator + Clone,
     I::Item: Clone;
 
 #[derive(Clone)]
+/// Internals for `MultiProduct`.
 struct MultiProductInner<I>
 where
     I: Iterator + Clone,
     I::Item: Clone,
 {
+    /// Holds the iterators.
     iters: Vec<MultiProductIter<I>>,
+    /// It is `None` at the beginning then it holds the current item of each iterator.
     cur: Option<Vec<I::Item>>,
 }
 

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -124,6 +124,34 @@ where
         }
     }
 
+    fn count(self) -> usize {
+        match self.0 {
+            None => 0,
+            Some(MultiProductInner { iters, cur }) => {
+                if cur.is_none() {
+                    iters
+                        .into_iter()
+                        .map(|iter| iter.iter_orig.count())
+                        .try_fold(1, |product, count| {
+                            if count == 0 {
+                                None
+                            } else {
+                                Some(product * count)
+                            }
+                        })
+                        .unwrap_or_default()
+                } else {
+                    iters.into_iter().fold(0, |mut acc, iter| {
+                        if acc != 0 {
+                            acc *= iter.iter_orig.count();
+                        }
+                        acc + iter.iter.count()
+                    })
+                }
+            }
+        }
+    }
+
     fn last(self) -> Option<Self::Item> {
         let MultiProductInner { iters, cur } = self.0?;
         if let Some(values) = cur {

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -1,8 +1,5 @@
 #![cfg(feature = "use_alloc")]
 
-use crate::size_hint;
-use crate::Itertools;
-
 use alloc::vec::Vec;
 
 #[derive(Clone)]
@@ -52,85 +49,8 @@ where
     I: Iterator + Clone,
     I::Item: Clone,
 {
-    cur: Option<I::Item>,
     iter: I,
     iter_orig: I,
-}
-
-/// Holds the current state during an iteration of a `MultiProduct`.
-#[derive(Debug)]
-enum MultiProductIterState {
-    StartOfIter,
-    MidIter { on_first_iter: bool },
-}
-
-impl<I> MultiProduct<I>
-where
-    I: Iterator + Clone,
-    I::Item: Clone,
-{
-    /// Iterates the rightmost iterator, then recursively iterates iterators
-    /// to the left if necessary.
-    ///
-    /// Returns true if the iteration succeeded, else false.
-    fn iterate_last(
-        multi_iters: &mut [MultiProductIter<I>],
-        mut state: MultiProductIterState,
-    ) -> bool {
-        use self::MultiProductIterState::*;
-
-        if let Some((last, rest)) = multi_iters.split_last_mut() {
-            let on_first_iter = match state {
-                StartOfIter => {
-                    let on_first_iter = !last.in_progress();
-                    state = MidIter { on_first_iter };
-                    on_first_iter
-                }
-                MidIter { on_first_iter } => on_first_iter,
-            };
-
-            if !on_first_iter {
-                last.iterate();
-            }
-
-            if last.in_progress() {
-                true
-            } else if Self::iterate_last(rest, state) {
-                last.reset();
-                last.iterate();
-                // If iterator is None twice consecutively, then iterator is
-                // empty; whole product is empty.
-                last.in_progress()
-            } else {
-                false
-            }
-        } else {
-            // Reached end of iterator list. On initialisation, return true.
-            // At end of iteration (final iterator finishes), finish.
-            match state {
-                StartOfIter => false,
-                MidIter { on_first_iter } => on_first_iter,
-            }
-        }
-    }
-
-    /// Returns the unwrapped value of the next iteration.
-    fn curr_iterator(&self) -> Vec<I::Item> {
-        self.0
-            .iter()
-            .map(|multi_iter| multi_iter.cur.clone().unwrap())
-            .collect()
-    }
-
-    /// Returns true if iteration has started and has not yet finished; false
-    /// otherwise.
-    fn in_progress(&self) -> bool {
-        if let Some(last) = self.0.last() {
-            last.in_progress()
-        } else {
-            false
-        }
-    }
 }
 
 impl<I> MultiProductIter<I>
@@ -140,26 +60,9 @@ where
 {
     fn new(iter: I) -> Self {
         Self {
-            cur: None,
             iter: iter.clone(),
             iter_orig: iter,
         }
-    }
-
-    /// Iterate the managed iterator.
-    fn iterate(&mut self) {
-        self.cur = self.iter.next();
-    }
-
-    /// Reset the managed iterator.
-    fn reset(&mut self) {
-        self.iter = self.iter_orig.clone();
-    }
-
-    /// Returns true if the current iterator has been started and has not yet
-    /// finished; false otherwise.
-    fn in_progress(&self) -> bool {
-        self.cur.is_some()
     }
 }
 
@@ -171,81 +74,6 @@ where
     type Item = Vec<I::Item>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if Self::iterate_last(&mut self.0, MultiProductIterState::StartOfIter) {
-            Some(self.curr_iterator())
-        } else {
-            None
-        }
-    }
-
-    fn count(self) -> usize {
-        if self.0.is_empty() {
-            return 0;
-        }
-
-        if !self.in_progress() {
-            return self
-                .0
-                .into_iter()
-                .fold(1, |acc, multi_iter| acc * multi_iter.iter.count());
-        }
-
-        self.0.into_iter().fold(
-            0,
-            |acc,
-             MultiProductIter {
-                 iter,
-                 iter_orig,
-                 cur: _,
-             }| {
-                let total_count = iter_orig.count();
-                let cur_count = iter.count();
-                acc * total_count + cur_count
-            },
-        )
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        // Not ExactSizeIterator because size may be larger than usize
-        if self.0.is_empty() {
-            return (0, Some(0));
-        }
-
-        if !self.in_progress() {
-            return self.0.iter().fold((1, Some(1)), |acc, multi_iter| {
-                size_hint::mul(acc, multi_iter.iter.size_hint())
-            });
-        }
-
-        self.0.iter().fold(
-            (0, Some(0)),
-            |acc,
-             MultiProductIter {
-                 iter,
-                 iter_orig,
-                 cur: _,
-             }| {
-                let cur_size = iter.size_hint();
-                let total_size = iter_orig.size_hint();
-                size_hint::add(size_hint::mul(acc, total_size), cur_size)
-            },
-        )
-    }
-
-    fn last(self) -> Option<Self::Item> {
-        let iter_count = self.0.len();
-
-        let lasts: Self::Item = self
-            .0
-            .into_iter()
-            .map(|multi_iter| multi_iter.iter.last())
-            .while_some()
-            .collect();
-
-        if lasts.len() == iter_count {
-            Some(lasts)
-        } else {
-            None
-        }
+        todo!()
     }
 }

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -105,6 +105,7 @@ where
         let inner = self.0.as_mut()?;
         match &mut inner.cur {
             Some(values) => {
+                debug_assert!(!inner.iters.is_empty());
                 for (iter, item) in inner.iters.iter_mut().zip(values.iter_mut()).rev() {
                     if let Some(new) = iter.iter.next() {
                         *item = new;
@@ -122,10 +123,11 @@ where
             // Only the first time.
             None => {
                 let next: Option<Vec<_>> = inner.iters.iter_mut().map(|i| i.iter.next()).collect();
-                if next.is_some() {
-                    inner.cur = next.clone();
-                } else {
+                if next.is_none() || inner.iters.is_empty() {
+                    // This cartesian product had at most one item to generate and now ends.
                     self.0 = None;
+                } else {
+                    inner.cur = next.clone();
                 }
                 next
             }
@@ -175,7 +177,8 @@ where
                         size_hint::add(sh, iter.iter.size_hint())
                     })
                 } else {
-                    (0, Some(0))
+                    // Since `cur` is some, this cartesian product has started so `iters` is not empty.
+                    unreachable!()
                 }
             }
         }

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -11,10 +11,20 @@ use alloc::vec::Vec;
 /// See [`.multi_cartesian_product()`](crate::Itertools::multi_cartesian_product)
 /// for more information.
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-pub struct MultiProduct<I>(Vec<MultiProductIter<I>>)
+pub struct MultiProduct<I>(Option<MultiProductInner<I>>)
 where
     I: Iterator + Clone,
     I::Item: Clone;
+
+#[derive(Clone)]
+struct MultiProductInner<I>
+where
+    I: Iterator + Clone,
+    I::Item: Clone,
+{
+    iters: Vec<MultiProductIter<I>>,
+    cur: Option<Vec<I::Item>>,
+}
 
 impl<I> std::fmt::Debug for MultiProduct<I>
 where
@@ -22,6 +32,14 @@ where
     I::Item: Clone + std::fmt::Debug,
 {
     debug_fmt_fields!(MultiProduct, 0);
+}
+
+impl<I> std::fmt::Debug for MultiProductInner<I>
+where
+    I: Iterator + Clone + std::fmt::Debug,
+    I::Item: Clone + std::fmt::Debug,
+{
+    debug_fmt_fields!(MultiProductInner, iters, cur);
 }
 
 /// Create a new cartesian product iterator over an arbitrary number
@@ -35,11 +53,13 @@ where
     <H::Item as IntoIterator>::IntoIter: Clone,
     <H::Item as IntoIterator>::Item: Clone,
 {
-    MultiProduct(
-        iters
+    let inner = MultiProductInner {
+        iters: iters
             .map(|i| MultiProductIter::new(i.into_iter()))
             .collect(),
-    )
+        cur: None,
+    };
+    MultiProduct(Some(inner))
 }
 
 #[derive(Clone, Debug)]
@@ -74,6 +94,7 @@ where
     type Item = Vec<I::Item>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        let inner = self.0.as_mut()?;
         todo!()
     }
 }

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -123,6 +123,31 @@ where
             }
         }
     }
+
+    fn last(self) -> Option<Self::Item> {
+        let MultiProductInner { iters, cur } = self.0?;
+        if let Some(values) = cur {
+            let mut count = iters.len();
+            let last = iters
+                .into_iter()
+                .zip(values)
+                .map(|(i, value)| {
+                    i.iter.last().unwrap_or_else(|| {
+                        count -= 1;
+                        value
+                    })
+                })
+                .collect();
+            if count == 0 {
+                // `values` was the last item.
+                None
+            } else {
+                Some(last)
+            }
+        } else {
+            iters.into_iter().map(|i| i.iter.last()).collect()
+        }
+    }
 }
 
 impl<I> std::iter::FusedIterator for MultiProduct<I>

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -124,3 +124,10 @@ where
         }
     }
 }
+
+impl<I> std::iter::FusedIterator for MultiProduct<I>
+where
+    I: Iterator + Clone,
+    I::Item: Clone,
+{
+}

--- a/src/adaptors/multi_product.rs
+++ b/src/adaptors/multi_product.rs
@@ -24,7 +24,7 @@ where
     I: Iterator + Clone + std::fmt::Debug,
     I::Item: Clone + std::fmt::Debug,
 {
-    debug_fmt_fields!(CoalesceBy, 0);
+    debug_fmt_fields!(MultiProduct, 0);
 }
 
 /// Create a new cartesian product iterator over an arbitrary number

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1162,9 +1162,10 @@ pub trait Itertools: Iterator {
     /// the product of iterators yielding multiple types, use the
     /// [`iproduct`] macro instead.
     ///
-    ///
     /// The iterator element type is `Vec<T>`, where `T` is the iterator element
     /// of the subiterators.
+    ///
+    /// Note that the iterator is fused.
     ///
     /// ```
     /// use itertools::Itertools;

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -450,6 +450,12 @@ quickcheck! {
         assert_eq!(answer.into_iter().last(), a.multi_cartesian_product().last());
     }
 
+    fn correct_empty_multi_product() -> () {
+        let empty = Vec::<std::vec::IntoIter<i32>>::new().into_iter().multi_cartesian_product();
+        assert!(correct_size_hint(empty.clone()));
+        itertools::assert_equal(empty, std::iter::once(Vec::new()))
+    }
+
     #[allow(deprecated)]
     fn size_step(a: Iter<i16, Exact>, s: usize) -> bool {
         let mut s = s;

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -163,7 +163,6 @@ quickcheck! {
         TestResult::passed()
     }
 
-    #[ignore] // It currently fails because `MultiProduct` is not fused.
     fn multi_cartesian_product(a: Vec<u8>, b: Vec<u8>, c: Vec<u8>) -> TestResult {
         if a.len() * b.len() * c.len() > 100 {
             return TestResult::discard();


### PR DESCRIPTION
Fixes #337. Closes #603 since this is an alternative.

#834 legitimately asked that we work on the bugfix #603. But after rebasing it, I saw that I could finally fuse the iterator (and therefore have a working specialization test). I thought of using #603 as a base but I eventually chose to make my own changes, starting over. I however credited @JakobDegen where it made sense.

I made commits as atomic as I could.

So this fuses the iterator which is a breaking change, which won't affect most people.