### PR TITLE
`MapInto`: relax `Debug/Clone` bounds

### DIFF
--- a/src/adaptors/map.rs
+++ b/src/adaptors/map.rs
@@ -108,8 +108,18 @@ impl<T: Into<U>, U> MapSpecialCaseFn<T> for MapSpecialCaseFnInto<U> {
     }
 }
 
-#[derive(Clone, Debug)]
 pub struct MapSpecialCaseFnInto<U>(PhantomData<U>);
+
+impl<U> std::fmt::Debug for MapSpecialCaseFnInto<U> {
+    debug_fmt_fields!(MapSpecialCaseFnInto, 0);
+}
+
+impl<U> Clone for MapSpecialCaseFnInto<U> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self(PhantomData)
+    }
+}
 
 /// Create a new [`MapInto`] iterator.
 pub fn map_into<I, R>(iter: I) -> MapInto<I, R> {


### PR DESCRIPTION
Derive those adds a bound on `U` which is not needed (I checked with the "expand macros" tool of the Rust [playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=7cc7458d9bd235cc822d9a53629083d1)) since it's only `PhantomData`.
Note that `PhantomData<T>` is `Debug + Clone` for any `T`.

I can hit easily hit the error ([playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=6aa90555457fd1bef38d3ba600efcd2a)).