### PR TITLE
Update crate keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 description = "Extra iterator adaptors, iterator methods, free functions, and macros."
 
-keywords = ["iterator", "data-structure", "zip", "product", "group-by"]
+keywords = ["iterator", "data-structure", "zip", "product"]
 categories = ["algorithms", "rust-patterns"]
 
 edition = "2018"


### PR DESCRIPTION
Now that `group_by` has been renamed to `chunk_by` in #866 I think we should just delete the crate keyword "group-by".
Note that on [crates.io](https://crates.io/keywords/group-by), this keyword only leads to "itertools" and "itertools-wild" so it does not seem useful at all.

_Should we delete another one as well?_