### PR TITLE
Specialize `TakeWhileInclusive::fold`

### DIFF
--- a/src/take_while_inclusive.rs
+++ b/src/take_while_inclusive.rs
@@ -64,6 +64,28 @@ where
             (0, self.iter.size_hint().1)
         }
     }
+
+    fn fold<B, Fold>(mut self, init: B, mut f: Fold) -> B
+    where
+        Fold: FnMut(B, Self::Item) -> B,
+    {
+        if self.done {
+            init
+        } else {
+            let predicate = &mut self.predicate;
+            self.iter
+                .try_fold(init, |mut acc, item| {
+                    let is_ok = predicate(&item);
+                    acc = f(acc, item);
+                    if is_ok {
+                        Ok(acc)
+                    } else {
+                        Err(acc)
+                    }
+                })
+                .unwrap_or_else(|err| err)
+        }
+    }
 }
 
 impl<I, F> FusedIterator for TakeWhileInclusive<I, F>


### PR DESCRIPTION
Related to #755

    cargo bench --bench specializations "take_while_inclusive/fold"

    take_while_inclusive/fold   [556.44 ns 559.37 ns 562.70 ns]
                                [536.51 ns 538.17 ns 539.76 ns]
                                [-6.2459% -4.9270% -3.8918%]

It's not much of a win but `try_fold` does not show real performance wins on slices and we benchmark on slices. It would perform better on other kind of iterators.