### PR TITLE
`iproduct`: generate tuples for simpler cases too

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,10 +250,13 @@ macro_rules! iproduct {
         $crate::iproduct!(@flatten $crate::cons_tuples($crate::iproduct!($I, $J)), $($K,)*)
     );
     ($I:expr $(,)?) => (
-        $crate::__std_iter::IntoIterator::into_iter($I)
+        $crate::__std_iter::IntoIterator::into_iter($I).map(|elt| (elt,))
     );
     ($I:expr, $J:expr $(,)?) => (
-        $crate::Itertools::cartesian_product($crate::iproduct!($I), $crate::iproduct!($J))
+        $crate::Itertools::cartesian_product(
+            $crate::__std_iter::IntoIterator::into_iter($I),
+            $crate::__std_iter::IntoIterator::into_iter($J),
+        )
     );
     ($I:expr, $J:expr, $($K:expr),+ $(,)?) => (
         $crate::iproduct!(@flatten $crate::iproduct!($I, $J), $($K,)+)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,6 +249,9 @@ macro_rules! iproduct {
     (@flatten $I:expr, $J:expr, $($K:expr,)*) => (
         $crate::iproduct!(@flatten $crate::cons_tuples($crate::iproduct!($I, $J)), $($K,)*)
     );
+    () => (
+        $crate::__std_iter::once(())
+    );
     ($I:expr $(,)?) => (
         $crate::__std_iter::IntoIterator::into_iter($I).map(|elt| (elt,))
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,13 +249,13 @@ macro_rules! iproduct {
     (@flatten $I:expr, $J:expr, $($K:expr,)*) => (
         $crate::iproduct!(@flatten $crate::cons_tuples($crate::iproduct!($I, $J)), $($K,)*)
     );
-    ($I:expr) => (
+    ($I:expr $(,)?) => (
         $crate::__std_iter::IntoIterator::into_iter($I)
     );
-    ($I:expr, $J:expr) => (
+    ($I:expr, $J:expr $(,)?) => (
         $crate::Itertools::cartesian_product($crate::iproduct!($I), $crate::iproduct!($J))
     );
-    ($I:expr, $J:expr, $($K:expr),+) => (
+    ($I:expr, $J:expr, $($K:expr),+ $(,)?) => (
         $crate::iproduct!(@flatten $crate::iproduct!($I, $J), $($K,)+)
     );
 }

--- a/tests/macros_hygiene.rs
+++ b/tests/macros_hygiene.rs
@@ -1,5 +1,6 @@
 #[test]
 fn iproduct_hygiene() {
+    let _ = itertools::iproduct!();
     let _ = itertools::iproduct!(0..6);
     let _ = itertools::iproduct!(0..6, 0..9);
     let _ = itertools::iproduct!(0..6, 0..9, 0..12);

--- a/tests/test_core.rs
+++ b/tests/test_core.rs
@@ -19,6 +19,23 @@ use core::iter;
 use itertools as it;
 
 #[test]
+fn product0() {
+    let mut prod = iproduct!();
+    assert_eq!(prod.next(), Some(()));
+    assert!(prod.next().is_none());
+}
+
+#[test]
+fn iproduct1() {
+    let s = "αβ";
+
+    let mut prod = iproduct!(s.chars());
+    assert_eq!(prod.next(), Some(('α',)));
+    assert_eq!(prod.next(), Some(('β',)));
+    assert!(prod.next().is_none());
+}
+
+#[test]
 fn product2() {
     let s = "αβ";
 


### PR DESCRIPTION
Fixes #868
Allow trailing commas is convenient when the macro is on multiple lines.

Fixes #869
It is more consistent to return tuples in every case.
It however is a breaking change.
Note the new case: the empty product generating a single unit tuple `()`, similar to the recent #835.

What do you think?
EDIT: 2nd option, we can fix the first one and close the second.

PS: I note that semver-checks does not see much breaking changes lately.