### PR TITLE
Fix `Itertools::k_smallest` on short unfused iterators

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2949,7 +2949,7 @@ pub trait Itertools: Iterator {
     /// itertools::assert_equal(five_smallest, 0..5);
     /// ```
     #[cfg(feature = "use_alloc")]
-    fn k_smallest(mut self, k: usize) -> VecIntoIter<Self::Item>
+    fn k_smallest(self, k: usize) -> VecIntoIter<Self::Item>
     where
         Self: Sized,
         Self::Item: Ord,
@@ -2963,9 +2963,10 @@ pub trait Itertools: Iterator {
             return Vec::new().into_iter();
         }
 
-        let mut heap = self.by_ref().take(k).collect::<BinaryHeap<_>>();
+        let mut iter = self.fuse();
+        let mut heap: BinaryHeap<_> = iter.by_ref().take(k).collect();
 
-        self.for_each(|i| {
+        iter.for_each(|i| {
             debug_assert_eq!(heap.len(), k);
             // Equivalent to heap.push(min(i, heap.pop())) but more efficient.
             // This should be done with a single `.peek_mut().unwrap()` but


### PR DESCRIPTION
I'm shocked! 😲 I found a bug in my favorite method!

In the case of an unfused iterator yielding at most k-1 elements, then None, then other elements, the heap is not k-long and `for_each` is called on the other elements leading `debug_assert_eq` to rightfully panic.

Our recent variants of `k_smallest` do not have this bug (the `.len() ==` check is present)!

Alternatively, iterators could be fused: `let mut iter = iter.fuse();`.

I probably should add a test about this.

**Story:** After recently reviewing #654 where I deeply looked at `k_smallest` and its variants and my really recent #899 where I similarly thought of checking the length of the collected elements before calling `for_each`, I eventually/_luckily_ saw this bug.