### PR TITLE
Fix `deprecated_in_future` lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2623,7 +2623,7 @@ pub trait Itertools: Iterator {
             Ok(x)
         }
 
-        match inner(usize::max_value(), &mut self, &mut f) {
+        match inner(usize::MAX, &mut self, &mut f) {
             Err(x) => x,
             _ => unreachable!(),
         }

--- a/src/powerset.rs
+++ b/src/powerset.rs
@@ -1,7 +1,6 @@
 use alloc::vec::Vec;
 use std::fmt;
 use std::iter::FusedIterator;
-use std::usize;
 
 use super::combinations::{combinations, Combinations};
 use crate::adaptors::checked_binomial;

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -2,7 +2,6 @@
 //!
 
 use std::cmp;
-use std::usize;
 
 /// `SizeHint` is the return type of `Iterator::size_hint()`.
 pub type SizeHint = (usize, Option<usize>);

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -58,7 +58,7 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (usize::max_value(), None)
+        (usize::MAX, None)
     }
 }
 
@@ -170,7 +170,7 @@ where
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (usize::max_value(), None)
+        (usize::MAX, None)
     }
 }
 

--- a/src/ziptuple.rs
+++ b/src/ziptuple.rs
@@ -82,7 +82,7 @@ macro_rules! impl_zip_iter {
 
             fn size_hint(&self) -> (usize, Option<usize>)
             {
-                let sh = (::std::usize::MAX, None);
+                let sh = (usize::MAX, None);
                 let ($(ref $B,)*) = self.t;
                 $(
                     let sh = size_hint::min($B.size_hint(), sh);

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -67,8 +67,8 @@ impl qc::Arbitrary for Inexact {
         let ue_value = usize::arbitrary(g);
         let oe_value = usize::arbitrary(g);
         // Compensate for quickcheck using extreme values too rarely
-        let ue_choices = &[0, ue_value, usize::max_value()];
-        let oe_choices = &[0, oe_value, usize::max_value()];
+        let ue_choices = &[0, ue_value, usize::MAX];
+        let oe_choices = &[0, oe_value, usize::MAX];
         Self {
             underestimate: *ue_choices.choose(g).unwrap(),
             overestimate: *oe_choices.choose(g).unwrap(),


### PR DESCRIPTION
I was wondering if we should remove some deprecated parts when I encountered the lint `deprecated_in_future`.

`usize::MAX` is stable since 1.43.0. Our MSRV is 1.43.1 so this is fine and the module `std::usize` and `usize::max_value` both say "_Deprecating in a future version_" so I remove those.