### PR TITLE
`ConsTuples`: remove `DoubleEndedIterator` implementation

### DIFF
--- a/src/cons_tuples_impl.rs
+++ b/src/cons_tuples_impl.rs
@@ -21,16 +21,6 @@ macro_rules! impl_cons_iter(
                 self.iter.fold(accum, move |acc, (($($B,)*), x)| f(acc, ($($B,)* x, )))
             }
         }
-
-        #[allow(non_snake_case)]
-        impl<X, Iter, $($B),*> DoubleEndedIterator for ConsTuples<Iter, (($($B,)*), X)>
-            where Iter: DoubleEndedIterator<Item = (($($B,)*), X)>,
-        {
-            fn next_back(&mut self) -> Option<Self::Item> {
-                self.iter.next().map(|(($($B,)*), x)| ($($B,)* x, ))
-            }
-        }
-
     );
 );
 


### PR DESCRIPTION
Fixes #852