### PR TITLE
Benchmark `.nth[_back](n)` with inputs `n`

### DIFF
--- a/benches/specializations.rs
+++ b/benches/specializations.rs
@@ -1,8 +1,11 @@
 #![allow(unstable_name_collisions)]
 
 use criterion::black_box;
+use criterion::BenchmarkId;
 use itertools::iproduct;
 use itertools::Itertools;
+
+const NTH_INPUTS: &[usize] = &[0, 1, 2, 4, 8];
 
 /// Create multiple functions each defining a benchmark group about iterator methods.
 ///
@@ -73,19 +76,19 @@ macro_rules! bench_specializations {
         $group.bench_function("last", |bencher| bencher.iter(|| {
             $iterator.last()
         }));
-        $group.bench_function("nth", |bencher| bencher.iter(|| {
-            for start in 0_usize..10 {
-                for n in 0..10 {
+        for n in NTH_INPUTS {
+            $group.bench_with_input(BenchmarkId::new("nth", n), n, |bencher, n| bencher.iter(|| {
+                for start in 0_usize..10 {
                     let mut it = $iterator;
                     if let Some(s) = start.checked_sub(1) {
                         black_box(it.nth(s));
                     }
-                    while let Some(x) = it.nth(n) {
+                    while let Some(x) = it.nth(*n) {
                         black_box(x);
                     }
                 }
-            }
-        }));
+            }));
+        }
         $group.bench_function("collect", |bencher| bencher.iter(|| {
             $iterator.collect::<Vec<_>>()
         }));
@@ -103,19 +106,19 @@ macro_rules! bench_specializations {
                 black_box(x);
             }
         }));
-        $group.bench_function("nth_back", |bencher| bencher.iter(|| {
-            for start in 0_usize..10 {
-                for n in 0..10 {
+        for n in NTH_INPUTS {
+            $group.bench_with_input(BenchmarkId::new("nth_back", n), n, |bencher, n| bencher.iter(|| {
+                for start in 0_usize..10 {
                     let mut it = $iterator;
                     if let Some(s) = start.checked_sub(1) {
                         black_box(it.nth_back(s));
                     }
-                    while let Some(x) = it.nth_back(n) {
+                    while let Some(x) = it.nth_back(*n) {
                         black_box(x);
                     }
                 }
-            }
-        }));
+            }));
+        }
         $group.bench_function("rfold", |bencher| bencher.iter(|| {
             $iterator.rfold((), |(), x| {
                 black_box(x);

--- a/benches/specializations.rs
+++ b/benches/specializations.rs
@@ -2,7 +2,6 @@
 
 use criterion::black_box;
 use criterion::BenchmarkId;
-use itertools::iproduct;
 use itertools::Itertools;
 
 const NTH_INPUTS: &[usize] = &[0, 1, 2, 4, 8];
@@ -261,7 +260,7 @@ bench_specializations! {
         {
             let v = black_box(vec![0; 16]);
         }
-        iproduct!(&v, &v, &v)
+        itertools::iproduct!(&v, &v, &v)
     }
     multi_cartesian_product {
         {

--- a/benches/specializations.rs
+++ b/benches/specializations.rs
@@ -12,7 +12,7 @@ const NTH_INPUTS: &[usize] = &[0, 1, 2, 4, 8];
 /// Each created group has functions with the following ids:
 ///
 /// - `next`, `size_hint`, `count`, `last`, `nth`, `collect`, `fold`
-/// - and when marked as `DoubleEndedIterator`: `next_back`, `rfold`
+/// - and when marked as `DoubleEndedIterator`: `next_back`, `nth_back`, `rfold`
 /// - and when marked as `ExactSizeIterator`: `len`
 ///
 /// Note that this macro can be called only once.
@@ -135,8 +135,11 @@ macro_rules! bench_specializations {
     };
 }
 
-// Example: To bench only `ZipLongest::fold`, you can do
+// Usage examples:
+// - For `ZipLongest::fold` only:
 //     cargo bench --bench specializations zip_longest/fold
+// - For `.combinations(k).nth(8)`:
+//     cargo bench --bench specializations combinations./nth/8
 bench_specializations! {
     interleave {
         {


### PR DESCRIPTION
I introduced specialization benchmarks in #786.
However, run `Combinations::nth` benchmarks in #914 did not give meaningful feedback. Sure it was globally faster but we could not say how much for each `n`.
So here I change the benchmarks to give informations based on the value `n` we feed `nth` with.