### PR TITLE
`Diff`: implement `Debug` and `Clone`

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -5,6 +5,8 @@
 //! describes the difference between two non-`Clone` iterators `I` and `J` after breaking ASAP from
 //! a lock-step comparison.
 
+use std::fmt;
+
 use crate::free::put_back;
 use crate::structs::PutBack;
 
@@ -24,6 +26,27 @@ where
     Shorter(usize, PutBack<I>),
     /// The total number of elements that were in `I` along with the remaining elements of `J`.
     Longer(usize, PutBack<J>),
+}
+
+impl<I, J> fmt::Debug for Diff<I, J>
+where
+    I: Iterator,
+    J: Iterator,
+    PutBack<I>: fmt::Debug,
+    PutBack<J>: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::FirstMismatch(idx, i, j) => f
+                .debug_tuple("FirstMismatch")
+                .field(idx)
+                .field(i)
+                .field(j)
+                .finish(),
+            Self::Shorter(idx, i) => f.debug_tuple("Shorter").field(idx).field(i).finish(),
+            Self::Longer(idx, j) => f.debug_tuple("Longer").field(idx).field(j).finish(),
+        }
+    }
 }
 
 /// Compares every element yielded by both `i` and `j` with the given function in lock-step and

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -49,6 +49,22 @@ where
     }
 }
 
+impl<I, J> Clone for Diff<I, J>
+where
+    I: Iterator,
+    J: Iterator,
+    PutBack<I>: Clone,
+    PutBack<J>: Clone,
+{
+    fn clone(&self) -> Self {
+        match self {
+            Self::FirstMismatch(idx, i, j) => Self::FirstMismatch(*idx, i.clone(), j.clone()),
+            Self::Shorter(idx, i) => Self::Shorter(*idx, i.clone()),
+            Self::Longer(idx, j) => Self::Longer(*idx, j.clone()),
+        }
+    }
+}
+
 /// Compares every element yielded by both `i` and `j` with the given function in lock-step and
 /// returns a [`Diff`] which describes how `j` differs from `i`.
 ///


### PR DESCRIPTION
Closes #438.

I'm not sure to see the point of being able to clone `Diff` ; but it should at least implement `Debug`.

They can't be derived because of missing constraints on `::Item`.
And we don't have macros to implement Debug and Clone for enums in a shorter way so it's manual.