### PR TITLE
pin the toolchain version used by clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           ]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.75.0
         with:
           components: clippy
       - run: RUSTFLAGS="--deny warnings" cargo clippy ${{ matrix.features }}
@@ -41,7 +41,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@cargo-no-dev-deps
-      - uses: dtolnay/rust-toolchain@1.43.1
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.43.1
       - run: cargo no-dev-deps check
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt
       - run: cargo fmt --check
 


### PR DESCRIPTION
see discussion in #618

- pin clippy version for consistent lints across all PRs
- modify MSRV action such that dependabot will bump version of clippy toolchain but not touch msrv