### PR TITLE
`assert_equal`: fix `clippy::default_numeric_fallback`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![warn(missing_docs)]
+#![warn(missing_docs, clippy::default_numeric_fallback)]
 #![crate_name = "itertools"]
 #![cfg_attr(not(feature = "use_std"), no_std)]
 
@@ -4225,7 +4225,7 @@ where
 {
     let mut ia = a.into_iter();
     let mut ib = b.into_iter();
-    let mut i = 0;
+    let mut i: usize = 0;
     loop {
         match (ia.next(), ib.next()) {
             (None, None) => return,


### PR DESCRIPTION
Type of `i` defaults to `i32` when `usize` should be used.
It's only a problem if this function is called with two iterators longer than `i32::MAX`. It seems unlikely to me but who knows?
`i32` should not be the default integer type in the library. `usize` would have more sense so **_I add the lint as warning_** (for the library only, it's okay in tests and benchmarks).

See lint doc: https://rust-lang.github.io/rust-clippy/master/index.html#/default_numeric_fallback