### PR TITLE
minor update to multizip documentation

### DIFF
--- a/src/ziptuple.rs
+++ b/src/ziptuple.rs
@@ -16,7 +16,7 @@ pub struct Zip<T> {
 /// The iterator element type is a tuple like like `(A, B, ..., E)` where `A` to `E` are the
 /// element types of the subiterator.
 ///
-/// **Note:** The result of this macro is a value of a named type (`Zip<(I, J,
+/// **Note:** The result of this function is a value of a named type (`Zip<(I, J,
 /// ..)>` of each component iterator `I, J, ...`) if each component iterator is
 /// nameable.
 ///


### PR DESCRIPTION
The docs for `multizip()` refer to it as a macro, even though it is clearly a function. I'm guessing this typo originated from the copy-paste from `izip!()`, which has a similar section noting the result:

from `multizip()`:
```
/// **Note:** The result of this macro is a value of a named type (`Zip<(I, J,
```

from `izip!()`:
```
/// **Note:** The result of this macro is in the general case an iterator
```