### PR TITLE
More generic maps in `GroupingMap` (v2)

### DIFF
--- a/src/generic_containers.rs
+++ b/src/generic_containers.rs
@@ -1,0 +1,94 @@
+//! **Private** generalizations of containers:
+//! - `Map`: `BTreeMap`, `HashMap` (any hasher) and _unordered_ `Vec`.
+
+#![cfg(feature = "use_alloc")]
+
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
+#[cfg(feature = "use_std")]
+use core::hash::{BuildHasher, Hash};
+#[cfg(feature = "use_std")]
+use std::collections::HashMap;
+
+pub trait Map {
+    type Key;
+    type Value;
+    fn insert(&mut self, key: Self::Key, value: Self::Value) -> Option<Self::Value>;
+    fn remove(&mut self, key: &Self::Key) -> Option<Self::Value>;
+    fn entry_or_default(&mut self, key: Self::Key) -> &mut Self::Value
+    where
+        Self::Value: Default;
+}
+
+impl<K, V> Map for BTreeMap<K, V>
+where
+    K: Ord,
+{
+    type Key = K;
+    type Value = V;
+    fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.insert(key, value)
+    }
+    fn remove(&mut self, key: &K) -> Option<V> {
+        self.remove(key)
+    }
+    fn entry_or_default(&mut self, key: K) -> &mut V
+    where
+        V: Default,
+    {
+        self.entry(key).or_default()
+    }
+}
+
+#[cfg(feature = "use_std")]
+impl<K, V, S> Map for HashMap<K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    type Key = K;
+    type Value = V;
+    fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.insert(key, value)
+    }
+    fn remove(&mut self, key: &K) -> Option<V> {
+        self.remove(key)
+    }
+    fn entry_or_default(&mut self, key: K) -> &mut V
+    where
+        V: Default,
+    {
+        self.entry(key).or_default()
+    }
+}
+
+impl<K, V> Map for Vec<(K, V)>
+where
+    K: Eq,
+{
+    type Key = K;
+    type Value = V;
+    fn insert(&mut self, key: K, value: V) -> Option<V> {
+        match self.iter_mut().find(|(k, _)| k == &key) {
+            Some((_, v)) => Some(core::mem::replace(v, value)),
+            None => {
+                self.push((key, value));
+                None
+            }
+        }
+    }
+    fn remove(&mut self, key: &K) -> Option<V> {
+        let index = self.iter().position(|(k, _)| k == key)?;
+        Some(self.swap_remove(index).1)
+    }
+    fn entry_or_default(&mut self, key: K) -> &mut V
+    where
+        V: Default,
+    {
+        let index = self.iter().position(|(k, _)| k == &key).unwrap_or_else(|| {
+            self.push((key, V::default()));
+            self.len() - 1
+        });
+        &mut self[index].1
+    }
+}

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -144,12 +144,8 @@ where
     {
         let mut destination_map = self.map;
 
-        self.iter.for_each(|(key, val)| {
-            let acc = destination_map.remove(&key);
-            if let Some(op_res) = operation(acc, &key, val) {
-                destination_map.insert(key, op_res);
-            }
-        });
+        self.iter
+            .for_each(|(key, val)| destination_map.aggregate(key, val, &mut operation));
 
         destination_map
     }

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -1,12 +1,11 @@
-#![cfg(feature = "use_std")]
+#![cfg(feature = "use_alloc")]
 
 use crate::{
     adaptors::map::{MapSpecialCase, MapSpecialCaseFn},
+    generic_containers::Map,
     MinMaxResult,
 };
 use std::cmp::Ordering;
-use std::collections::HashMap;
-use std::hash::Hash;
 use std::iter::Iterator;
 use std::ops::{Add, Mul};
 
@@ -37,41 +36,43 @@ pub(crate) fn new_map_for_grouping<K, I: Iterator, F: FnMut(&I::Item) -> K>(
     }
 }
 
-/// Creates a new `GroupingMap` from `iter`
-pub fn new<I, K, V>(iter: I) -> GroupingMap<I>
+pub fn new_in<I, K, V, M>(iter: I, map: M) -> GroupingGenericMap<I, M>
 where
     I: Iterator<Item = (K, V)>,
-    K: Hash + Eq,
+    K: Eq,
+    M: Map<Key = K>,
 {
-    GroupingMap { iter }
+    GroupingGenericMap { iter, map }
 }
 
-/// `GroupingMapBy` is an intermediate struct for efficient group-and-fold operations.
+/// `GroupingGenericMapBy` is an intermediate struct for efficient group-and-fold operations.
 ///
-/// See [`GroupingMap`] for more informations.
-pub type GroupingMapBy<I, F> = GroupingMap<MapForGrouping<I, F>>;
+/// See [`GroupingGenericMap`] for more informations.
+pub type GroupingGenericMapBy<I, F, M> = GroupingGenericMap<MapForGrouping<I, F>, M>;
 
-/// `GroupingMap` is an intermediate struct for efficient group-and-fold operations.
+/// `GroupingGenericMap` is an intermediate struct for efficient group-and-fold operations.
 /// It groups elements by their key and at the same time fold each group
 /// using some aggregating operation.
 ///
 /// No method on this struct performs temporary allocations.
 #[derive(Clone, Debug)]
-#[must_use = "GroupingMap is lazy and do nothing unless consumed"]
-pub struct GroupingMap<I> {
+#[must_use = "GroupingGenericMap is lazy and do nothing unless consumed"]
+pub struct GroupingGenericMap<I, M> {
     iter: I,
+    map: M,
 }
 
-impl<I, K, V> GroupingMap<I>
+impl<I, K, V, M> GroupingGenericMap<I, M>
 where
     I: Iterator<Item = (K, V)>,
-    K: Hash + Eq,
+    K: Eq,
+    M: Map<Key = K>,
 {
-    /// This is the generic way to perform any operation on a `GroupingMap`.
+    /// This is the generic way to perform any operation on a `GroupingGenericMap`.
     /// It's suggested to use this method only to implement custom operations
     /// when the already provided ones are not enough.
     ///
-    /// Groups elements from the `GroupingMap` source by key and applies `operation` to the elements
+    /// Groups elements from the `GroupingGenericMap` source by key and applies `operation` to the elements
     /// of each group sequentially, passing the previously accumulated value, a reference to the key
     /// and the current element as arguments, and stores the results in an `HashMap`.
     ///
@@ -107,11 +108,12 @@ where
     /// assert_eq!(lookup[&3], 7);
     /// assert_eq!(lookup.len(), 3);      // The final keys are only 0, 1 and 2
     /// ```
-    pub fn aggregate<FO, R>(self, mut operation: FO) -> HashMap<K, R>
+    pub fn aggregate<FO, R>(self, mut operation: FO) -> M
     where
         FO: FnMut(Option<R>, &K, V) -> Option<R>,
+        M: Map<Value = R>,
     {
-        let mut destination_map = HashMap::new();
+        let mut destination_map = self.map;
 
         self.iter.for_each(|(key, val)| {
             let acc = destination_map.remove(&key);
@@ -123,7 +125,7 @@ where
         destination_map
     }
 
-    /// Groups elements from the `GroupingMap` source by key and applies `operation` to the elements
+    /// Groups elements from the `GroupingGenericMap` source by key and applies `operation` to the elements
     /// of each group sequentially, passing the previously accumulated value, a reference to the key
     /// and the current element as arguments, and stores the results in a new map.
     ///
@@ -156,10 +158,11 @@ where
     /// assert_eq!(lookup[&2].acc, 2 + 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn fold_with<FI, FO, R>(self, mut init: FI, mut operation: FO) -> HashMap<K, R>
+    pub fn fold_with<FI, FO, R>(self, mut init: FI, mut operation: FO) -> M
     where
         FI: FnMut(&K, &V) -> R,
         FO: FnMut(R, &K, V) -> R,
+        M: Map<Value = R>,
     {
         self.aggregate(|acc, key, val| {
             let acc = acc.unwrap_or_else(|| init(key, &val));
@@ -167,7 +170,7 @@ where
         })
     }
 
-    /// Groups elements from the `GroupingMap` source by key and applies `operation` to the elements
+    /// Groups elements from the `GroupingGenericMap` source by key and applies `operation` to the elements
     /// of each group sequentially, passing the previously accumulated value, a reference to the key
     /// and the current element as arguments, and stores the results in a new map.
     ///
@@ -192,15 +195,16 @@ where
     /// assert_eq!(lookup[&2], 2 + 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn fold<FO, R>(self, init: R, operation: FO) -> HashMap<K, R>
+    pub fn fold<FO, R>(self, init: R, operation: FO) -> M
     where
         R: Clone,
         FO: FnMut(R, &K, V) -> R,
+        M: Map<Value = R>,
     {
         self.fold_with(|_, _| init.clone(), operation)
     }
 
-    /// Groups elements from the `GroupingMap` source by key and applies `operation` to the elements
+    /// Groups elements from the `GroupingGenericMap` source by key and applies `operation` to the elements
     /// of each group sequentially, passing the previously accumulated value, a reference to the key
     /// and the current element as arguments, and stores the results in a new map.
     ///
@@ -213,7 +217,7 @@ where
     ///
     /// Return a `HashMap` associating the key of each group with the result of folding that group's elements.
     ///
-    /// [`fold`]: GroupingMap::fold
+    /// [`fold`]: GroupingGenericMap::fold
     ///
     /// ```
     /// use itertools::Itertools;
@@ -227,9 +231,10 @@ where
     /// assert_eq!(lookup[&2], 2 + 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn reduce<FO>(self, mut operation: FO) -> HashMap<K, V>
+    pub fn reduce<FO>(self, mut operation: FO) -> M
     where
         FO: FnMut(V, &K, V) -> V,
+        M: Map<Value = V>,
     {
         self.aggregate(|acc, key, val| {
             Some(match acc {
@@ -239,16 +244,17 @@ where
         })
     }
 
-    /// See [`.reduce()`](GroupingMap::reduce).
+    /// See [`.reduce()`](GroupingGenericMap::reduce).
     #[deprecated(note = "Use .reduce() instead", since = "0.13.0")]
-    pub fn fold_first<FO>(self, operation: FO) -> HashMap<K, V>
+    pub fn fold_first<FO>(self, operation: FO) -> M
     where
         FO: FnMut(V, &K, V) -> V,
+        M: Map<Value = V>,
     {
         self.reduce(operation)
     }
 
-    /// Groups elements from the `GroupingMap` source by key and collects the elements of each group in
+    /// Groups elements from the `GroupingGenericMap` source by key and collects the elements of each group in
     /// an instance of `C`. The iteration order is preserved when inserting elements.
     ///
     /// Return a `HashMap` associating the key of each group with the collection containing that group's elements.
@@ -266,23 +272,21 @@ where
     /// assert_eq!(lookup[&2], vec![2, 5].into_iter().collect::<HashSet<_>>());
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn collect<C>(self) -> HashMap<K, C>
+    pub fn collect<C>(self) -> M
     where
         C: Default + Extend<V>,
+        M: Map<Value = C>,
     {
-        let mut destination_map = HashMap::new();
+        let mut destination_map = self.map;
 
         self.iter.for_each(|(key, val)| {
-            destination_map
-                .entry(key)
-                .or_insert_with(C::default)
-                .extend(Some(val));
+            destination_map.entry_or_default(key).extend(Some(val));
         });
 
         destination_map
     }
 
-    /// Groups elements from the `GroupingMap` source by key and finds the maximum of each group.
+    /// Groups elements from the `GroupingGenericMap` source by key and finds the maximum of each group.
     ///
     /// If several elements are equally maximum, the last element is picked.
     ///
@@ -300,14 +304,15 @@ where
     /// assert_eq!(lookup[&2], 8);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn max(self) -> HashMap<K, V>
+    pub fn max(self) -> M
     where
         V: Ord,
+        M: Map<Value = V>,
     {
         self.max_by(|_, v1, v2| V::cmp(v1, v2))
     }
 
-    /// Groups elements from the `GroupingMap` source by key and finds the maximum of each group
+    /// Groups elements from the `GroupingGenericMap` source by key and finds the maximum of each group
     /// with respect to the specified comparison function.
     ///
     /// If several elements are equally maximum, the last element is picked.
@@ -326,9 +331,10 @@ where
     /// assert_eq!(lookup[&2], 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn max_by<F>(self, mut compare: F) -> HashMap<K, V>
+    pub fn max_by<F>(self, mut compare: F) -> M
     where
         F: FnMut(&K, &V, &V) -> Ordering,
+        M: Map<Value = V>,
     {
         self.reduce(|acc, key, val| match compare(key, &acc, &val) {
             Ordering::Less | Ordering::Equal => val,
@@ -336,7 +342,7 @@ where
         })
     }
 
-    /// Groups elements from the `GroupingMap` source by key and finds the element of each group
+    /// Groups elements from the `GroupingGenericMap` source by key and finds the element of each group
     /// that gives the maximum from the specified function.
     ///
     /// If several elements are equally maximum, the last element is picked.
@@ -355,15 +361,16 @@ where
     /// assert_eq!(lookup[&2], 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn max_by_key<F, CK>(self, mut f: F) -> HashMap<K, V>
+    pub fn max_by_key<F, CK>(self, mut f: F) -> M
     where
         F: FnMut(&K, &V) -> CK,
         CK: Ord,
+        M: Map<Value = V>,
     {
         self.max_by(|key, v1, v2| f(key, v1).cmp(&f(key, v2)))
     }
 
-    /// Groups elements from the `GroupingMap` source by key and finds the minimum of each group.
+    /// Groups elements from the `GroupingGenericMap` source by key and finds the minimum of each group.
     ///
     /// If several elements are equally minimum, the first element is picked.
     ///
@@ -381,14 +388,15 @@ where
     /// assert_eq!(lookup[&2], 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn min(self) -> HashMap<K, V>
+    pub fn min(self) -> M
     where
         V: Ord,
+        M: Map<Value = V>,
     {
         self.min_by(|_, v1, v2| V::cmp(v1, v2))
     }
 
-    /// Groups elements from the `GroupingMap` source by key and finds the minimum of each group
+    /// Groups elements from the `GroupingGenericMap` source by key and finds the minimum of each group
     /// with respect to the specified comparison function.
     ///
     /// If several elements are equally minimum, the first element is picked.
@@ -407,9 +415,10 @@ where
     /// assert_eq!(lookup[&2], 8);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn min_by<F>(self, mut compare: F) -> HashMap<K, V>
+    pub fn min_by<F>(self, mut compare: F) -> M
     where
         F: FnMut(&K, &V, &V) -> Ordering,
+        M: Map<Value = V>,
     {
         self.reduce(|acc, key, val| match compare(key, &acc, &val) {
             Ordering::Less | Ordering::Equal => acc,
@@ -417,7 +426,7 @@ where
         })
     }
 
-    /// Groups elements from the `GroupingMap` source by key and finds the element of each group
+    /// Groups elements from the `GroupingGenericMap` source by key and finds the element of each group
     /// that gives the minimum from the specified function.
     ///
     /// If several elements are equally minimum, the first element is picked.
@@ -436,15 +445,16 @@ where
     /// assert_eq!(lookup[&2], 8);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn min_by_key<F, CK>(self, mut f: F) -> HashMap<K, V>
+    pub fn min_by_key<F, CK>(self, mut f: F) -> M
     where
         F: FnMut(&K, &V) -> CK,
         CK: Ord,
+        M: Map<Value = V>,
     {
         self.min_by(|key, v1, v2| f(key, v1).cmp(&f(key, v2)))
     }
 
-    /// Groups elements from the `GroupingMap` source by key and find the maximum and minimum of
+    /// Groups elements from the `GroupingGenericMap` source by key and find the maximum and minimum of
     /// each group.
     ///
     /// If several elements are equally maximum, the last element is picked.
@@ -471,14 +481,15 @@ where
     /// assert_eq!(lookup[&2], OneElement(5));
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn minmax(self) -> HashMap<K, MinMaxResult<V>>
+    pub fn minmax(self) -> M
     where
         V: Ord,
+        M: Map<Value = MinMaxResult<V>>,
     {
         self.minmax_by(|_, v1, v2| V::cmp(v1, v2))
     }
 
-    /// Groups elements from the `GroupingMap` source by key and find the maximum and minimum of
+    /// Groups elements from the `GroupingGenericMap` source by key and find the maximum and minimum of
     /// each group with respect to the specified comparison function.
     ///
     /// If several elements are equally maximum, the last element is picked.
@@ -501,9 +512,10 @@ where
     /// assert_eq!(lookup[&2], OneElement(5));
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn minmax_by<F>(self, mut compare: F) -> HashMap<K, MinMaxResult<V>>
+    pub fn minmax_by<F>(self, mut compare: F) -> M
     where
         F: FnMut(&K, &V, &V) -> Ordering,
+        M: Map<Value = MinMaxResult<V>>,
     {
         self.aggregate(|acc, key, val| {
             Some(match acc {
@@ -529,7 +541,7 @@ where
         })
     }
 
-    /// Groups elements from the `GroupingMap` source by key and find the elements of each group
+    /// Groups elements from the `GroupingGenericMap` source by key and find the elements of each group
     /// that gives the minimum and maximum from the specified function.
     ///
     /// If several elements are equally maximum, the last element is picked.
@@ -552,15 +564,16 @@ where
     /// assert_eq!(lookup[&2], OneElement(5));
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn minmax_by_key<F, CK>(self, mut f: F) -> HashMap<K, MinMaxResult<V>>
+    pub fn minmax_by_key<F, CK>(self, mut f: F) -> M
     where
         F: FnMut(&K, &V) -> CK,
         CK: Ord,
+        M: Map<Value = MinMaxResult<V>>,
     {
         self.minmax_by(|key, v1, v2| f(key, v1).cmp(&f(key, v2)))
     }
 
-    /// Groups elements from the `GroupingMap` source by key and sums them.
+    /// Groups elements from the `GroupingGenericMap` source by key and sums them.
     ///
     /// This is just a shorthand for `self.reduce(|acc, _, val| acc + val)`.
     /// It is more limited than `Iterator::sum` since it doesn't use the `Sum` trait.
@@ -579,14 +592,15 @@ where
     /// assert_eq!(lookup[&2], 5 + 8);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn sum(self) -> HashMap<K, V>
+    pub fn sum(self) -> M
     where
         V: Add<V, Output = V>,
+        M: Map<Value = V>,
     {
         self.reduce(|acc, _, val| acc + val)
     }
 
-    /// Groups elements from the `GroupingMap` source by key and multiply them.
+    /// Groups elements from the `GroupingGenericMap` source by key and multiply them.
     ///
     /// This is just a shorthand for `self.reduce(|acc, _, val| acc * val)`.
     /// It is more limited than `Iterator::product` since it doesn't use the `Product` trait.
@@ -605,9 +619,10 @@ where
     /// assert_eq!(lookup[&2], 5 * 8);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn product(self) -> HashMap<K, V>
+    pub fn product(self) -> M
     where
         V: Mul<V, Output = V>,
+        M: Map<Value = V>,
     {
         self.reduce(|acc, _, val| acc * val)
     }

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -9,6 +9,35 @@ use std::cmp::Ordering;
 use std::iter::Iterator;
 use std::ops::{Add, Mul};
 
+#[cfg(feature = "use_std")]
+pub use with_hashmap::{GroupingMap, GroupingMapBy};
+
+#[cfg(feature = "use_std")]
+mod with_hashmap {
+    use super::*;
+    use std::collections::HashMap;
+
+    // This is used to infer `K` when `I::Item = (K, V)` since we can't write `I::Item.0`.
+    pub trait KeyValue {
+        type Key;
+    }
+
+    impl<K, V> KeyValue for (K, V) {
+        type Key = K;
+    }
+
+    /// `GroupingMap` is an intermediate struct for efficient group-and-fold operations.
+    ///
+    /// See [`GroupingGenericMap`] for more informations.
+    pub type GroupingMap<I, R> =
+        GroupingGenericMap<I, HashMap<<<I as Iterator>::Item as KeyValue>::Key, R>>;
+
+    /// `GroupingMapBy` is an intermediate struct for efficient group-and-fold operations.
+    ///
+    /// See [`GroupingGenericMap`] for more informations.
+    pub type GroupingMapBy<I, F, R> = GroupingMap<MapForGrouping<I, F>, R>;
+}
+
 /// A wrapper to allow for an easy [`into_grouping_map_by`](crate::Itertools::into_grouping_map_by)
 pub type MapForGrouping<I, F> = MapSpecialCase<I, GroupingMapFn<F>>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,8 @@ mod extrema_set;
 mod flatten_ok;
 mod format;
 #[cfg(feature = "use_alloc")]
+mod generic_containers;
+#[cfg(feature = "use_alloc")]
 mod group_map;
 #[cfg(feature = "use_alloc")]
 mod groupbylazy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,8 @@ pub mod structs {
     pub use crate::groupbylazy::{Chunk, ChunkBy, Chunks, Group, Groups, IntoChunks};
     #[cfg(feature = "use_alloc")]
     pub use crate::grouping_map::{GroupingGenericMap, GroupingGenericMapBy};
+    #[cfg(feature = "use_std")]
+    pub use crate::grouping_map::{GroupingMap, GroupingMapBy};
     pub use crate::intersperse::{Intersperse, IntersperseWith};
     #[cfg(feature = "use_alloc")]
     pub use crate::kmerge_impl::{KMerge, KMergeBy};
@@ -3338,6 +3340,42 @@ pub trait Itertools: Iterator {
         F: FnMut(&V) -> K,
     {
         group_map::into_group_map_by(self, f)
+    }
+
+    /// Constructs a `GroupingMap` to be used later with one of the efficient
+    /// group-and-fold operations it allows to perform.
+    ///
+    /// The input iterator must yield item in the form of `(K, V)` where the
+    /// value of type `K` will be used as key to identify the groups and the
+    /// value of type `V` as value for the folding operation.
+    ///
+    /// See [`GroupingGenericMap`] for more informations
+    /// on what operations are available.
+    #[cfg(feature = "use_std")]
+    fn into_grouping_map<K, V, R>(self) -> GroupingMap<Self, R>
+    where
+        Self: Iterator<Item = (K, V)> + Sized,
+        K: Hash + Eq,
+    {
+        self.into_grouping_map_in(HashMap::new())
+    }
+
+    /// Constructs a `GroupingMap` to be used later with one of the efficient
+    /// group-and-fold operations it allows to perform.
+    ///
+    /// The values from this iterator will be used as values for the folding operation
+    /// while the keys will be obtained from the values by calling `key_mapper`.
+    ///
+    /// See [`GroupingGenericMap`] for more informations
+    /// on what operations are available.
+    #[cfg(feature = "use_std")]
+    fn into_grouping_map_by<K, V, F, R>(self, key_mapper: F) -> GroupingMapBy<Self, F, R>
+    where
+        Self: Iterator<Item = V> + Sized,
+        K: Hash + Eq,
+        F: FnMut(&V) -> K,
+    {
+        self.into_grouping_map_by_in(key_mapper, HashMap::new())
     }
 
     /// Constructs a `GroupingGenericMap` to be used later with one of the efficient

--- a/tests/laziness.rs
+++ b/tests/laziness.rs
@@ -229,10 +229,10 @@ must_use_tests! {
     }
     // Not iterator themselves but still lazy.
     into_grouping_map {
-        let _ = Panicking.map(|x| (x, x + 1)).into_grouping_map();
+        let _ = Panicking.map(|x| (x, x + 1)).into_grouping_map::<_, _, u8>();
     }
     into_grouping_map_by {
-        let _ = Panicking.into_grouping_map_by(|x| *x);
+        let _ = Panicking.into_grouping_map_by::<_, _, _, u8>(|x| *x);
     }
     // Macros:
     iproduct {


### PR DESCRIPTION
This an alternative to #901 that I learnt from, it would close #901, close #588 and eventually solve most https://github.com/rust-itertools/itertools/labels/generic-container issues.

- I reuse `Map` polished earlier.
- Transform `GroupingMap[By]` into `GroupingGenericMap[By]`
  This is a huge but quite straightforward transformation:
  - `GroupingMap[By]` becomes `GroupingGenericMap[By]` with a generic type `M`
  - `K: Hash` becomes `M: Map<Key = K>`
  - `HashMap<K, ...>` becomes `M` with a `M: Map<Value = ...>` bound
  - Remove `Hash` and `HashMap`
  - `use_std` becomes `use_alloc`
- Reintroduce `GroupingMap[By]` with **one more generic parameter**
  This is a **breaking change!** However, this is mostly inferred.
  Note that it breaks (only) laziness tests because the `GroupingMap` object is not used (I could write any type but `u8` is one of the possible returned types). If it was used then it would have been inferred.
  I copied/pasted the code of old `into_grouping_map[_by]` methods, added the generic `R` and updated each function body with `_in(.., HashMap::new())`.
  _The old types are aliases of the new ones._

The main interest of this PR over #901 is that **there is not `_in` versions for each `GroupingMap` method.**

---

More than the additional parameter, the following code (weird but currently working) would not compile anymore.

```rust
let g = (0..10).into_grouping_map_by(|n| n % 2); // the map would now lives here so the values type is fixed earlier.
if true {
    println!("{:?}", g.collect::<Vec<_>>()); // HashMap<i32, Vec<i32>>
} else {
    println!("{:?}", g.sum());               // HashMap<i32, i32>
}
```
However, it's easily solvable here, `.into_grouping_map_by(|n| n % 2)` should be moved to both branches for the code to work as before.

_Now, in other cases, it might be not that easily solvable!_ **Is it a too big breaking change?**