### PR TITLE
Specialize TakeWhileRef fold

### DIFF
--- a/benches/bench1.rs
+++ b/benches/bench1.rs
@@ -792,6 +792,21 @@ fn permutations_slice(c: &mut Criterion) {
     });
 }
 
+fn take_while_ref(c: &mut Criterion) {
+    c.bench_function("take_while_ref", |b| {
+        b.iter(|| {
+            let mut data = black_box("0123456789abcdef".chars());
+            let result =
+                data.take_while_ref(|c| c.is_numeric())
+                    .fold(String::new(), |mut acc, ch| {
+                        acc.push(ch);
+                        acc
+                    });
+            assert_eq!(result.as_str(), "0123456789");
+        });
+    });
+}
+
 criterion_group!(
     benches,
     slice_iter,
@@ -837,5 +852,6 @@ criterion_group!(
     permutations_iter,
     permutations_range,
     permutations_slice,
+    take_while_ref
 );
 criterion_main!(benches);


### PR DESCRIPTION
#755 

This PR introduces a custom fold method for `TakeWhileRef`. The optimization hinges on the `fold_while` logic:

Benchmark Results:

Default fold: time:   [53.963 ns 54.083 ns 54.209 ns]
Custom fold: time:   [53.210 ns 53.359 ns 53.511 ns]