### PR TITLE
`CoalesceBy`: missing field in `Debug`

### DIFF
--- a/src/adaptors/coalesce.rs
+++ b/src/adaptors/coalesce.rs
@@ -33,7 +33,7 @@ where
     C: CountItem<I::Item>,
     C::CItem: fmt::Debug,
 {
-    debug_fmt_fields!(CoalesceBy, iter);
+    debug_fmt_fields!(CoalesceBy, iter, last);
 }
 
 pub trait CoalescePredicate<Item, T> {


### PR DESCRIPTION
Very quick PR. Yet another missing field just like in #860. The bounds were right for this field to be there.

I thought I successfully went through all our Debug implementations.. well I did it again. I do not see another mistake.