### PR TITLE
Do not implement `ZipEq::fold` (and change test)

### DIFF
--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -571,6 +571,14 @@ quickcheck! {
         let b = &b[..len];
         itertools::equal(zip_eq(a, b), zip(a, b))
     }
+
+    #[should_panic]
+    fn zip_eq_panics(a: Vec<u8>, b: Vec<u8>) -> TestResult {
+        if a.len() == b.len() { return TestResult::discard(); }
+        zip_eq(a.iter(), b.iter()).for_each(|_| {});
+        TestResult::passed() // won't come here
+    }
+
     fn equal_positions(a: Vec<i32>) -> bool {
         let with_pos = a.iter().positions(|v| v % 2 == 0);
         let without = a.iter().enumerate().filter(|(_, v)| *v % 2 == 0).map(|(i, _)| i);

--- a/tests/zip.rs
+++ b/tests/zip.rs
@@ -1,4 +1,3 @@
-use itertools::free::zip_eq;
 use itertools::multizip;
 use itertools::EitherOrBoth::{Both, Left, Right};
 use itertools::Itertools;
@@ -54,22 +53,4 @@ fn test_double_ended_zip() {
     assert_eq!(it.next_back(), Some((2, 2)));
     assert_eq!(it.next_back(), Some((1, 1)));
     assert_eq!(it.next_back(), None);
-}
-
-#[should_panic]
-#[test]
-fn zip_eq_panic1() {
-    let a = [1, 2];
-    let b = [1, 2, 3];
-
-    zip_eq(&a, &b).count();
-}
-
-#[should_panic]
-#[test]
-fn zip_eq_panic2() {
-    let a: [i32; 0] = [];
-    let b = [1, 2, 3];
-
-    zip_eq(&a, &b).count();
 }


### PR DESCRIPTION
Relates to #755. 

I can't really think of a better way to implement this, but it still yields a regression :(

```
cargo bench --bench specializations "zip_eq/fold"

zip_eq/fold             time:   [509.89 ns 510.95 ns 512.02 ns]
                        change: [+4.8744% +5.1665% +5.4970%] (p = 0.00 < 0.05)
                        Performance has regressed.
```
