### PR TITLE
Specialize `Powerset::nth`

### DIFF
--- a/src/powerset.rs
+++ b/src/powerset.rs
@@ -42,6 +42,18 @@ where
     }
 }
 
+impl<I: Iterator> Powerset<I> {
+    /// Returns true if `k` has been incremented, false otherwise.
+    fn increment_k(&mut self) -> bool {
+        if self.combs.k() < self.combs.n() || self.combs.k() == 0 {
+            self.combs.reset(self.combs.k() + 1);
+            true
+        } else {
+            false
+        }
+    }
+}
+
 impl<I> Iterator for Powerset<I>
 where
     I: Iterator,
@@ -52,8 +64,7 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(elt) = self.combs.next() {
             Some(elt)
-        } else if self.combs.k() < self.combs.n() || self.combs.k() == 0 {
-            self.combs.reset(self.combs.k() + 1);
+        } else if self.increment_k() {
             self.combs.next()
         } else {
             None

--- a/src/powerset.rs
+++ b/src/powerset.rs
@@ -71,6 +71,20 @@ where
         }
     }
 
+    fn nth(&mut self, mut n: usize) -> Option<Self::Item> {
+        loop {
+            match self.combs.try_nth(n) {
+                Ok(item) => return Some(item),
+                Err(steps) => {
+                    if !self.increment_k() {
+                        return None;
+                    }
+                    n -= steps;
+                }
+            }
+        }
+    }
+
     fn size_hint(&self) -> SizeHint {
         let k = self.combs.k();
         // Total bounds for source iterator.


### PR DESCRIPTION
    cargo bench --bench specializations "powerset/nth"

    Same allocations for:
    powerset/nth/0 [798.27 µs 800.91 µs 803.82 µs] [821.70 µs 822.85 µs 824.01 µs] [+2.3972% +3.7714% +5.6787%]

    -50% allocations for:
    powerset/nth/1 [794.67 µs 796.80 µs 799.04 µs] [458.11 µs 458.77 µs 459.43 µs] [-42.712% -42.235% -41.642%]

    -67% allocations for:
    powerset/nth/2 [837.00 µs 838.81 µs 840.64 µs] [342.81 µs 343.53 µs 344.27 µs] [-59.118% -58.982% -58.848%]

    -80% allocations for:
    powerset/nth/4 [811.66 µs 814.08 µs 816.47 µs] [241.11 µs 241.62 µs 242.14 µs] [-70.888% -70.441% -70.073%]

    -89% allocations for:
    powerset/nth/8 [806.11 µs 807.74 µs 809.67 µs] [178.03 µs 178.38 µs 178.76 µs] [-77.959% -77.869% -77.772%]

It doesn't follow the decrease in allocations as closely as `combinations[_with_replacement]` did. ~I think it's due to the reallocations in `Combinations::reset`~ (EDIT: apparently not).
