### PR TITLE
update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily


### PR DESCRIPTION
adds dependabot config for bumping cargo dependencies

this should generate PRs for criterion, quickcheck, and rand.

the quickcheck PR will fail CI since there are breaking changes, likely blocked on https://github.com/BurntSushi/quickcheck/issues/267