### PR TITLE
CI: tell dependabot to not update the MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@cargo-no-dev-deps
-      - uses: dtolnay/rust-toolchain@1.43.1
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          # Here, it does not trigger a PR from dependabot.
+          toolchain: 1.43.1
       - run: cargo no-dev-deps check
 
   test:


### PR DESCRIPTION
Based on https://github.com/rust-itertools/itertools/pull/846#issuecomment-1890380544, I therefore credited @danieleades .

> Dependabot doesn't parse the toolchain config, only the action version, so this should work fine

It should lead to the resolution of #758 in which we will be able to unpause dependabot.