### PR TITLE
More generic maps (in `GroupingMap`)

### DIFF
--- a/src/generic_containers.rs
+++ b/src/generic_containers.rs
@@ -1,0 +1,62 @@
+//! **Private** generalizations of containers:
+//! - `Map`: `BTreeMap` and `HashMap` (any hasher).
+
+#![cfg(feature = "use_alloc")]
+
+use alloc::collections::BTreeMap;
+#[cfg(feature = "use_std")]
+use core::hash::{BuildHasher, Hash};
+#[cfg(feature = "use_std")]
+use std::collections::HashMap;
+
+pub trait Map {
+    type Key;
+    type Value;
+    fn insert(&mut self, key: Self::Key, value: Self::Value) -> Option<Self::Value>;
+    fn remove(&mut self, key: &Self::Key) -> Option<Self::Value>;
+    fn entry_or_default(&mut self, key: Self::Key) -> &mut Self::Value
+    where
+        Self::Value: Default;
+}
+
+impl<K, V> Map for BTreeMap<K, V>
+where
+    K: Ord,
+{
+    type Key = K;
+    type Value = V;
+    fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.insert(key, value)
+    }
+    fn remove(&mut self, key: &K) -> Option<V> {
+        self.remove(key)
+    }
+    fn entry_or_default(&mut self, key: K) -> &mut V
+    where
+        V: Default,
+    {
+        self.entry(key).or_default()
+    }
+}
+
+#[cfg(feature = "use_std")]
+impl<K, V, S> Map for HashMap<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    type Key = K;
+    type Value = V;
+    fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.insert(key, value)
+    }
+    fn remove(&mut self, key: &K) -> Option<V> {
+        self.remove(key)
+    }
+    fn entry_or_default(&mut self, key: K) -> &mut V
+    where
+        V: Default,
+    {
+        self.entry(key).or_default()
+    }
+}

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -257,16 +257,7 @@ where
     where
         C: Default + Extend<V>,
     {
-        let mut destination_map = HashMap::new();
-
-        self.iter.for_each(|(key, val)| {
-            destination_map
-                .entry(key)
-                .or_insert_with(C::default)
-                .extend(Some(val));
-        });
-
-        destination_map
+        self.collect_in(HashMap::new())
     }
 
     /// Groups elements from the `GroupingMap` source by key and finds the maximum of each group.
@@ -662,5 +653,18 @@ where
             },
             map,
         )
+    }
+
+    /// Apply [`collect`](Self::collect) with a provided map.
+    pub fn collect_in<C, M>(self, mut map: M) -> M
+    where
+        C: Default + Extend<V>,
+        M: Map<Key = K, Value = C>,
+    {
+        self.iter.for_each(|(key, val)| {
+            map.entry_or_default(key).extend(Some(val));
+        });
+
+        map
     }
 }

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -570,6 +570,28 @@ where
     K: Eq,
 {
     /// Apply [`aggregate`](Self::aggregate) with a provided map.
+    ///
+    /// ```
+    /// use std::collections::BTreeMap;
+    /// use itertools::Itertools;
+    ///
+    /// let data = vec![2, 8, 5, 7, 9, 0, 4, 10];
+    /// let lookup = data.into_iter()
+    ///     .into_grouping_map_by(|&n| n % 4)
+    ///     .aggregate_in(|acc, _key, val| {
+    ///         if val == 0 || val == 10 {
+    ///             None
+    ///         } else {
+    ///             Some(acc.unwrap_or(0) + val)
+    ///         }
+    ///     }, BTreeMap::new());
+    ///
+    /// assert_eq!(lookup[&0], 4);        // 0 resets the accumulator so only 4 is summed
+    /// assert_eq!(lookup[&1], 5 + 9);
+    /// assert_eq!(lookup.get(&2), None); // 10 resets the accumulator and nothing is summed afterward
+    /// assert_eq!(lookup[&3], 7);
+    /// assert_eq!(lookup.len(), 3);      // The final keys are only 0, 1 and 2
+    /// ```
     pub fn aggregate_in<FO, R, M>(self, mut operation: FO, mut map: M) -> M
     where
         FO: FnMut(Option<R>, &K, V) -> Option<R>,
@@ -586,6 +608,28 @@ where
     }
 
     /// Apply [`fold_with`](Self::fold_with) with a provided map.
+    ///
+    /// ```
+    /// use std::collections::BTreeMap;
+    /// use itertools::Itertools;
+    ///
+    /// #[derive(Debug, Default)]
+    /// struct Accumulator {
+    ///   acc: usize,
+    /// }
+    ///
+    /// let lookup = (1..=7)
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .fold_with_in(|_key, _val| Default::default(), |Accumulator { acc }, _key, val| {
+    ///         let acc = acc + val;
+    ///         Accumulator { acc }
+    ///      }, BTreeMap::new());
+    ///
+    /// assert_eq!(lookup[&0].acc, 3 + 6);
+    /// assert_eq!(lookup[&1].acc, 1 + 4 + 7);
+    /// assert_eq!(lookup[&2].acc, 2 + 5);
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn fold_with_in<FI, FO, R, M>(self, mut init: FI, mut operation: FO, map: M) -> M
     where
         FI: FnMut(&K, &V) -> R,
@@ -602,6 +646,20 @@ where
     }
 
     /// Apply [`fold`](Self::fold) with a provided map.
+    ///
+    /// ```
+    /// use std::collections::BTreeMap;
+    /// use itertools::Itertools;
+    ///
+    /// let lookup = (1..=7)
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .fold_in(0, |acc, _key, val| acc + val, BTreeMap::new());
+    ///
+    /// assert_eq!(lookup[&0], 3 + 6);
+    /// assert_eq!(lookup[&1], 1 + 4 + 7);
+    /// assert_eq!(lookup[&2], 2 + 5);
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn fold_in<FO, R, M>(self, init: R, operation: FO, map: M) -> M
     where
         R: Clone,
@@ -612,6 +670,20 @@ where
     }
 
     /// Apply [`reduce`](Self::reduce) with a provided map.
+    ///
+    /// ```
+    /// use std::collections::BTreeMap;
+    /// use itertools::Itertools;
+    ///
+    /// let lookup = (1..=7)
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .reduce_in(|acc, _key, val| acc + val, BTreeMap::new());
+    ///
+    /// assert_eq!(lookup[&0], 3 + 6);
+    /// assert_eq!(lookup[&1], 1 + 4 + 7);
+    /// assert_eq!(lookup[&2], 2 + 5);
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn reduce_in<FO, M>(self, mut operation: FO, map: M) -> M
     where
         FO: FnMut(V, &K, V) -> V,
@@ -629,6 +701,20 @@ where
     }
 
     /// Apply [`collect`](Self::collect) with a provided map.
+    ///
+    /// ```
+    /// use std::collections::{BTreeMap, BTreeSet};
+    /// use itertools::Itertools;
+    ///
+    /// let lookup = vec![0, 1, 2, 3, 4, 5, 6, 2, 3, 6].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .collect_in::<BTreeSet<_>, _>(BTreeMap::new());
+    ///
+    /// assert_eq!(lookup[&0], vec![0, 3, 6].into_iter().collect::<BTreeSet<_>>());
+    /// assert_eq!(lookup[&1], vec![1, 4].into_iter().collect::<BTreeSet<_>>());
+    /// assert_eq!(lookup[&2], vec![2, 5].into_iter().collect::<BTreeSet<_>>());
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn collect_in<C, M>(self, mut map: M) -> M
     where
         C: Default + Extend<V>,
@@ -642,6 +728,20 @@ where
     }
 
     /// Apply [`max`](Self::max) with a provided map.
+    ///
+    /// ```
+    /// use std::collections::BTreeMap;
+    /// use itertools::Itertools;
+    ///
+    /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .max_in(BTreeMap::new());
+    ///
+    /// assert_eq!(lookup[&0], 12);
+    /// assert_eq!(lookup[&1], 7);
+    /// assert_eq!(lookup[&2], 8);
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn max_in<M>(self, map: M) -> M
     where
         V: Ord,
@@ -651,6 +751,20 @@ where
     }
 
     /// Apply [`max_by`](Self::max_by) with a provided map.
+    ///
+    /// ```
+    /// use std::collections::BTreeMap;
+    /// use itertools::Itertools;
+    ///
+    /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .max_by_in(|_key, x, y| y.cmp(x), BTreeMap::new());
+    ///
+    /// assert_eq!(lookup[&0], 3);
+    /// assert_eq!(lookup[&1], 1);
+    /// assert_eq!(lookup[&2], 5);
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn max_by_in<F, M>(self, mut compare: F, map: M) -> M
     where
         F: FnMut(&K, &V, &V) -> Ordering,
@@ -666,6 +780,20 @@ where
     }
 
     /// Apply [`max_by_key`](Self::max_by_key) with a provided map.
+    ///
+    /// ```
+    /// use std::collections::BTreeMap;
+    /// use itertools::Itertools;
+    ///
+    /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .max_by_key_in(|_key, &val| val % 4, BTreeMap::new());
+    ///
+    /// assert_eq!(lookup[&0], 3);
+    /// assert_eq!(lookup[&1], 7);
+    /// assert_eq!(lookup[&2], 5);
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn max_by_key_in<F, CK, M>(self, mut f: F, map: M) -> M
     where
         F: FnMut(&K, &V) -> CK,
@@ -676,6 +804,20 @@ where
     }
 
     /// Apply [`min`](Self::min) with a provided map.
+    ///
+    /// ```
+    /// use std::collections::BTreeMap;
+    /// use itertools::Itertools;
+    ///
+    /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .min_in(BTreeMap::new());
+    ///
+    /// assert_eq!(lookup[&0], 3);
+    /// assert_eq!(lookup[&1], 1);
+    /// assert_eq!(lookup[&2], 5);
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn min_in<M>(self, map: M) -> M
     where
         V: Ord,
@@ -685,6 +827,20 @@ where
     }
 
     /// Apply [`min_by`](Self::min_by) with a provided map.
+    ///
+    /// ```
+    /// use std::collections::BTreeMap;
+    /// use itertools::Itertools;
+    ///
+    /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .min_by_in(|_key, x, y| y.cmp(x), BTreeMap::new());
+    ///
+    /// assert_eq!(lookup[&0], 12);
+    /// assert_eq!(lookup[&1], 7);
+    /// assert_eq!(lookup[&2], 8);
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn min_by_in<F, M>(self, mut compare: F, map: M) -> M
     where
         F: FnMut(&K, &V, &V) -> Ordering,
@@ -700,6 +856,20 @@ where
     }
 
     /// Apply [`min_by_key`](Self::min_by_key) with a provided map.
+    ///
+    /// ```
+    /// use std::collections::BTreeMap;
+    /// use itertools::Itertools;
+    ///
+    /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .min_by_key_in(|_key, &val| val % 4, BTreeMap::new());
+    ///
+    /// assert_eq!(lookup[&0], 12);
+    /// assert_eq!(lookup[&1], 4);
+    /// assert_eq!(lookup[&2], 8);
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn min_by_key_in<F, CK, M>(self, mut f: F, map: M) -> M
     where
         F: FnMut(&K, &V) -> CK,
@@ -710,6 +880,21 @@ where
     }
 
     /// Apply [`minmax`](Self::minmax) with a provided map.
+    ///
+    /// ```
+    /// use std::collections::BTreeMap;
+    /// use itertools::Itertools;
+    /// use itertools::MinMaxResult::{OneElement, MinMax};
+    ///
+    /// let lookup = vec![1, 3, 4, 5, 7, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .minmax_in(BTreeMap::new());
+    ///
+    /// assert_eq!(lookup[&0], MinMax(3, 12));
+    /// assert_eq!(lookup[&1], MinMax(1, 7));
+    /// assert_eq!(lookup[&2], OneElement(5));
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn minmax_in<M>(self, map: M) -> M
     where
         V: Ord,
@@ -719,6 +904,21 @@ where
     }
 
     /// Apply [`minmax_by`](Self::minmax_by) with a provided map.
+    ///
+    /// ```
+    /// use std::collections::BTreeMap;
+    /// use itertools::Itertools;
+    /// use itertools::MinMaxResult::{OneElement, MinMax};
+    ///
+    /// let lookup = vec![1, 3, 4, 5, 7, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .minmax_by_in(|_key, x, y| y.cmp(x), BTreeMap::new());
+    ///
+    /// assert_eq!(lookup[&0], MinMax(12, 3));
+    /// assert_eq!(lookup[&1], MinMax(7, 1));
+    /// assert_eq!(lookup[&2], OneElement(5));
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn minmax_by_in<F, M>(self, mut compare: F, map: M) -> M
     where
         F: FnMut(&K, &V, &V) -> Ordering,
@@ -752,6 +952,21 @@ where
     }
 
     /// Apply [`minmax_by_key`](Self::minmax_by_key) with a provided map.
+    ///
+    /// ```
+    /// use std::collections::BTreeMap;
+    /// use itertools::Itertools;
+    /// use itertools::MinMaxResult::{OneElement, MinMax};
+    ///
+    /// let lookup = vec![1, 3, 4, 5, 7, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .minmax_by_key_in(|_key, &val| val % 4, BTreeMap::new());
+    ///
+    /// assert_eq!(lookup[&0], MinMax(12, 3));
+    /// assert_eq!(lookup[&1], MinMax(4, 7));
+    /// assert_eq!(lookup[&2], OneElement(5));
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn minmax_by_key_in<F, CK, M>(self, mut f: F, map: M) -> M
     where
         F: FnMut(&K, &V) -> CK,
@@ -762,6 +977,20 @@ where
     }
 
     /// Apply [`sum`](Self::sum) with a provided map.
+    ///
+    /// ```
+    /// use std::collections::BTreeMap;
+    /// use itertools::Itertools;
+    ///
+    /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .sum_in(BTreeMap::new());
+    ///
+    /// assert_eq!(lookup[&0], 3 + 9 + 12);
+    /// assert_eq!(lookup[&1], 1 + 4 + 7);
+    /// assert_eq!(lookup[&2], 5 + 8);
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn sum_in<M>(self, map: M) -> M
     where
         V: Add<V, Output = V>,
@@ -771,6 +1000,20 @@ where
     }
 
     /// Apply [`product`](Self::product) with a provided map.
+    ///
+    /// ```
+    /// use std::collections::BTreeMap;
+    /// use itertools::Itertools;
+    ///
+    /// let lookup = vec![1, 3, 4, 5, 7, 8, 9, 12].into_iter()
+    ///     .into_grouping_map_by(|&n| n % 3)
+    ///     .product_in(BTreeMap::new());
+    ///
+    /// assert_eq!(lookup[&0], 3 * 9 * 12);
+    /// assert_eq!(lookup[&1], 1 * 4 * 7);
+    /// assert_eq!(lookup[&2], 5 * 8);
+    /// assert_eq!(lookup.len(), 3);
+    /// ```
     pub fn product_in<M>(self, map: M) -> M
     where
         V: Mul<V, Output = V>,

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -534,7 +534,7 @@ where
     where
         V: Add<V, Output = V>,
     {
-        self.reduce(|acc, _, val| acc + val)
+        self.sum_in(HashMap::new())
     }
 
     /// Groups elements from the `GroupingMap` source by key and multiply them.
@@ -759,5 +759,14 @@ where
         M: Map<Key = K, Value = MinMaxResult<V>>,
     {
         self.minmax_by_in(|key, v1, v2| f(key, v1).cmp(&f(key, v2)), map)
+    }
+
+    /// Apply [`sum`](Self::sum) with a provided map.
+    pub fn sum_in<M>(self, map: M) -> M
+    where
+        V: Add<V, Output = V>,
+        M: Map<Key = K, Value = V>,
+    {
+        self.reduce_in(|acc, _, val| acc + val, map)
     }
 }

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -560,7 +560,7 @@ where
     where
         V: Mul<V, Output = V>,
     {
-        self.reduce(|acc, _, val| acc * val)
+        self.product_in(HashMap::new())
     }
 }
 
@@ -768,5 +768,14 @@ where
         M: Map<Key = K, Value = V>,
     {
         self.reduce_in(|acc, _, val| acc + val, map)
+    }
+
+    /// Apply [`product`](Self::product) with a provided map.
+    pub fn product_in<M>(self, map: M) -> M
+    where
+        V: Mul<V, Output = V>,
+        M: Map<Key = K, Value = V>,
+    {
+        self.reduce_in(|acc, _, val| acc * val, map)
     }
 }

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -219,16 +219,11 @@ where
     /// assert_eq!(lookup[&2], 2 + 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn reduce<FO>(self, mut operation: FO) -> HashMap<K, V>
+    pub fn reduce<FO>(self, operation: FO) -> HashMap<K, V>
     where
         FO: FnMut(V, &K, V) -> V,
     {
-        self.aggregate(|acc, key, val| {
-            Some(match acc {
-                Some(acc) => operation(acc, key, val),
-                None => val,
-            })
-        })
+        self.reduce_in(operation, HashMap::new())
     }
 
     /// See [`.reduce()`](GroupingMap::reduce).
@@ -650,5 +645,22 @@ where
         M: Map<Key = K, Value = R>,
     {
         self.fold_with_in(|_, _| init.clone(), operation, map)
+    }
+
+    /// Apply [`reduce`](Self::reduce) with a provided map.
+    pub fn reduce_in<FO, M>(self, mut operation: FO, map: M) -> M
+    where
+        FO: FnMut(V, &K, V) -> V,
+        M: Map<Key = K, Value = V>,
+    {
+        self.aggregate_in(
+            |acc, key, val| {
+                Some(match acc {
+                    Some(acc) => operation(acc, key, val),
+                    None => val,
+                })
+            },
+            map,
+        )
     }
 }

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -282,7 +282,7 @@ where
     where
         V: Ord,
     {
-        self.max_by(|_, v1, v2| V::cmp(v1, v2))
+        self.max_in(HashMap::new())
     }
 
     /// Groups elements from the `GroupingMap` source by key and finds the maximum of each group
@@ -304,14 +304,11 @@ where
     /// assert_eq!(lookup[&2], 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn max_by<F>(self, mut compare: F) -> HashMap<K, V>
+    pub fn max_by<F>(self, compare: F) -> HashMap<K, V>
     where
         F: FnMut(&K, &V, &V) -> Ordering,
     {
-        self.reduce(|acc, key, val| match compare(key, &acc, &val) {
-            Ordering::Less | Ordering::Equal => val,
-            Ordering::Greater => acc,
-        })
+        self.max_by_in(compare, HashMap::new())
     }
 
     /// Groups elements from the `GroupingMap` source by key and finds the element of each group
@@ -333,12 +330,12 @@ where
     /// assert_eq!(lookup[&2], 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn max_by_key<F, CK>(self, mut f: F) -> HashMap<K, V>
+    pub fn max_by_key<F, CK>(self, f: F) -> HashMap<K, V>
     where
         F: FnMut(&K, &V) -> CK,
         CK: Ord,
     {
-        self.max_by(|key, v1, v2| f(key, v1).cmp(&f(key, v2)))
+        self.max_by_key_in(f, HashMap::new())
     }
 
     /// Groups elements from the `GroupingMap` source by key and finds the minimum of each group.
@@ -666,5 +663,39 @@ where
         });
 
         map
+    }
+
+    /// Apply [`max`](Self::max) with a provided map.
+    pub fn max_in<M>(self, map: M) -> M
+    where
+        V: Ord,
+        M: Map<Key = K, Value = V>,
+    {
+        self.max_by_in(|_, v1, v2| V::cmp(v1, v2), map)
+    }
+
+    /// Apply [`max_by`](Self::max_by) with a provided map.
+    pub fn max_by_in<F, M>(self, mut compare: F, map: M) -> M
+    where
+        F: FnMut(&K, &V, &V) -> Ordering,
+        M: Map<Key = K, Value = V>,
+    {
+        self.reduce_in(
+            |acc, key, val| match compare(key, &acc, &val) {
+                Ordering::Less | Ordering::Equal => val,
+                Ordering::Greater => acc,
+            },
+            map,
+        )
+    }
+
+    /// Apply [`max_by_key`](Self::max_by_key) with a provided map.
+    pub fn max_by_key_in<F, CK, M>(self, mut f: F, map: M) -> M
+    where
+        F: FnMut(&K, &V) -> CK,
+        CK: Ord,
+        M: Map<Key = K, Value = V>,
+    {
+        self.max_by_in(|key, v1, v2| f(key, v1).cmp(&f(key, v2)), map)
     }
 }

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -58,6 +58,12 @@ pub type GroupingMapBy<I, F> = GroupingMap<MapForGrouping<I, F>>;
 /// It groups elements by their key and at the same time fold each group
 /// using some aggregating operation.
 ///
+/// Each method have a `_in`-suffixed version where you can provide a map other than
+/// `HashMap::new()` such as:
+/// - `BTreeMap::new()` when the values are `Ord` and not necessarily `Hash + Eq`.
+/// - `HashMap::default()` to use a different hasher.
+/// - `HashMap::with_capacity(100)` to pre-allocate.
+///
 /// No method on this struct performs temporary allocations.
 #[derive(Clone, Debug)]
 #[must_use = "GroupingMap is lazy and do nothing unless consumed"]

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -1,11 +1,13 @@
-#![cfg(feature = "use_std")]
+#![cfg(feature = "use_alloc")]
 
 use crate::{
     adaptors::map::{MapSpecialCase, MapSpecialCaseFn},
     MinMaxResult,
 };
 use std::cmp::Ordering;
+#[cfg(feature = "use_std")]
 use std::collections::HashMap;
+#[cfg(feature = "use_std")]
 use std::hash::Hash;
 use std::iter::Iterator;
 use std::ops::{Add, Mul};
@@ -41,7 +43,7 @@ pub(crate) fn new_map_for_grouping<K, I: Iterator, F: FnMut(&I::Item) -> K>(
 pub fn new<I, K, V>(iter: I) -> GroupingMap<I>
 where
     I: Iterator<Item = (K, V)>,
-    K: Hash + Eq,
+    K: Eq,
 {
     GroupingMap { iter }
 }
@@ -62,6 +64,7 @@ pub struct GroupingMap<I> {
     iter: I,
 }
 
+#[cfg(feature = "use_std")]
 impl<I, K, V> GroupingMap<I>
 where
     I: Iterator<Item = (K, V)>,

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -189,7 +189,7 @@ where
         R: Clone,
         FO: FnMut(R, &K, V) -> R,
     {
-        self.fold_with(|_, _| init.clone(), operation)
+        self.fold_in(init, operation, HashMap::new())
     }
 
     /// Groups elements from the `GroupingMap` source by key and applies `operation` to the elements
@@ -640,5 +640,15 @@ where
             },
             map,
         )
+    }
+
+    /// Apply [`fold`](Self::fold) with a provided map.
+    pub fn fold_in<FO, R, M>(self, init: R, operation: FO, map: M) -> M
+    where
+        R: Clone,
+        FO: FnMut(R, &K, V) -> R,
+        M: Map<Key = K, Value = R>,
+    {
+        self.fold_with_in(|_, _| init.clone(), operation, map)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,8 @@ mod extrema_set;
 mod flatten_ok;
 mod format;
 #[cfg(feature = "use_alloc")]
+mod generic_containers;
+#[cfg(feature = "use_alloc")]
 mod group_map;
 #[cfg(feature = "use_alloc")]
 mod groupbylazy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ pub mod structs {
     pub use crate::groupbylazy::GroupBy;
     #[cfg(feature = "use_alloc")]
     pub use crate::groupbylazy::{Chunk, ChunkBy, Chunks, Group, Groups, IntoChunks};
-    #[cfg(feature = "use_std")]
+    #[cfg(feature = "use_alloc")]
     pub use crate::grouping_map::{GroupingMap, GroupingMapBy};
     pub use crate::intersperse::{Intersperse, IntersperseWith};
     #[cfg(feature = "use_alloc")]
@@ -191,7 +191,7 @@ mod generic_containers;
 mod group_map;
 #[cfg(feature = "use_alloc")]
 mod groupbylazy;
-#[cfg(feature = "use_std")]
+#[cfg(feature = "use_alloc")]
 mod grouping_map;
 mod intersperse;
 #[cfg(feature = "use_alloc")]
@@ -3283,11 +3283,11 @@ pub trait Itertools: Iterator {
     ///
     /// See [`GroupingMap`] for more informations
     /// on what operations are available.
-    #[cfg(feature = "use_std")]
+    #[cfg(feature = "use_alloc")]
     fn into_grouping_map<K, V>(self) -> GroupingMap<Self>
     where
         Self: Iterator<Item = (K, V)> + Sized,
-        K: Hash + Eq,
+        K: Eq,
     {
         grouping_map::new(self)
     }
@@ -3300,11 +3300,11 @@ pub trait Itertools: Iterator {
     ///
     /// See [`GroupingMap`] for more informations
     /// on what operations are available.
-    #[cfg(feature = "use_std")]
+    #[cfg(feature = "use_alloc")]
     fn into_grouping_map_by<K, V, F>(self, key_mapper: F) -> GroupingMapBy<Self, F>
     where
         Self: Iterator<Item = V> + Sized,
-        K: Hash + Eq,
+        K: Eq,
         F: FnMut(&V) -> K,
     {
         grouping_map::new(grouping_map::new_map_for_grouping(self, key_mapper))


### PR DESCRIPTION
At the moment, this is only a proof of concept, but it would close #588 (and eventually solve some issues, see https://github.com/rust-itertools/itertools/labels/generic-container).

- I wrote a straightforward _private_ trait generalizing both `BTreeMap` and `HashMap` (with any hasher).
  Maybe too much methods, or not enough. I will adjust it.
  I don't think we should generalize to more than those two maps but I guess it's possible.
- Changed `use_std` to `use_alloc` where possible (because `BTreeMap` only needs `use_alloc` while `HashMap` needs `use_std`) and relaxed some `Eq + Hash` bounds.
- I added a alternative `aggregate_in` to `aggregate` which _takes one more argument_:
  any empty map (or one we would `.clear()`).

The last point is where I struggled the most but that's pretty much the only real possibility because there is so many possibilities of initializations: `BTreeMap::new()`, `HashMap::new()`, `HashMap::default()` for some hashers, and `with_capacity` shenanigans. And I think it's the most general solution (I can even imagine one single `HashMap` being used multiple times to avoid reallocations).

This could extend to other areas than just `GroupingMap`, and a `Set` trait could be wrote to generalize `BTreeSet` and `HashSet` but it's for another PR.

For now, I would like some feedback.

CI currently fails because of temporary unused imports.