### PR TITLE
Specialize `ZipLongest::rfold`

### DIFF
--- a/src/zip_longest.rs
+++ b/src/zip_longest.rs
@@ -87,6 +87,37 @@ where
             Less => self.b.next_back().map(EitherOrBoth::Right),
         }
     }
+
+    fn rfold<B, F>(self, mut init: B, mut f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        let Self { mut a, mut b } = self;
+        let a_len = a.len();
+        let b_len = b.len();
+        match a_len.cmp(&b_len) {
+            Equal => {}
+            Greater => {
+                init = a
+                    .by_ref()
+                    .rev()
+                    .take(a_len - b_len)
+                    .map(EitherOrBoth::Left)
+                    .fold(init, &mut f)
+            }
+            Less => {
+                init = b
+                    .by_ref()
+                    .rev()
+                    .take(b_len - a_len)
+                    .map(EitherOrBoth::Right)
+                    .fold(init, &mut f)
+            }
+        }
+        a.rfold(init, |acc, item_a| {
+            f(acc, EitherOrBoth::Both(item_a, b.next_back().unwrap()))
+        })
+    }
 }
 
 impl<T, U> ExactSizeIterator for ZipLongest<T, U>


### PR DESCRIPTION
Related to #755

    cargo bench --bench specializations "zip_longest/rfold"

    zip_longest/rfold  [1.5947 µs 1.6000 µs 1.6061 µs]
                       [814.20 ns 817.88 ns 822.20 ns]
                       [-50.441% -49.494% -48.665%]
