### PR TITLE
`PutBack::put_back` now returns the old value

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -280,10 +280,10 @@ where
 
     /// Put back a single value to the front of the iterator.
     ///
-    /// If a value is already in the put back slot, it is overwritten.
+    /// If a value is already in the put back slot, it is returned.
     #[inline]
-    pub fn put_back(&mut self, x: I::Item) {
-        self.top = Some(x);
+    pub fn put_back(&mut self, x: I::Item) -> Option<I::Item> {
+        self.top.replace(x)
     }
 }
 

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -882,7 +882,7 @@ quickcheck! {
     fn size_put_back(a: Vec<u8>, x: Option<u8>) -> bool {
         let mut it = put_back(a.into_iter());
         if let Some(t) = x {
-            it.put_back(t)
+            it.put_back(t);
         }
         correct_size_hint(it)
     }


### PR DESCRIPTION
Fixes #313 

Discard the value sure is the main usage but I don't see a non-tricky usage of this so I'm not sure if we should do this, feel free to close this.

Because it does not return `()` anymore, some changes can be necessary to ignore the returned value like here in "tests/quick.rs".