### PR TITLE
Add `.get(range)`

### DIFF
--- a/src/iter_index.rs
+++ b/src/iter_index.rs
@@ -48,11 +48,17 @@ impl<I> IteratorIndex<I> for RangeInclusive<usize>
 where
     I: Iterator,
 {
-    type Output = Skip<Take<I>>;
+    type Output = Take<Skip<I>>;
 
     fn index(self, iter: I) -> Self::Output {
-        assert_ne!(*self.end(), usize::MAX);
-        iter.take(self.end() + 1).skip(*self.start())
+        // end - start + 1 without overflowing if possible
+        let length = if *self.end() == usize::MAX {
+            assert_ne!(*self.start(), 0);
+            self.end() - self.start() + 1
+        } else {
+            (self.end() + 1).saturating_sub(*self.start())
+        };
+        iter.skip(*self.start()).take(length)
     }
 }
 

--- a/src/iter_index.rs
+++ b/src/iter_index.rs
@@ -1,6 +1,7 @@
 use core::iter::{Skip, Take};
 use core::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 
+#[cfg(doc)]
 use crate::Itertools;
 
 mod private_iter_index {
@@ -16,17 +17,16 @@ mod private_iter_index {
     impl Sealed for ops::RangeFull {}
 }
 
-/// Used by the ``range`` function to know which iterator
+/// Used by [`get`] and [`Itertools::get`] to know which iterator
 /// to turn different ranges into.
 pub trait IteratorIndex<I>: private_iter_index::Sealed
 where
     I: Iterator,
 {
-    /// The type that [`get`] or [`Itertools::get`]
-    /// returns when called with this type of index.
+    /// The type returned for this type of index.
     type Output: Iterator<Item = I::Item>;
 
-    /// Returns an iterator(or value) in the specified range.
+    /// Returns an adapted iterator for the current index.
     ///
     /// Prefer calling [`get`] or [`Itertools::get`] instead
     /// of calling this directly.
@@ -102,8 +102,7 @@ where
     }
 }
 
-/// Returns an element of the iterator or an iterator
-/// over a subsection of the iterator.
+/// Returns an iterator over a subsection of the iterator.
 ///
 /// See [`Itertools::get`] for more information.
 pub fn get<I, R>(iter: I, index: R) -> R::Output

--- a/src/iter_index.rs
+++ b/src/iter_index.rs
@@ -37,11 +37,10 @@ impl<I> IteratorIndex<I> for Range<usize>
 where
     I: Iterator,
 {
-    type Output = Take<Skip<I>>;
+    type Output = Skip<Take<I>>;
 
     fn index(self, iter: I) -> Self::Output {
-        iter.skip(self.start)
-            .take(self.end.saturating_sub(self.start))
+        iter.take(self.end).skip(self.start)
     }
 }
 

--- a/src/iter_index.rs
+++ b/src/iter_index.rs
@@ -52,7 +52,6 @@ where
     type Output = Take<Skip<I>>;
 
     fn index(self, iter: I) -> Self::Output {
-        debug_assert!(!self.is_empty(), "The given `RangeInclusive` is exhausted. The result of indexing with an exhausted `RangeInclusive` is unspecified.");
         iter.skip(*self.start())
             .take((1 + *self.end()).saturating_sub(*self.start()))
     }

--- a/src/iter_index.rs
+++ b/src/iter_index.rs
@@ -1,0 +1,126 @@
+use core::iter::{Skip, Take};
+use core::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
+
+use crate::Itertools;
+
+mod private_iter_index {
+    use core::ops;
+
+    pub trait Sealed {}
+
+    impl Sealed for ops::Range<usize> {}
+    impl Sealed for ops::RangeInclusive<usize> {}
+    impl Sealed for ops::RangeTo<usize> {}
+    impl Sealed for ops::RangeToInclusive<usize> {}
+    impl Sealed for ops::RangeFrom<usize> {}
+    impl Sealed for ops::RangeFull {}
+    impl Sealed for usize {}
+}
+
+/// Used by the ``range`` function to know which iterator
+/// to turn different ranges into.
+pub trait IteratorIndex<I>: private_iter_index::Sealed
+where
+    I: Iterator,
+{
+    /// The type that [`get`] or [`Itertools::get`]
+    /// returns when called with this type of index.
+    type Output: Iterator<Item = I::Item>;
+
+    /// Returns an iterator(or value) in the specified range.
+    ///
+    /// Prefer calling [`get`] or [`Itertools::get`] instead
+    /// of calling this directly.
+    fn index(self, from: I) -> Self::Output;
+}
+
+impl<I> IteratorIndex<I> for Range<usize>
+where
+    I: Iterator,
+{
+    type Output = Take<Skip<I>>;
+
+    fn index(self, iter: I) -> Self::Output {
+        iter.skip(self.start)
+            .take(self.end.saturating_sub(self.start))
+    }
+}
+
+impl<I> IteratorIndex<I> for RangeInclusive<usize>
+where
+    I: Iterator,
+{
+    type Output = Take<Skip<I>>;
+
+    fn index(self, iter: I) -> Self::Output {
+        iter.skip(*self.start())
+            .take((1 + *self.end()).saturating_sub(*self.start()))
+    }
+}
+
+impl<I> IteratorIndex<I> for RangeTo<usize>
+where
+    I: Iterator,
+{
+    type Output = Take<I>;
+
+    fn index(self, iter: I) -> Self::Output {
+        iter.take(self.end)
+    }
+}
+
+impl<I> IteratorIndex<I> for RangeToInclusive<usize>
+where
+    I: Iterator,
+{
+    type Output = Take<I>;
+
+    fn index(self, iter: I) -> Self::Output {
+        iter.take(self.end + 1)
+    }
+}
+
+impl<I> IteratorIndex<I> for RangeFrom<usize>
+where
+    I: Iterator,
+{
+    type Output = Skip<I>;
+
+    fn index(self, iter: I) -> Self::Output {
+        iter.skip(self.start)
+    }
+}
+
+impl<I> IteratorIndex<I> for RangeFull
+where
+    I: Iterator,
+{
+    type Output = I;
+
+    fn index(self, iter: I) -> Self::Output {
+        iter
+    }
+}
+
+impl<I> IteratorIndex<I> for usize
+where
+    I: Iterator,
+{
+    type Output = <Option<I::Item> as IntoIterator>::IntoIter;
+
+    fn index(self, mut iter: I) -> Self::Output {
+        iter.nth(self).into_iter()
+    }
+}
+
+/// Returns an element of the iterator or an iterator
+/// over a subsection of the iterator.
+///
+/// See [`Itertools::get`] for more information.
+pub fn get<I, R>(iter: I, index: R) -> R::Output
+where
+    I: IntoIterator,
+    R: IteratorIndex<I::IntoIter>,
+{
+    index.index(iter.into_iter())
+}

--- a/src/iter_index.rs
+++ b/src/iter_index.rs
@@ -17,7 +17,7 @@ mod private_iter_index {
     impl Sealed for ops::RangeFull {}
 }
 
-/// Used by [`get`] and [`Itertools::get`] to know which iterator
+/// Used by [`Itertools::get`] to know which iterator
 /// to turn different ranges into.
 pub trait IteratorIndex<I>: private_iter_index::Sealed
 where
@@ -28,7 +28,7 @@ where
 
     /// Returns an adapted iterator for the current index.
     ///
-    /// Prefer calling [`get`] or [`Itertools::get`] instead
+    /// Prefer calling [`Itertools::get`] instead
     /// of calling this directly.
     fn index(self, from: I) -> Self::Output;
 }
@@ -107,9 +107,6 @@ where
     }
 }
 
-/// Returns an iterator over a subsection of the iterator.
-///
-/// See [`Itertools::get`] for more information.
 pub fn get<I, R>(iter: I, index: R) -> R::Output
 where
     I: IntoIterator,

--- a/src/iter_index.rs
+++ b/src/iter_index.rs
@@ -48,11 +48,11 @@ impl<I> IteratorIndex<I> for RangeInclusive<usize>
 where
     I: Iterator,
 {
-    type Output = Take<Skip<I>>;
+    type Output = Skip<Take<I>>;
 
     fn index(self, iter: I) -> Self::Output {
-        iter.skip(*self.start())
-            .take((1 + *self.end()).saturating_sub(*self.start()))
+        assert_ne!(*self.end(), usize::MAX);
+        iter.take(self.end() + 1).skip(*self.start())
     }
 }
 
@@ -74,6 +74,7 @@ where
     type Output = Take<I>;
 
     fn index(self, iter: I) -> Self::Output {
+        assert_ne!(self.end, usize::MAX);
         iter.take(self.end + 1)
     }
 }

--- a/src/iter_index.rs
+++ b/src/iter_index.rs
@@ -14,7 +14,6 @@ mod private_iter_index {
     impl Sealed for ops::RangeToInclusive<usize> {}
     impl Sealed for ops::RangeFrom<usize> {}
     impl Sealed for ops::RangeFull {}
-    impl Sealed for usize {}
 }
 
 /// Used by the ``range`` function to know which iterator
@@ -53,6 +52,7 @@ where
     type Output = Take<Skip<I>>;
 
     fn index(self, iter: I) -> Self::Output {
+        debug_assert!(!self.is_empty(), "The given `RangeInclusive` is exhausted. The result of indexing with an exhausted `RangeInclusive` is unspecified.");
         iter.skip(*self.start())
             .take((1 + *self.end()).saturating_sub(*self.start()))
     }
@@ -99,17 +99,6 @@ where
 
     fn index(self, iter: I) -> Self::Output {
         iter
-    }
-}
-
-impl<I> IteratorIndex<I> for usize
-where
-    I: Iterator,
-{
-    type Output = <Option<I::Item> as IntoIterator>::IntoIter;
-
-    fn index(self, mut iter: I) -> Self::Output {
-        iter.nth(self).into_iter()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,6 @@ pub use crate::concat_impl::concat;
 pub use crate::cons_tuples_impl::cons_tuples;
 pub use crate::diff::diff_with;
 pub use crate::diff::Diff;
-pub use crate::iter_index::get;
 #[cfg(feature = "use_alloc")]
 pub use crate::kmerge_impl::kmerge_by;
 pub use crate::minmax::MinMaxResult;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,13 +507,14 @@ pub trait Itertools: Iterator {
         intersperse::intersperse_with(self, element)
     }
 
-    /// Returns an element at a specific location, or returns an iterator
-    /// over a subsection of the iterator.
+    /// Returns an iterator over a subsection of the iterator.
     ///
     /// Works similarly to [`slice::get`](https://doc.rust-lang.org/std/primitive.slice.html#method.get).
     ///
-    /// It's a generalisation of [`take`], [`skip`] and [`nth`], and uses these
-    /// under the hood.
+    /// It's a generalisation of [`Iterator::take`] and [`Iterator::skip`],
+    /// and uses these under the hood.
+    /// Therefore, the resulting iterator is [`DoubleEndedIterator`]
+    /// and/or [`ExactSizeIterator`] if the adapted iterator is.
     ///
     /// # Unspecified Behavior
     /// The result of indexing with an exhausted [`core::ops::RangeInclusive`] is unspecified.
@@ -526,7 +527,7 @@ pub trait Itertools: Iterator {
     /// let vec = vec![3, 1, 4, 1, 5];
     ///
     /// let mut range: Vec<_> =
-    ///        vec.iter().get(1..=3).copied().collect();
+    ///         vec.iter().get(1..=3).copied().collect();
     /// assert_eq!(&range, &[1, 4, 1]);
     ///
     /// // It works with other types of ranges, too
@@ -539,17 +540,16 @@ pub trait Itertools: Iterator {
     /// range = vec.iter().get(2..).copied().collect();
     /// assert_eq!(&range, &[4, 1, 5]);
     ///
+    /// range = vec.iter().get(..=2).copied().collect();
+    /// assert_eq!(&range, &[3, 1, 4]);
+    ///
     /// range = vec.iter().get(..).copied().collect();
     /// assert_eq!(range, vec);
     /// ```
-    ///
-    /// [`take`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.take
-    /// [`skip`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.skip
-    /// [`nth`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.nth
     fn get<R>(self, index: R) -> R::Output
     where
         Self: Sized,
-        R: iter_index::IteratorIndex<Self>,
+        R: traits::IteratorIndex<Self>,
     {
         iter_index::get(self, index)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,6 +515,9 @@ pub trait Itertools: Iterator {
     /// It's a generalisation of [`take`], [`skip`] and [`nth`], and uses these
     /// under the hood.
     ///
+    /// # Unspecified Behavior
+    /// The result of indexing with an exhausted [`core::ops::RangeInclusive`] is unspecified.
+    ///
     /// # Examples
     ///
     /// ```
@@ -538,9 +541,6 @@ pub trait Itertools: Iterator {
     ///
     /// range = vec.iter().get(..).copied().collect();
     /// assert_eq!(range, vec);
-    ///
-    /// range = vec.iter().get(3).copied().collect();
-    /// assert_eq!(&range, &[1]);
     /// ```
     ///
     /// [`take`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.take

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -511,7 +511,7 @@ pub trait Itertools: Iterator {
     ///
     /// Works similarly to [`slice::get`](https://doc.rust-lang.org/std/primitive.slice.html#method.get).
     ///
-    /// **Panics** if the range includes `usize::MAX`.
+    /// **Panics** for ranges `..=usize::MAX` and `0..=usize::MAX`.
     ///
     /// It's a generalisation of [`Iterator::take`] and [`Iterator::skip`],
     /// and uses these under the hood.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,8 +515,9 @@ pub trait Itertools: Iterator {
     ///
     /// It's a generalisation of [`Iterator::take`] and [`Iterator::skip`],
     /// and uses these under the hood.
-    /// Therefore, the resulting iterator is [`DoubleEndedIterator`]
-    /// and/or [`ExactSizeIterator`] if the adapted iterator is.
+    /// Therefore, the resulting iterator is:
+    /// - [`ExactSizeIterator`] if the adapted iterator is [`ExactSizeIterator`].
+    /// - [`DoubleEndedIterator`] if the adapted iterator is [`DoubleEndedIterator`] and [`ExactSizeIterator`].
     ///
     /// # Unspecified Behavior
     /// The result of indexing with an exhausted [`core::ops::RangeInclusive`] is unspecified.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -511,6 +511,8 @@ pub trait Itertools: Iterator {
     ///
     /// Works similarly to [`slice::get`](https://doc.rust-lang.org/std/primitive.slice.html#method.get).
     ///
+    /// **Panics** if the range includes `usize::MAX`.
+    ///
     /// It's a generalisation of [`Iterator::take`] and [`Iterator::skip`],
     /// and uses these under the hood.
     /// Therefore, the resulting iterator is [`DoubleEndedIterator`]

--- a/tests/laziness.rs
+++ b/tests/laziness.rs
@@ -63,6 +63,14 @@ must_use_tests! {
     intersperse_with {
         let _ = Panicking.intersperse_with(|| 0);
     }
+    get {
+        let _ = Panicking.get(1..4);
+        let _ = Panicking.get(1..=4);
+        let _ = Panicking.get(1..);
+        let _ = Panicking.get(..4);
+        let _ = Panicking.get(..=4);
+        let _ = Panicking.get(..);
+    }
     zip_longest {
         let _ = Panicking.zip_longest(Panicking);
     }

--- a/tests/test_core.rs
+++ b/tests/test_core.rs
@@ -18,6 +18,28 @@ use crate::it::Itertools;
 use core::iter;
 use itertools as it;
 
+#[allow(dead_code)]
+fn get_esi_then_esi<I: ExactSizeIterator + Clone>(it: I) {
+    fn is_esi(_: impl ExactSizeIterator) {}
+    is_esi(it.clone().get(1..4));
+    is_esi(it.clone().get(1..=4));
+    is_esi(it.clone().get(1..));
+    is_esi(it.clone().get(..4));
+    is_esi(it.clone().get(..=4));
+    is_esi(it.get(..));
+}
+
+#[allow(dead_code)]
+fn get_dei_esi_then_dei_esi<I: DoubleEndedIterator + ExactSizeIterator + Clone>(it: I) {
+    fn is_dei_esi(_: impl DoubleEndedIterator + ExactSizeIterator) {}
+    is_dei_esi(it.clone().get(1..4));
+    is_dei_esi(it.clone().get(1..=4));
+    is_dei_esi(it.clone().get(1..));
+    is_dei_esi(it.clone().get(..4));
+    is_dei_esi(it.clone().get(..=4));
+    is_dei_esi(it.get(..));
+}
+
 #[test]
 fn product0() {
     let mut prod = iproduct!();

--- a/tests/test_core.rs
+++ b/tests/test_core.rs
@@ -41,6 +41,19 @@ fn get_dei_esi_then_dei_esi<I: DoubleEndedIterator + ExactSizeIterator + Clone>(
 }
 
 #[test]
+fn get_1_max() {
+    let mut it = (0..5).get(1..=usize::MAX);
+    assert_eq!(it.next(), Some(1));
+    assert_eq!(it.next_back(), Some(4));
+}
+
+#[test]
+#[should_panic]
+fn get_full_range_inclusive() {
+    let _it = (0..5).get(0..=usize::MAX);
+}
+
+#[test]
 fn product0() {
     let mut prod = iproduct!();
     assert_eq!(prod.next(), Some(()));


### PR DESCRIPTION
Closes #447.

So much changes happened since this work was initiated that rebase on top of master seems nothing less than a nightmare to me (I know, I tried). I therefore looked at the git differences, committed those (after formatting) and credited @wod3 and @TrolledWoods for their respective commits. Then I fixed my own review and a bit more.

---

I thought I would additionally implement `IteratorIndex` for `Either<range, range>` (and `Box<dyn range>` but I could not) but doing so would later result in a nasty breaking change if this was removed after an eventual inclusion to `Iterator`.

<details>
<summary>Details about either</summary>

```rust
    impl<L: Sealed, R: Sealed> Sealed for either::Either<L, R> {}


impl<I, L, R> IteratorIndex<I> for Either<L, R>
where
    I: Iterator,
    L: IteratorIndex<I>,
    R: IteratorIndex<I>,
{
    type Output = Either<<L as IteratorIndex<I>>::Output, <R as IteratorIndex<I>>::Output>;

    fn index(self, iter: I) -> Self::Output {
        // Could be more succinct with `map_either_with` but it would require to bump `either` version.
        match self {
            Either::Left(left) => Either::Left(left.index(iter)),
            Either::Right(right) => Either::Right(right.index(iter)),
        }
    }
}


    /// // It works nicely with either.
    /// use itertools::Either;
    ///
    /// let mut either_range = Either::Left(0..1);
    /// range = vec.iter().get(either_range).copied().collect();
    /// assert_eq!(&range, &[3]);
    ///
    /// either_range = Either::Right(2..);
    /// range = vec.iter().get(either_range).copied().collect();
    /// assert_eq!(&range, &[4, 1, 5]);
```
</details>