### PR TITLE
Faster `find_position`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1910,12 +1910,7 @@ pub trait Itertools: Iterator {
     where
         P: FnMut(&Self::Item) -> bool,
     {
-        for (index, elt) in self.enumerate() {
-            if pred(&elt) {
-                return Some((index, elt));
-            }
-        }
-        None
+        self.enumerate().find(|(_, elt)| pred(elt))
     }
     /// Find the value of the first element satisfying a predicate or return the last element, if any.
     ///


### PR DESCRIPTION
`find` usually rely on `try_fold` so this change should improve performance for iterators specializing `find/try_fold`.

Credits to #618, I also noticed https://github.com/phimuemue/rust-itertools/tree/simplify_find_position