### PR TITLE
Specialize `MapForGrouping::fold`

### DIFF
--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -22,6 +22,7 @@ impl<I, F> MapForGrouping<I, F> {
     }
 }
 
+#[allow(clippy::missing_trait_methods)]
 impl<K, V, I, F> Iterator for MapForGrouping<I, F>
 where
     I: Iterator<Item = V>,
@@ -31,6 +32,14 @@ where
     type Item = (K, V);
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(|val| ((self.1)(&val), val))
+    }
+
+    fn fold<B, G>(self, init: B, f: G) -> B
+    where
+        G: FnMut(B, Self::Item) -> B,
+    {
+        let mut key_mapper = self.1;
+        self.0.map(|val| (key_mapper(&val), val)).fold(init, f)
     }
 }
 


### PR DESCRIPTION
Related to #755

`MapForGrouping` is only internally used by `GroupingMapBy` and it only calls `for_each` on it (which in turn rely on `fold`). So I allow the clippy lint `missing_trait_methods` because specialize other methods is simply useless. (In case we run clippy with warning it.)

_I could replace `next` body by `unreachable!()` and it would still work fine._
Anyway, it will disappear from test coverage now that we have one ([see here](https://app.codecov.io/gh/rust-itertools/itertools/pull/873/blob/src/grouping_map.rs#L34)).

I previously wandered how to test and benchmark this:
- The current tests will test this.
- And I guess I could benchmark this `fold` specialization through some `into_grouping_map_by` benchmark but I simply don't think it's worth the time: no doubt `adapted_iterator.map.fold` is faster than the default `fold` calling `next` repeatedly. We just don't know how much faster.

Note that all `GroupingMapBy` methods ultimately rely on this `fold` so this specialization will improve performance for all its methods.