### PR TITLE
Fix two `Debug`

### DIFF
--- a/src/flatten_ok.rs
+++ b/src/flatten_ok.rs
@@ -147,13 +147,7 @@ where
     T: IntoIterator,
     T::IntoIter: fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("FlattenOk")
-            .field("iter", &self.iter)
-            .field("inner_front", &self.inner_front)
-            .field("inner_back", &self.inner_back)
-            .finish()
-    }
+    debug_fmt_fields!(FlattenOk, iter, inner_front, inner_back);
 }
 
 /// Only the iterator being flattened needs to implement [`FusedIterator`].

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -3,13 +3,18 @@
 use crate::MinMaxResult;
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::fmt;
 use std::hash::Hash;
 use std::iter::Iterator;
 use std::ops::{Add, Mul};
 
 /// A wrapper to allow for an easy [`into_grouping_map_by`](crate::Itertools::into_grouping_map_by)
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct MapForGrouping<I, F>(I, F);
+
+impl<I: fmt::Debug, F> fmt::Debug for MapForGrouping<I, F> {
+    debug_fmt_fields!(MapForGrouping, 0);
+}
 
 impl<I, F> MapForGrouping<I, F> {
     pub(crate) fn new(iter: I, key_mapper: F) -> Self {

--- a/src/take_while_inclusive.rs
+++ b/src/take_while_inclusive.rs
@@ -34,7 +34,7 @@ impl<I, F> fmt::Debug for TakeWhileInclusive<I, F>
 where
     I: Iterator + fmt::Debug,
 {
-    debug_fmt_fields!(TakeWhileInclusive, iter);
+    debug_fmt_fields!(TakeWhileInclusive, iter, done);
 }
 
 impl<I, F> Iterator for TakeWhileInclusive<I, F>


### PR DESCRIPTION
- `TakeWhileInclusive` debug implementation missed a field ;
- `GroupingMapBy` was not really debug because functions usually are not ;
- `FlattenOk`: use our debug macro instead.