### PR TITLE
Case 0 and 1 of `k_smallest` and variants

### DIFF
--- a/src/k_smallest.rs
+++ b/src/k_smallest.rs
@@ -42,6 +42,7 @@ where
     }
 
     if k == 0 {
+        iter.last();
         return Vec::new();
     }
     let mut iter = iter.fuse();

--- a/src/k_smallest.rs
+++ b/src/k_smallest.rs
@@ -45,6 +45,9 @@ where
         iter.last();
         return Vec::new();
     }
+    if k == 1 {
+        return iter.min_by(comparator).into_iter().collect();
+    }
     let mut iter = iter.fuse();
     let mut storage: Vec<I::Item> = iter.by_ref().take(k).collect();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2975,6 +2975,9 @@ pub trait Itertools: Iterator {
             self.last();
             return Vec::new().into_iter();
         }
+        if k == 1 {
+            return self.min().into_iter().collect_vec().into_iter();
+        }
 
         let mut iter = self.fuse();
         let mut heap: BinaryHeap<_> = iter.by_ref().take(k).collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2972,6 +2972,7 @@ pub trait Itertools: Iterator {
         use alloc::collections::BinaryHeap;
 
         if k == 0 {
+            self.last();
             return Vec::new().into_iter();
         }
 


### PR DESCRIPTION
Fixes #904.
About the case `k=0`, I wonder if all our iterators behave well on iterators with side-effects. I think we should update the specialization tests.