### PR TITLE
Make `TakeWhileInclusive::new` private

### DIFF
--- a/src/take_while_inclusive.rs
+++ b/src/take_while_inclusive.rs
@@ -21,7 +21,7 @@ where
     F: FnMut(&I::Item) -> bool,
 {
     /// Create a new [`TakeWhileInclusive`] from an iterator and a predicate.
-    pub fn new(iter: I, predicate: F) -> Self {
+    pub(crate) fn new(iter: I, predicate: F) -> Self {
         Self {
             iter,
             predicate,


### PR DESCRIPTION
I don't know about you but I think it's hard to know what is accessible outside the crate (except manually reading docs.rs entirely). `pub` without documentation is private thanks to `#![warn(missing_docs)]` (denied in CI) but `pub` with a small documentation might be public without us knowing.

I therefore considered adding `#![deny(unreachable_pub)]` (description [there](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unreachable-pub)).
After doing so and (easily) fixing 60+ errors and `ripgrep "pub "`, I found out that `TakeWhileInclusive` has a public method `new` while we usually do not publish such method.

I'm actually not fully satisfied with `unreachable_pub` because some `pub` remain without being accessible outside the crate.
(Maybe [public-api](https://docs.rs/public-api) is better suited for this).

Anyway, I here made `TakeWhileInclusive::new` private.