### PR TITLE
Deprecate `GroupingMap::fold_first` for `reduce`

### DIFF
--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -220,14 +220,14 @@ where
     ///
     /// let lookup = (1..=7)
     ///     .into_grouping_map_by(|&n| n % 3)
-    ///     .fold_first(|acc, _key, val| acc + val);
+    ///     .reduce(|acc, _key, val| acc + val);
     ///
     /// assert_eq!(lookup[&0], 3 + 6);
     /// assert_eq!(lookup[&1], 1 + 4 + 7);
     /// assert_eq!(lookup[&2], 2 + 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn fold_first<FO>(self, mut operation: FO) -> HashMap<K, V>
+    pub fn reduce<FO>(self, mut operation: FO) -> HashMap<K, V>
     where
         FO: FnMut(V, &K, V) -> V,
     {
@@ -237,6 +237,15 @@ where
                 None => val,
             })
         })
+    }
+
+    /// See [`.reduce()`](GroupingMap::reduce).
+    #[deprecated(note = "Use .reduce() instead", since = "0.13.0")]
+    pub fn fold_first<FO>(self, operation: FO) -> HashMap<K, V>
+    where
+        FO: FnMut(V, &K, V) -> V,
+    {
+        self.reduce(operation)
     }
 
     /// Groups elements from the `GroupingMap` source by key and collects the elements of each group in
@@ -321,7 +330,7 @@ where
     where
         F: FnMut(&K, &V, &V) -> Ordering,
     {
-        self.fold_first(|acc, key, val| match compare(key, &acc, &val) {
+        self.reduce(|acc, key, val| match compare(key, &acc, &val) {
             Ordering::Less | Ordering::Equal => val,
             Ordering::Greater => acc,
         })
@@ -402,7 +411,7 @@ where
     where
         F: FnMut(&K, &V, &V) -> Ordering,
     {
-        self.fold_first(|acc, key, val| match compare(key, &acc, &val) {
+        self.reduce(|acc, key, val| match compare(key, &acc, &val) {
             Ordering::Less | Ordering::Equal => acc,
             Ordering::Greater => val,
         })
@@ -553,7 +562,7 @@ where
 
     /// Groups elements from the `GroupingMap` source by key and sums them.
     ///
-    /// This is just a shorthand for `self.fold_first(|acc, _, val| acc + val)`.
+    /// This is just a shorthand for `self.reduce(|acc, _, val| acc + val)`.
     /// It is more limited than `Iterator::sum` since it doesn't use the `Sum` trait.
     ///
     /// Returns a `HashMap` associating the key of each group with the sum of that group's elements.
@@ -574,12 +583,12 @@ where
     where
         V: Add<V, Output = V>,
     {
-        self.fold_first(|acc, _, val| acc + val)
+        self.reduce(|acc, _, val| acc + val)
     }
 
     /// Groups elements from the `GroupingMap` source by key and multiply them.
     ///
-    /// This is just a shorthand for `self.fold_first(|acc, _, val| acc * val)`.
+    /// This is just a shorthand for `self.reduce(|acc, _, val| acc * val)`.
     /// It is more limited than `Iterator::product` since it doesn't use the `Product` trait.
     ///
     /// Returns a `HashMap` associating the key of each group with the product of that group's elements.
@@ -600,6 +609,6 @@ where
     where
         V: Mul<V, Output = V>,
     {
-        self.fold_first(|acc, _, val| acc * val)
+        self.reduce(|acc, _, val| acc * val)
     }
 }

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -1495,16 +1495,16 @@ quickcheck! {
         }
     }
 
-    fn correct_grouping_map_by_fold_first_modulo_key(a: Vec<u8>, modulo: u8) -> () {
+    fn correct_grouping_map_by_reduce_modulo_key(a: Vec<u8>, modulo: u8) -> () {
         let modulo = if modulo == 0 { 1 } else { modulo } as u64; // Avoid `% 0`
         let lookup = a.iter().map(|&b| b as u64) // Avoid overflows
             .into_grouping_map_by(|i| i % modulo)
-            .fold_first(|acc, &key, val| {
+            .reduce(|acc, &key, val| {
                 assert!(val % modulo == key);
                 acc + val
             });
 
-        // TODO: Swap `fold1` with stdlib's `fold_first` when it's stabilized
+        // TODO: Swap `fold1` with stdlib's `reduce` when it's stabilized
         let group_map_lookup = a.iter()
             .map(|&b| b as u64)
             .map(|i| (i % modulo, i))


### PR DESCRIPTION
I just became aware of https://github.com/rust-lang/rust/issues/68125 and https://github.com/rust-lang/rust/pull/79805 and the names that were previously considered.

So we have:
- `Itertools::fold1` (deprecated) which basically is `Iterator::reduce`.
- `Itertools::tree_fold1` deprecated/renamed `tree_reduce` in #895 (not merged yet).
- And I now suggest to **deprecate `GroupingMap::fold_first` and rename it `reduce`** (before I finish #901 where I might have wrote a new `fold_first_in` instead of `reduce_in`).

What a _naming mess!_

Hopefully, we might be able to remove all three deprecated methods at the same time and close this page once and for all.