### PR TITLE
`LazyBuffer::get_at` (+ simplify `Combinations::nth`)

### DIFF
--- a/src/combinations.rs
+++ b/src/combinations.rs
@@ -162,14 +162,10 @@ where
             return None;
         }
 
-        Some(self.indices.iter().map(|i| self.pool[*i].clone()).collect())
+        Some(self.pool.get_at(&self.indices))
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        if n == 0 {
-            return self.next();
-        }
-
         let done = if self.first {
             self.init()
         } else {
@@ -186,7 +182,7 @@ where
             }
         }
 
-        Some(self.indices.iter().map(|i| self.pool[*i].clone()).collect())
+        Some(self.pool.get_at(&self.indices))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/combinations_with_replacement.rs
+++ b/src/combinations_with_replacement.rs
@@ -30,17 +30,6 @@ where
     debug_fmt_fields!(CombinationsWithReplacement, indices, pool, first);
 }
 
-impl<I> CombinationsWithReplacement<I>
-where
-    I: Iterator,
-    I::Item: Clone,
-{
-    /// Map the current mask over the pool to get an output combination
-    fn current(&self) -> Vec<I::Item> {
-        self.indices.iter().map(|i| self.pool[*i].clone()).collect()
-    }
-}
-
 /// Create a new `CombinationsWithReplacement` from a clonable iterator.
 pub fn combinations_with_replacement<I>(iter: I, k: usize) -> CombinationsWithReplacement<I>
 where
@@ -72,7 +61,7 @@ where
             // Otherwise, yield the initial state
             } else {
                 self.first = false;
-                Some(self.current())
+                Some(self.pool.get_at(&self.indices))
             };
         }
 
@@ -97,7 +86,7 @@ where
                 for indices_index in increment_from..self.indices.len() {
                     self.indices[indices_index] = increment_value;
                 }
-                Some(self.current())
+                Some(self.pool.get_at(&self.indices))
             }
             // Otherwise, we're done
             None => None,

--- a/src/lazy_buffer.rs
+++ b/src/lazy_buffer.rs
@@ -51,6 +51,16 @@ where
     }
 }
 
+impl<I> LazyBuffer<I>
+where
+    I: Iterator,
+    I::Item: Clone,
+{
+    pub fn get_at(&self, indices: &[usize]) -> Vec<I::Item> {
+        indices.iter().map(|i| self.buffer[*i].clone()).collect()
+    }
+}
+
 impl<I, J> Index<J> for LazyBuffer<I>
 where
     I: Iterator,

--- a/src/permutations.rs
+++ b/src/permutations.rs
@@ -99,7 +99,7 @@ where
                             return None;
                         }
                     }
-                    let item = indices[0..*k].iter().map(|&i| vals[i].clone()).collect();
+                    let item = vals.get_at(&indices[0..*k]);
                     *state = PermutationState::Loaded { indices, cycles };
                     Some(item)
                 }
@@ -110,7 +110,7 @@ where
                     return None;
                 }
                 let k = cycles.len();
-                Some(indices[0..k].iter().map(|&i| vals[i].clone()).collect())
+                Some(vals.get_at(&indices[0..k]))
             }
             PermutationState::End => None,
         }


### PR DESCRIPTION
As requested in https://github.com/rust-itertools/itertools/pull/914#issuecomment-2056489069, I've added a helper for returning the 'current' combination. 

I also realised that there's no reason to delegate from `.nth` to `.next()` when `n==0` so I junked it.