### PR TITLE
`MinMaxResult`: derive `Eq`

### DIFF
--- a/src/minmax.rs
+++ b/src/minmax.rs
@@ -1,7 +1,7 @@
 /// `MinMaxResult` is an enum returned by `minmax`.
 ///
 /// See [`.minmax()`](crate::Itertools::minmax) for more detail.
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum MinMaxResult<T> {
     /// Empty iterator
     NoElements,


### PR DESCRIPTION
I merely did `cargo clippy --fix -- -D clippy::derive_partial_eq_without_eq` but the next link is useful to understand why it should be done
https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq