### PR TITLE
`ExactlyOneError`: prettier Debug implementation

### DIFF
--- a/src/exactly_one_err.rs
+++ b/src/exactly_one_err.rs
@@ -102,25 +102,17 @@ where
     I::Item: Debug,
 {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        let mut dbg = f.debug_struct("ExactlyOneError");
         match &self.first_two {
             Some(Either::Left([first, second])) => {
-                write!(
-                    f,
-                    "ExactlyOneError[First: {:?}, Second: {:?}, RemainingIter: {:?}]",
-                    first, second, self.inner
-                )
+                dbg.field("first", first).field("second", second);
             }
             Some(Either::Right(second)) => {
-                write!(
-                    f,
-                    "ExactlyOneError[Second: {:?}, RemainingIter: {:?}]",
-                    second, self.inner
-                )
+                dbg.field("second", second);
             }
-            None => {
-                write!(f, "ExactlyOneError[RemainingIter: {:?}]", self.inner)
-            }
+            None => {}
         }
+        dbg.field("inner", &self.inner).finish()
     }
 }
 


### PR DESCRIPTION
It could be derived. It was, and it apparently was decided not to in #484, probably to not leak implementation details that could confuse the user. However, it would not render well for pretty formats such as `"{:#?}"`. I think we should call methods on `f` instead of using `write!`. Then it can be both pretty and helpful to the user.