### PR TITLE
Specialize `Interleave[Shortest]::fold`

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -195,6 +195,34 @@ where
         };
         (lower, upper)
     }
+
+    fn fold<B, F>(self, mut init: B, mut f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        let Self {
+            mut it0,
+            mut it1,
+            phase,
+        } = self;
+        if phase {
+            match it1.next() {
+                Some(y) => init = f(init, y),
+                None => return init,
+            }
+        }
+        let res = it0.try_fold(init, |mut acc, x| {
+            acc = f(acc, x);
+            match it1.next() {
+                Some(y) => Ok(f(acc, y)),
+                None => Err(acc),
+            }
+        });
+        match res {
+            Ok(val) => val,
+            Err(val) => val,
+        }
+    }
 }
 
 impl<I, J> FusedIterator for InterleaveShortest<I, J>


### PR DESCRIPTION
Related to #755

    cargo bench --bench specializations "interleave(_shortest)?/fold"

    interleave/fold            [2.1749 µs 2.1782 µs 2.1817 µs]
                               [754.64 ns 757.16 ns 760.51 ns]
                               [-66.092% -65.545% -65.107%]

    interleave_shortest/fold   [1.6414 µs 1.6460 µs 1.6511 µs]
                               [412.05 ns 413.60 ns 415.41 ns]
                               [-74.904% -74.580% -74.173%]