### PR TITLE
Implement `DuplicatesBy::fold`

### DIFF
--- a/src/duplicates_impl.rs
+++ b/src/duplicates_impl.rs
@@ -81,6 +81,21 @@ mod private {
             iter.find_map(|v| meta.filter(v))
         }
 
+        fn fold<B, G>(self, init: B, mut f: G) -> B
+        where
+            Self: Sized,
+            G: FnMut(B, Self::Item) -> B,
+        {
+            let Self { iter, mut meta } = self;
+            iter.fold(init, |mut acc, v| {
+                if let Some(x) = meta.filter(v) {
+                    acc = f(acc, x)
+                }
+
+                acc
+            })
+        }
+
         #[inline]
         fn size_hint(&self) -> (usize, Option<usize>) {
             let (_, hi) = self.iter.size_hint();


### PR DESCRIPTION
Relates to #755. I didn't grab the output earlier (is there a way to print without re-benchmarking?) but this makes no difference to the performance. Submitting a PR for record keeping sake

```
{
  "mean": {
    "confidence_interval": {
      "confidence_level": 0.95,
      "lower_bound": -0.0081767782683812,
      "upper_bound": 0.0038785180687818605
    },
    "point_estimate": -0.00312222985963162,
    "standard_error": 0.003180882676320771
  },
  "median": {
    "confidence_interval": {
      "confidence_level": 0.95,
      "lower_bound": -0.009367663685134739,
      "upper_bound": -0.003824443197890548
    },
    "point_estimate": -0.006249808601540896,
    "standard_error": 0.0014046028043885176
  }
}

```