### PR TITLE
Implement `MergeBy::fold`

### DIFF
--- a/benches/specializations.rs
+++ b/benches/specializations.rs
@@ -582,29 +582,29 @@ bench_specializations! {
     }
     merge {
         {
-            let v1 = black_box(vec![0; 1024]);
-            let v2 = black_box(vec![0; 768]);
+            let v1 = black_box((0..1024).collect_vec());
+            let v2 = black_box((0..768).collect_vec());
         }
         v1.iter().merge(&v2)
     }
     merge_by {
         {
-            let v1 = black_box(vec![0; 1024]);
-            let v2 = black_box(vec![0; 768]);
+            let v1 = black_box((0..1024).collect_vec());
+            let v2 = black_box((0..768).collect_vec());
         }
         v1.iter().merge_by(&v2, PartialOrd::ge)
     }
     merge_join_by_ordering {
         {
-            let v1 = black_box(vec![0; 1024]);
-            let v2 = black_box(vec![0; 768]);
+            let v1 = black_box((0..1024).collect_vec());
+            let v2 = black_box((0..768).collect_vec());
         }
         v1.iter().merge_join_by(&v2, Ord::cmp)
     }
     merge_join_by_bool {
         {
-            let v1 = black_box(vec![0; 1024]);
-            let v2 = black_box(vec![0; 768]);
+            let v1 = black_box((0..1024).collect_vec());
+            let v2 = black_box((0..768).collect_vec());
         }
         v1.iter().merge_join_by(&v2, PartialOrd::ge)
     }

--- a/src/merge_join.rs
+++ b/src/merge_join.rs
@@ -308,52 +308,6 @@ where
         F::size_hint(self.left.size_hint(), self.right.size_hint())
     }
 
-    fn count(mut self) -> usize {
-        let mut count = 0;
-        loop {
-            match (self.left.next(), self.right.next()) {
-                (None, None) => break count,
-                (Some(_left), None) => break count + 1 + self.left.into_parts().1.count(),
-                (None, Some(_right)) => break count + 1 + self.right.into_parts().1.count(),
-                (Some(left), Some(right)) => {
-                    count += 1;
-                    let (left, right, _) = self.cmp_fn.merge(left, right);
-                    if let Some(left) = left {
-                        self.left.put_back(left);
-                    }
-                    if let Some(right) = right {
-                        self.right.put_back(right);
-                    }
-                }
-            }
-        }
-    }
-
-    fn last(mut self) -> Option<Self::Item> {
-        let mut previous_element = None;
-        loop {
-            match (self.left.next(), self.right.next()) {
-                (None, None) => break previous_element,
-                (Some(left), None) => {
-                    break Some(F::left(self.left.into_parts().1.last().unwrap_or(left)))
-                }
-                (None, Some(right)) => {
-                    break Some(F::right(self.right.into_parts().1.last().unwrap_or(right)))
-                }
-                (Some(left), Some(right)) => {
-                    let (left, right, elem) = self.cmp_fn.merge(left, right);
-                    if let Some(left) = left {
-                        self.left.put_back(left);
-                    }
-                    if let Some(right) = right {
-                        self.right.put_back(right);
-                    }
-                    previous_element = Some(elem);
-                }
-            }
-        }
-    }
-
     fn nth(&mut self, mut n: usize) -> Option<Self::Item> {
         loop {
             if n == 0 {


### PR DESCRIPTION
Relates to #755 

```
cargo bench --bench specializations merge_by/fold

merge_by/fold           time:   [741.63 ns 743.35 ns 745.12 ns]
                        change: [-75.583% -75.488% -75.382%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
```