### PR TITLE
Implement `FlattenOk::{fold, rfold}`

### DIFF
--- a/src/flatten_ok.rs
+++ b/src/flatten_ok.rs
@@ -72,6 +72,29 @@ where
         }
     }
 
+    fn fold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        // Front
+        let mut acc = match self.inner_front {
+            Some(x) => x.fold(init, |a, o| f(a, Ok(o))),
+            None => init,
+        };
+
+        acc = self.iter.fold(acc, |acc, x| match x {
+            Ok(it) => it.into_iter().fold(acc, |a, o| f(a, Ok(o))),
+            Err(e) => f(acc, Err(e)),
+        });
+
+        // Back
+        match self.inner_back {
+            Some(x) => x.fold(acc, |a, o| f(a, Ok(o))),
+            None => acc,
+        }
+    }
+
     fn size_hint(&self) -> (usize, Option<usize>) {
         let inner_hint = |inner: &Option<T::IntoIter>| {
             inner

--- a/src/flatten_ok.rs
+++ b/src/flatten_ok.rs
@@ -153,6 +153,29 @@ where
             }
         }
     }
+
+    fn rfold<B, F>(self, init: B, mut f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        // Back
+        let mut acc = match self.inner_back {
+            Some(x) => x.rfold(init, |a, o| f(a, Ok(o))),
+            None => init,
+        };
+
+        acc = self.iter.rfold(acc, |acc, x| match x {
+            Ok(it) => it.into_iter().rfold(acc, |a, o| f(a, Ok(o))),
+            Err(e) => f(acc, Err(e)),
+        });
+
+        // Front
+        match self.inner_front {
+            Some(x) => x.rfold(acc, |a, o| f(a, Ok(o))),
+            None => acc,
+        }
+    }
 }
 
 impl<I, T, E> Clone for FlattenOk<I, T, E>

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -1,7 +1,9 @@
 #![allow(unstable_name_collisions)]
 
 use itertools::Itertools;
+use quickcheck::Arbitrary;
 use quickcheck::{quickcheck, TestResult};
+use rand::Rng;
 use std::fmt::Debug;
 
 struct Unspecialized<I>(I);
@@ -452,8 +454,8 @@ quickcheck! {
         test_specializations(&v.into_iter().filter_map_ok(|i| if i < 20 { Some(i * 2) } else { None }));
     }
 
-    // `Option<u8>` because `Vec<u8>` would be very slow!! And we can't give `[u8; 3]`.
-    fn flatten_ok(v: Vec<Result<Option<u8>, char>>) -> () {
+    // `SmallIter2<u8>` because `Vec<u8>` is too slow and we get bad coverage from a singleton like Option<u8>
+    fn flatten_ok(v: Vec<Result<SmallIter2<u8>, char>>) -> () {
         let it = v.into_iter().flatten_ok();
         test_specializations(&it);
         test_double_ended_specializations(&it);
@@ -516,6 +518,64 @@ quickcheck! {
             }
             for n in 0..size + 2 {
                 check_results_specialized!(it, |mut i| i.nth_back(n));
+            }
+        }
+    }
+}
+
+/// Like `VecIntoIter<T>` with maximum 2 elements.
+#[derive(Debug, Clone, Default)]
+enum SmallIter2<T> {
+    #[default]
+    Zero,
+    One(T),
+    Two(T, T),
+}
+
+impl<T: Arbitrary> Arbitrary for SmallIter2<T> {
+    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+        match g.gen_range(0u8, 3) {
+            0 => Self::Zero,
+            1 => Self::One(T::arbitrary(g)),
+            2 => Self::Two(T::arbitrary(g), T::arbitrary(g)),
+            _ => unreachable!(),
+        }
+    }
+    // maybe implement shrink too, maybe not
+}
+
+impl<T> Iterator for SmallIter2<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match std::mem::take(self) {
+            Self::Zero => None,
+            Self::One(val) => Some(val),
+            Self::Two(val, second) => {
+                *self = Self::One(second);
+                Some(val)
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = match self {
+            Self::Zero => 0,
+            Self::One(_) => 1,
+            Self::Two(_, _) => 2,
+        };
+        (len, Some(len))
+    }
+}
+
+impl<T> DoubleEndedIterator for SmallIter2<T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match std::mem::take(self) {
+            Self::Zero => None,
+            Self::One(val) => Some(val),
+            Self::Two(first, val) => {
+                *self = Self::One(first);
+                Some(val)
             }
         }
     }


### PR DESCRIPTION
Relates to #755 

```
$ cargo bench --bench specializations flatten_ok/fold -- --baseline flatten_ok

flatten_ok/fold         time:   [3.0078 µs 3.2944 µs 3.5502 µs]
                        change: [-47.164% -42.833% -38.023%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Edit: `.rfold` is an almost identical implementation, so I'll put it through in a moment. Just running benchmarks...

Edit:

```
$ cargo bench --bench specializations flatten_ok/rfold -- --baseline flatten_ok

flatten_ok/rfold        time:   [2.7442 µs 2.8254 µs 2.9134 µs]
                        change: [-42.924% -39.835% -36.485%] (p = 0.00 < 0.05)
                        Performance has improved.
```
