### PR TITLE
Prefer boxed slices over vectors internally

### DIFF
--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 use std::fmt;
 use std::iter::FusedIterator;
@@ -16,7 +17,7 @@ where
     I: Iterator,
     I::Item: Clone,
 {
-    indices: Vec<usize>,
+    indices: Box<[usize]>,
     pool: LazyBuffer<I>,
     first: bool,
 }
@@ -46,7 +47,7 @@ where
     I: Iterator,
     I::Item: Clone,
 {
-    let indices: Vec<usize> = alloc::vec![0; k];
+    let indices = alloc::vec![0; k].into_boxed_slice();
     let pool: LazyBuffer<I> = LazyBuffer::new(iter);
 
     CombinationsWithReplacement {

--- a/src/permutations.rs
+++ b/src/permutations.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 use std::fmt;
 use std::iter::once;
@@ -33,8 +34,8 @@ enum PermutationState {
     Buffered { k: usize, min_n: usize },
     /// All values from the iterator are known so `n` is known.
     Loaded {
-        indices: Vec<usize>,
-        cycles: Vec<usize>,
+        indices: Box<[usize]>,
+        cycles: Box<[usize]>,
     },
     /// No permutation left to generate.
     End,
@@ -89,8 +90,8 @@ where
                 } else {
                     let n = *min_n;
                     let prev_iteration_count = n - *k + 1;
-                    let mut indices: Vec<_> = (0..n).collect();
-                    let mut cycles: Vec<_> = (n - k..n).rev().collect();
+                    let mut indices: Box<[_]> = (0..n).collect();
+                    let mut cycles: Box<[_]> = (n - k..n).rev().collect();
                     // Advance the state to the correct point.
                     for _ in 0..prev_iteration_count {
                         if advance(&mut indices, &mut cycles) {


### PR DESCRIPTION
While reading [This Week in Rust 531](https://this-week-in-rust.org/blog/2024/01/24/this-week-in-rust-531/) and specifically [Identifying Rust's `collect::<Vec<_>>()` memory leak footgun](https://blog.polybdenum.com/2024/01/17/identifying-the-collect-vec-memory-leak-footgun.html), I got the remainder that

> The proper data structure for fixed-length lists is `Box<[T]>` rather than `Vec<T>`.

So I went through our codebase and found three places to apply this: two are committed and `MultiProduct`. I thought I would wait #835 to be merged to do it there too but I reached one [limitation](https://doc.rust-lang.org/edition-guide/rust-2021/IntoIterator-for-arrays.html) of edition 2018 (in `last` specialization) so I'm not.

The other vectors we internally use do not have a fixed length. Such as `Combinations` that has a growing vector in order for `Powerset` to work too.
(_And I obviously do not want to break our iterators generating vectors when it could be boxed slices._)