### PR TITLE
Remove badges in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ Extra iterator adaptors, functions and macros.
 
 Please read the [API documentation here](https://docs.rs/itertools/).
 
-[![build_status](https://github.com/rust-itertools/itertools/actions/workflows/ci.yml/badge.svg)](https://github.com/rust-itertools/itertools/actions)
-[![crates.io](https://img.shields.io/crates/v/itertools.svg)](https://crates.io/crates/itertools)
-
 How to use with Cargo:
 
 ```toml


### PR DESCRIPTION
I might have been overzealous on the badges here but I think it's nice, especially the MSRV one that does not need manual updates.

<details>
<summary>Rendered badges</summary>

[![Documentation](https://docs.rs/itertools/badge.svg)](https://docs.rs/itertools) [![crates.io](https://img.shields.io/crates/v/itertools.svg)](https://crates.io/crates/itertools) [![MSRV](https://img.shields.io/crates/msrv/itertools "Minimum Supported Rust Version")](https://github.com/rust-itertools/itertools/blob/master/Cargo.toml) [![License](https://img.shields.io/crates/l/itertools.svg)](https://github.com/rust-itertools/itertools) [![Build Status](https://github.com/rust-itertools/itertools/actions/workflows/ci.yml/badge.svg)](https://github.com/rust-itertools/itertools/actions) [![Code Coverage](https://img.shields.io/codecov/c/github/rust-itertools/itertools)](https://codecov.io/github/rust-itertools/itertools) [![Total Downloads](https://img.shields.io/crates/d/itertools.svg)](https://crates.io/crates/itertools) [![Contributors](https://img.shields.io/github/contributors/rust-itertools/itertools)](https://github.com/rust-itertools/itertools/graphs/contributors)
</details>