### PR TITLE
Deprecate `unfold` for `std::iter::from_fn`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-itertools/itertools"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ How to use with Cargo:
 
 ```toml
 [dependencies]
-itertools = "0.12.1"
+itertools = "0.13.0"
 ```
 
 How to use in your crate:

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -98,6 +98,7 @@ where
 ///                         vec![1, 1, 2, 3, 5, 8, 13, 21]);
 /// assert_eq!(fibonacci.last(), Some(2_971_215_073))
 /// ```
+#[deprecated(note = "Use std from_fn() instead", since = "0.13.0")]
 pub fn unfold<A, St, F>(initial_state: St, f: F) -> Unfold<St, F>
 where
     F: FnMut(&mut St) -> Option<A>,
@@ -118,6 +119,7 @@ where
 /// See [`unfold`](crate::unfold) for more information.
 #[derive(Clone)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
+#[deprecated(note = "Use std from_fn() instead", since = "0.13.0")]
 pub struct Unfold<St, F> {
     f: F,
     /// Internal state that will be passed to the closure on the next iteration


### PR DESCRIPTION
Solves #223. Based on https://github.com/rust-itertools/itertools/pull/610#issuecomment-1145341531 that suggested to add a deprecation notice instead of removing it directly.