### PR TITLE
Loosen `Fn` bounds to `FnMut`

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -77,11 +77,11 @@ where
 ///
 /// If `i` becomes exhausted before `j` becomes exhausted, the number of elements in `i` along with
 /// the remaining `j` elements will be returned as `Diff::Longer`.
-pub fn diff_with<I, J, F>(i: I, j: J, is_equal: F) -> Option<Diff<I::IntoIter, J::IntoIter>>
+pub fn diff_with<I, J, F>(i: I, j: J, mut is_equal: F) -> Option<Diff<I::IntoIter, J::IntoIter>>
 where
     I: IntoIterator,
     J: IntoIterator,
-    F: Fn(&I::Item, &J::Item) -> bool,
+    F: FnMut(&I::Item, &J::Item) -> bool,
 {
     let mut i = i.into_iter();
     let mut j = j.into_iter();

--- a/src/group_map.rs
+++ b/src/group_map.rs
@@ -22,10 +22,11 @@ where
     lookup
 }
 
-pub fn into_group_map_by<I, K, V>(iter: I, f: impl Fn(&V) -> K) -> HashMap<K, Vec<V>>
+pub fn into_group_map_by<I, K, V, F>(iter: I, mut f: F) -> HashMap<K, Vec<V>>
 where
     I: Iterator<Item = V>,
     K: Hash + Eq,
+    F: FnMut(&V) -> K,
 {
     into_group_map(iter.map(|v| (f(&v), v)))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3257,7 +3257,7 @@ pub trait Itertools: Iterator {
     where
         Self: Iterator<Item = V> + Sized,
         K: Hash + Eq,
-        F: Fn(&V) -> K,
+        F: FnMut(&V) -> K,
     {
         group_map::into_group_map_by(self, f)
     }


### PR DESCRIPTION
In #885, I relaxed the `Fn` bounds to `FnMut` for the new variants of `k_smallest`.
It lead me to find out this is also possible for `diff_with` and `Itertools::into_group_map_by`.

I'm not sure why we would need `Fn` bounds in our crate.
clippy does not have a `disallowed_traits` lint or I would have added `Fn` to it.