### PR TITLE
"no-std" categories in "Cargo.toml"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 description = "Extra iterator adaptors, iterator methods, free functions, and macros."
 
 keywords = ["iterator", "data-structure", "zip", "product"]
-categories = ["algorithms", "rust-patterns"]
+categories = ["algorithms", "rust-patterns", "no-std", "no-std::no-alloc"]
 
 edition = "2018"
 


### PR DESCRIPTION
This crate can be used in no-std context, with alloc or not.
So I add [`no-std`](https://crates.io/categories/no-std) and [`no-std::no-alloc`](https://crates.io/categories/no-std::no-alloc) to the categories in Cargo.toml.

---

I checked what is done in similar conditions and found that serde have some similar features

	[features]
	default = ["std"]
	std = []
	alloc = []

And has these two categories as well: https://github.com/serde-rs/serde/blob/00c4b0cef80557c33fbcd75fcc70dc034720b4df/serde/Cargo.toml#L6