### PR TITLE
Either or both: `impl From` implies `impl Into`

### DIFF
--- a/src/either_or_both.rs
+++ b/src/either_or_both.rs
@@ -494,10 +494,9 @@ impl<T> EitherOrBoth<T, T> {
     }
 }
 
-#[allow(clippy::from_over_into)]
-impl<A, B> Into<Option<Either<A, B>>> for EitherOrBoth<A, B> {
-    fn into(self) -> Option<Either<A, B>> {
-        match self {
+impl<A, B> From<EitherOrBoth<A, B>> for Option<Either<A, B>> {
+    fn from(value: EitherOrBoth<A, B>) -> Self {
+        match value {
             Left(l) => Some(Either::Left(l)),
             Right(r) => Some(Either::Right(r)),
             Both(..) => None,


### PR DESCRIPTION
Fixes #836. This change was extracted from #740 in order to not delay it any further.

Reference: https://rust-lang.github.io/rust-clippy/master/index.html#/from_over_into

I removed the clippy lint, commit, run `clippy --fix`, squash.