### PR TITLE
Remove deprecated

### DIFF
--- a/src/adaptors/map.rs
+++ b/src/adaptors/map.rs
@@ -67,10 +67,6 @@ where
 /// See [`.map_ok()`](crate::Itertools::map_ok) for more information.
 pub type MapOk<I, F> = MapSpecialCase<I, MapSpecialCaseFnOk<F>>;
 
-/// See [`MapOk`].
-#[deprecated(note = "Use MapOk instead", since = "0.10.0")]
-pub type MapResults<I, F> = MapOk<I, F>;
-
 impl<F, T, U, E> MapSpecialCaseFn<Result<T, E>> for MapSpecialCaseFnOk<F>
 where
     F: FnMut(T) -> U,

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -8,8 +8,6 @@ mod coalesce;
 pub(crate) mod map;
 mod multi_product;
 pub use self::coalesce::*;
-#[allow(deprecated)]
-pub use self::map::MapResults;
 pub use self::map::{map_into, map_ok, MapInto, MapOk};
 #[cfg(feature = "use_alloc")]
 pub use self::multi_product::*;

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -507,69 +507,6 @@ where
     }
 }
 
-/// An iterator adaptor that steps a number elements in the base iterator
-/// for each iteration.
-///
-/// The iterator steps by yielding the next element from the base iterator,
-/// then skipping forward *n-1* elements.
-///
-/// See [`.step()`](crate::Itertools::step) for more information.
-#[deprecated(note = "Use std .step_by() instead", since = "0.8.0")]
-#[allow(deprecated)]
-#[derive(Clone, Debug)]
-#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-pub struct Step<I> {
-    iter: Fuse<I>,
-    skip: usize,
-}
-
-/// Create a `Step` iterator.
-///
-/// **Panics** if the step is 0.
-#[allow(deprecated)]
-pub fn step<I>(iter: I, step: usize) -> Step<I>
-where
-    I: Iterator,
-{
-    assert!(step != 0);
-    Step {
-        iter: iter.fuse(),
-        skip: step - 1,
-    }
-}
-
-#[allow(deprecated)]
-impl<I> Iterator for Step<I>
-where
-    I: Iterator,
-{
-    type Item = I::Item;
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        let elt = self.iter.next();
-        if self.skip > 0 {
-            self.iter.nth(self.skip - 1);
-        }
-        elt
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let (low, high) = self.iter.size_hint();
-        let div = |x: usize| {
-            if x == 0 {
-                0
-            } else {
-                1 + (x - 1) / (self.skip + 1)
-            }
-        };
-        (div(low), high.map(div))
-    }
-}
-
-// known size
-#[allow(deprecated)]
-impl<I> ExactSizeIterator for Step<I> where I: ExactSizeIterator {}
-
 /// An iterator adaptor that borrows from a `Clone`-able iterator
 /// to only pick off elements while the predicate returns `true`.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2322,16 +2322,6 @@ pub trait Itertools: Iterator {
         format::new_format(self, sep, format)
     }
 
-    /// See [`.fold_ok()`](Itertools::fold_ok).
-    #[deprecated(note = "Use .fold_ok() instead", since = "0.10.0")]
-    fn fold_results<A, E, B, F>(&mut self, start: B, f: F) -> Result<B, E>
-    where
-        Self: Iterator<Item = Result<A, E>>,
-        F: FnMut(B, A) -> B,
-    {
-        self.fold_ok(start, f)
-    }
-
     /// Fold `Result` values from an iterator.
     ///
     /// Only `Ok` values are folded. If no error is encountered, the folded

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2149,32 +2149,6 @@ pub trait Itertools: Iterator {
         self
     }
 
-    /// Run the closure `f` eagerly on each element of the iterator.
-    ///
-    /// Consumes the iterator until its end.
-    ///
-    /// ```
-    /// use std::sync::mpsc::channel;
-    /// use itertools::Itertools;
-    ///
-    /// let (tx, rx) = channel();
-    ///
-    /// // use .foreach() to apply a function to each value -- sending it
-    /// (0..5).map(|x| x * 2 + 1).foreach(|x| { tx.send(x).unwrap(); } );
-    ///
-    /// drop(tx);
-    ///
-    /// itertools::assert_equal(rx.iter(), vec![1, 3, 5, 7, 9]);
-    /// ```
-    #[deprecated(note = "Use .for_each() instead", since = "0.8.0")]
-    fn foreach<F>(self, f: F)
-    where
-        F: FnMut(Self::Item),
-        Self: Sized,
-    {
-        self.for_each(f);
-    }
-
     /// Combine all an iterator's elements into one element by using [`Extend`].
     ///
     /// This combinator will extend the first item with each of the rest of the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,8 @@ pub use std::iter as __std_iter;
 
 /// The concrete iterator types.
 pub mod structs {
+    #[allow(deprecated)]
+    pub use crate::adaptors::MapResults;
     #[cfg(feature = "use_alloc")]
     pub use crate::adaptors::MultiProduct;
     pub use crate::adaptors::{
@@ -87,8 +89,6 @@ pub mod structs {
         FilterOk, Interleave, InterleaveShortest, MapInto, MapOk, Positions, Product, PutBack,
         TakeWhileRef, TupleCombinations, Update, WhileSome,
     };
-    #[allow(deprecated)]
-    pub use crate::adaptors::{MapResults, Step};
     #[cfg(feature = "use_alloc")]
     pub use crate::combinations::Combinations;
     #[cfg(feature = "use_alloc")]
@@ -812,31 +812,6 @@ pub trait Itertools: Iterator {
         Self::Item: Clone,
     {
         tee::new(self)
-    }
-
-    /// Return an iterator adaptor that steps `n` elements in the base iterator
-    /// for each iteration.
-    ///
-    /// The iterator steps by yielding the next element from the base iterator,
-    /// then skipping forward `n - 1` elements.
-    ///
-    /// Iterator element type is `Self::Item`.
-    ///
-    /// **Panics** if the step is 0.
-    ///
-    /// ```
-    /// use itertools::Itertools;
-    ///
-    /// let it = (0..8).step(3);
-    /// itertools::assert_equal(it, vec![0, 3, 6]);
-    /// ```
-    #[deprecated(note = "Use std .step_by() instead", since = "0.8.0")]
-    #[allow(deprecated)]
-    fn step(self, n: usize) -> Step<Self>
-    where
-        Self: Sized,
-    {
-        adaptors::step(self, n)
     }
 
     /// Convert each item of the iterator using the [`Into`] trait.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ pub mod structs {
     pub use crate::rciter_impl::RcIter;
     pub use crate::repeatn::RepeatN;
     #[allow(deprecated)]
-    pub use crate::sources::{Iterate, RepeatCall, Unfold};
+    pub use crate::sources::{Iterate, Unfold};
     pub use crate::take_while_inclusive::TakeWhileInclusive;
     #[cfg(feature = "use_alloc")]
     pub use crate::tee::Tee;
@@ -156,7 +156,7 @@ pub use crate::peeking_take_while::PeekingNext;
 pub use crate::process_results_impl::process_results;
 pub use crate::repeatn::repeat_n;
 #[allow(deprecated)]
-pub use crate::sources::{iterate, repeat_call, unfold};
+pub use crate::sources::{iterate, unfold};
 #[allow(deprecated)]
 pub use crate::structs::*;
 pub use crate::unziptuple::{multiunzip, MultiUnzip};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,6 @@ pub use std::iter as __std_iter;
 
 /// The concrete iterator types.
 pub mod structs {
-    #[allow(deprecated)]
-    pub use crate::adaptors::MapResults;
     #[cfg(feature = "use_alloc")]
     pub use crate::adaptors::MultiProduct;
     pub use crate::adaptors::{
@@ -827,16 +825,6 @@ pub trait Itertools: Iterator {
         Self::Item: Into<R>,
     {
         adaptors::map_into(self)
-    }
-
-    /// See [`.map_ok()`](Itertools::map_ok).
-    #[deprecated(note = "Use .map_ok() instead", since = "0.10.0")]
-    fn map_results<F, T, U, E>(self, f: F) -> MapOk<Self, F>
-    where
-        Self: Iterator<Item = Result<T, E>> + Sized,
-        F: FnMut(T) -> U,
-    {
-        self.map_ok(f)
     }
 
     /// Return an iterator adaptor that applies the provided closure

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -5,63 +5,6 @@
 use std::fmt;
 use std::mem;
 
-/// See [`repeat_call`](crate::repeat_call) for more information.
-#[derive(Clone)]
-#[deprecated(note = "Use std repeat_with() instead", since = "0.8.0")]
-pub struct RepeatCall<F> {
-    f: F,
-}
-
-impl<F> fmt::Debug for RepeatCall<F> {
-    debug_fmt_fields!(RepeatCall,);
-}
-
-/// An iterator source that produces elements indefinitely by calling
-/// a given closure.
-///
-/// Iterator element type is the return type of the closure.
-///
-/// ```
-/// use itertools::repeat_call;
-/// use itertools::Itertools;
-/// use std::collections::BinaryHeap;
-///
-/// let mut heap = BinaryHeap::from(vec![2, 5, 3, 7, 8]);
-///
-/// // extract each element in sorted order
-/// for element in repeat_call(|| heap.pop()).while_some() {
-///     print!("{}", element);
-/// }
-///
-/// itertools::assert_equal(
-///     repeat_call(|| 1).take(5),
-///     vec![1, 1, 1, 1, 1]
-/// );
-/// ```
-#[deprecated(note = "Use std repeat_with() instead", since = "0.8.0")]
-pub fn repeat_call<F, A>(function: F) -> RepeatCall<F>
-where
-    F: FnMut() -> A,
-{
-    RepeatCall { f: function }
-}
-
-impl<A, F> Iterator for RepeatCall<F>
-where
-    F: FnMut() -> A,
-{
-    type Item = A;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        Some((self.f)())
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (usize::MAX, None)
-    }
-}
-
 /// Creates a new unfold source with the specified closure as the "iterator
 /// function" and an initial state to eventually pass to the closure
 ///

--- a/tests/laziness.rs
+++ b/tests/laziness.rs
@@ -104,10 +104,6 @@ must_use_tests! {
     tee {
         let _ = Panicking.tee();
     }
-    #[allow(deprecated)]
-    step {
-        let _ = Panicking.step(2);
-    }
     map_into {
         let _ = Panicking.map_into::<u16>();
     }

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -456,45 +456,6 @@ quickcheck! {
         itertools::assert_equal(empty, std::iter::once(Vec::new()))
     }
 
-    #[allow(deprecated)]
-    fn size_step(a: Iter<i16, Exact>, s: usize) -> bool {
-        let mut s = s;
-        if s == 0 {
-            s += 1; // never zero
-        }
-        let filt = a.clone().dedup();
-        correct_size_hint(filt.step(s)) &&
-            exact_size(a.step(s))
-    }
-
-    #[allow(deprecated)]
-    fn equal_step(a: Iter<i16>, s: usize) -> bool {
-        let mut s = s;
-        if s == 0 {
-            s += 1; // never zero
-        }
-        let mut i = 0;
-        itertools::equal(a.clone().step(s), a.filter(|_| {
-            let keep = i % s == 0;
-            i += 1;
-            keep
-        }))
-    }
-
-    #[allow(deprecated)]
-    fn equal_step_vec(a: Vec<i16>, s: usize) -> bool {
-        let mut s = s;
-        if s == 0 {
-            s += 1; // never zero
-        }
-        let mut i = 0;
-        itertools::equal(a.iter().step(s), a.iter().filter(|_| {
-            let keep = i % s == 0;
-            i += 1;
-            keep
-        }))
-    }
-
     fn size_multipeek(a: Iter<u16, Exact>, s: u8) -> bool {
         let mut it = multipeek(a);
         // peek a few times
@@ -1373,13 +1334,12 @@ quickcheck! {
 }
 
 quickcheck! {
-    #[allow(deprecated)]
     fn tree_fold1_f64(mut a: Vec<f64>) -> TestResult {
         fn collapse_adjacent<F>(x: Vec<f64>, mut f: F) -> Vec<f64>
             where F: FnMut(f64, f64) -> f64
         {
             let mut out = Vec::new();
-            for i in (0..x.len()).step(2) {
+            for i in (0..x.len()).step_by(2) {
                 if i == x.len()-1 {
                     out.push(x[i])
                 } else {

--- a/tests/test_core.rs
+++ b/tests/test_core.rs
@@ -214,18 +214,9 @@ fn test_put_back() {
     it::assert_equal(pb, xs.iter().cloned());
 }
 
-#[allow(deprecated)]
-#[test]
-fn step() {
-    it::assert_equal((0..10).step(1), 0..10);
-    it::assert_equal((0..10).step(2), (0..10).filter(|x: &i32| *x % 2 == 0));
-    it::assert_equal((0..10).step(10), 0..1);
-}
-
-#[allow(deprecated)]
 #[test]
 fn merge() {
-    it::assert_equal((0..10).step(2).merge((1..10).step(2)), 0..10);
+    it::assert_equal((0..10).step_by(2).merge((1..10).step_by(2)), 0..10);
 }
 
 #[test]

--- a/tests/test_core.rs
+++ b/tests/test_core.rs
@@ -172,15 +172,6 @@ fn test_intersperse_with() {
     it::assert_equal(it, ys.iter());
 }
 
-#[allow(deprecated)]
-#[test]
-fn foreach() {
-    let xs = [1i32, 2, 3];
-    let mut sum = 0;
-    xs.iter().foreach(|elt| sum += *elt);
-    assert!(sum == 6);
-}
-
 #[test]
 fn dropping() {
     let xs = [1, 2, 3];

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -423,18 +423,16 @@ fn merge_by_btree() {
     it::assert_equal(results, expected);
 }
 
-#[allow(deprecated)]
 #[test]
 fn kmerge() {
-    let its = (0..4).map(|s| (s..10).step(4));
+    let its = (0..4).map(|s| (s..10).step_by(4));
 
     it::assert_equal(its.kmerge(), 0..10);
 }
 
-#[allow(deprecated)]
 #[test]
 fn kmerge_2() {
-    let its = vec![3, 2, 1, 0].into_iter().map(|s| (s..10).step(4));
+    let its = vec![3, 2, 1, 0].into_iter().map(|s| (s..10).step_by(4));
 
     it::assert_equal(its.kmerge(), 0..10);
 }

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -1384,7 +1384,6 @@ fn while_some() {
     it::assert_equal(ns, vec![1, 2, 3, 4]);
 }
 
-#[allow(deprecated)]
 #[test]
 fn fold_while() {
     let mut iterations = 0;

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -360,7 +360,6 @@ fn test_rciter() {
     assert_eq!(z.next(), Some((0, 1)));
 }
 
-#[allow(deprecated)]
 #[test]
 fn trait_pointers() {
     struct ByRef<'r, I: ?Sized>(&'r mut I);
@@ -379,7 +378,6 @@ fn trait_pointers() {
     assert_eq!(it.next(), Some(0));
 
     {
-        /* make sure foreach works on non-Sized */
         let jt: &mut dyn Iterator<Item = i32> = &mut *it;
         assert_eq!(jt.next(), Some(1));
 
@@ -389,7 +387,7 @@ fn trait_pointers() {
         }
 
         assert_eq!(jt.find_position(|x| *x == 4), Some((1, 4)));
-        jt.foreach(|_| ());
+        jt.for_each(|_| ());
     }
 }
 


### PR DESCRIPTION
At the same time as #877, I listed our deprecated parts:

Deprecated | Alternative | Comment
:---------:|:-----------:|:-------:
`Itertools::group_by`<br>since 0.13.0     | `Itertools::chunk_by`                       | Newly deprecated.<br>Do not remove!
`unfold`<br>since 0.13.0                  | `core::iter::from_fn`<br>MSRV &ge; 1.34.0     | Newly deprecated.<br>Do not remove!
`Itertools::fold1`<br>since 0.10.2        | `Iterator::reduce`<br>MSRV &ge; 1.51.0        | Unavailable alternative<br>since MSRV = 1.43.1<br>Do not remove!
`zip`<br>since 0.10.4                     | `core::iter::zip`<br>MSRV &ge; 1.59.0         | Unavailable alternative<br>since MSRV = 1.43.1<br>Do not remove!
`repeat_call`<br>since 0.8.0              | `core::iter::repeat_with`<br>MSRV &ge; 1.28.0 | Remove?!
`Itertools::foreach`<br>since 0.8.0       | `Iterator::for_each`<br>MSRV &ge; 1.21.0      | Remove?!
`Itertools::step`<br>since 0.8.0          | `Iterator::step_by`<br>MSRV &ge; 1.28.0       | Remove?!
`Itertools::map_results`<br>since 0.10.0  | `Itertools::map_ok`                         | Remove?!
`Itertools::fold_results`<br>since 0.10.0 | `Itertools::fold_ok`                        | Remove?!

Should we remove `repeat_call, Itertools::{foreach, step, map_results, fold_results}` (which is what I did here)?
Or _when should we_?

Note: 0.8.0 and 0.10.0 are resp. 5 and 3 years old.