### PR TITLE
Documentation: various visual fixes

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -33,7 +33,7 @@ pub struct Interleave<I, J> {
 
 /// Create an iterator that interleaves elements in `i` and `j`.
 ///
-/// [`IntoIterator`] enabled version of `[Itertools::interleave]`.
+/// [`IntoIterator`] enabled version of [`Itertools::interleave`](crate::Itertools::interleave).
 pub fn interleave<I, J>(
     i: I,
     j: J,
@@ -471,7 +471,7 @@ where
 /// A “meta iterator adaptor”. Its closure receives a reference to the iterator
 /// and may pick off as many elements as it likes, to produce the next iterator element.
 ///
-/// Iterator element type is *X*, if the return type of `F` is *Option\<X\>*.
+/// Iterator element type is `X` if the return type of `F` is `Option<X>`.
 ///
 /// See [`.batching()`](crate::Itertools::batching) for more information.
 #[derive(Clone)]

--- a/src/format.rs
+++ b/src/format.rs
@@ -9,7 +9,7 @@ use std::fmt;
 /// See [`.format_with()`](crate::Itertools::format_with) for more information.
 pub struct FormatWith<'a, I, F> {
     sep: &'a str,
-    /// FormatWith uses interior mutability because Display::fmt takes &self.
+    /// `FormatWith` uses interior mutability because `Display::fmt` takes `&self`.
     inner: Cell<Option<(I, F)>>,
 }
 
@@ -22,7 +22,7 @@ pub struct FormatWith<'a, I, F> {
 /// for more information.
 pub struct Format<'a, I> {
     sep: &'a str,
-    /// Format uses interior mutability because Display::fmt takes &self.
+    /// `Format` uses interior mutability because `Display::fmt` takes `&self`.
     inner: Cell<Option<I>>,
 }
 

--- a/src/free.rs
+++ b/src/free.rs
@@ -157,7 +157,7 @@ where
     i.into_iter().chain(j)
 }
 
-/// Create an iterator that clones each element from &T to T
+/// Create an iterator that clones each element from `&T` to `T`.
 ///
 /// [`IntoIterator`] enabled version of [`Iterator::cloned`].
 ///
@@ -259,7 +259,7 @@ where
     iterable.into_iter().min()
 }
 
-/// Combine all iterator elements into one String, separated by `sep`.
+/// Combine all iterator elements into one `String`, separated by `sep`.
 ///
 /// [`IntoIterator`] enabled version of [`Itertools::join`].
 ///
@@ -298,6 +298,7 @@ where
 
 /// Sort all iterator elements into a new iterator in ascending order.
 /// This sort is unstable (i.e., may reorder equal elements).
+///
 /// [`IntoIterator`] enabled version of [`Itertools::sorted_unstable`].
 ///
 /// ```

--- a/src/groupbylazy.rs
+++ b/src/groupbylazy.rs
@@ -66,12 +66,13 @@ where
     /// Least index for which we still have elements buffered
     oldest_buffered_group: usize,
     /// Group index for `buffer[0]` -- the slots
-    /// bottom_group..oldest_buffered_group are unused and will be erased when
+    /// `bottom_group..oldest_buffered_group` are unused and will be erased when
     /// that range is large enough.
     bottom_group: usize,
     /// Buffered groups, from `bottom_group` (index 0) to `top_group`.
     buffer: Vec<vec::IntoIter<I::Item>>,
-    /// index of last group iter that was dropped, usize::MAX == none
+    /// index of last group iter that was dropped,
+    /// `usize::MAX` initially when no group was dropped
     dropped_group: usize,
 }
 

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -450,7 +450,7 @@ where
     /// If several elements are equally maximum, the last element is picked.
     /// If several elements are equally minimum, the first element is picked.
     ///
-    /// See [.minmax()](crate::Itertools::minmax) for the non-grouping version.
+    /// See [`Itertools::minmax`](crate::Itertools::minmax) for the non-grouping version.
     ///
     /// Differences from the non grouping version:
     /// - It never produces a `MinMaxResult::NoElements`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2426,7 +2426,10 @@ pub trait Itertools: Iterator {
     /// assert_eq!((0..10).fold1(|x, y| x + y).unwrap_or(0), 45);
     /// assert_eq!((0..0).fold1(|x, y| x * y), None);
     /// ```
-    #[deprecated(since = "0.10.2", note = "Use `Iterator::reduce` instead")]
+    #[deprecated(
+        note = "Use [`Iterator::reduce`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.reduce) instead",
+        since = "0.10.2"
+    )]
     fn fold1<F>(mut self, f: F) -> Option<Self::Item>
     where
         F: FnMut(Self::Item, Self::Item) -> Self::Item,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1565,6 +1565,11 @@ pub trait Itertools: Iterator {
     /// Iterator element can be any homogeneous tuple of type `Self::Item` with
     /// size up to 12.
     ///
+    /// # Guarantees
+    ///
+    /// If the adapted iterator is deterministic,
+    /// this iterator adapter yields items in a reliable order.
+    ///
     /// ```
     /// use itertools::Itertools;
     ///
@@ -1592,11 +1597,6 @@ pub trait Itertools: Iterator {
     /// let it: TupleCombinations<Range<u32>, (u32, u32, u32)> = (1..5).tuple_combinations();
     /// itertools::assert_equal(it, vec![(1, 2, 3), (1, 2, 4), (1, 3, 4), (2, 3, 4)]);
     /// ```
-    ///
-    /// # Guarantees
-    ///
-    /// If the adapted iterator is deterministic,
-    /// this iterator adapter yields items in a reliable order.
     fn tuple_combinations<T>(self) -> TupleCombinations<Self, T>
     where
         Self: Sized + Clone,
@@ -1611,6 +1611,11 @@ pub trait Itertools: Iterator {
     ///
     /// Iterator element type is `Vec<Self::Item>`. The iterator produces a new `Vec` per iteration,
     /// and clones the iterator elements.
+    ///
+    /// # Guarantees
+    ///
+    /// If the adapted iterator is deterministic,
+    /// this iterator adapter yields items in a reliable order.
     ///
     /// ```
     /// use itertools::Itertools;
@@ -1635,11 +1640,6 @@ pub trait Itertools: Iterator {
     ///     vec![2, 2],
     /// ]);
     /// ```
-    ///
-    /// # Guarantees
-    ///
-    /// If the adapted iterator is deterministic,
-    /// this iterator adapter yields items in a reliable order.
     #[cfg(feature = "use_alloc")]
     fn combinations(self, k: usize) -> Combinations<Self>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4206,7 +4206,7 @@ where
 /// semantics as [`equal(a, b)`](equal).
 ///
 /// **Panics** on assertion failure with a message that shows the
-/// two iteration elements.
+/// two different elements and the iteration index.
 ///
 /// ```should_panic
 /// # use itertools::assert_equal;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4131,7 +4131,7 @@ pub trait Itertools: Iterator {
 
     /// Converts an iterator of tuples into a tuple of containers.
     ///
-    /// `unzip()` consumes an entire iterator of n-ary tuples, producing `n` collections, one for each
+    /// It consumes an entire iterator of n-ary tuples, producing `n` collections, one for each
     /// column.
     ///
     /// This function is, in some sense, the opposite of [`multizip`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1609,7 +1609,7 @@ pub trait Itertools: Iterator {
     /// Return an iterator adaptor that iterates over the `k`-length combinations of
     /// the elements from an iterator.
     ///
-    /// Iterator element type is `Vec<Self::Item>`. The iterator produces a new Vec per iteration,
+    /// Iterator element type is `Vec<Self::Item>`. The iterator produces a new `Vec` per iteration,
     /// and clones the iterator elements.
     ///
     /// ```
@@ -1652,7 +1652,7 @@ pub trait Itertools: Iterator {
     /// Return an iterator that iterates over the `k`-length combinations of
     /// the elements from an iterator, with replacement.
     ///
-    /// Iterator element type is `Vec<Self::Item>`. The iterator produces a new Vec per iteration,
+    /// Iterator element type is `Vec<Self::Item>`. The iterator produces a new `Vec` per iteration,
     /// and clones the iterator elements.
     ///
     /// ```
@@ -1681,7 +1681,7 @@ pub trait Itertools: Iterator {
     /// elements from an iterator.
     ///
     /// Iterator element type is `Vec<Self::Item>` with length `k`. The iterator
-    /// produces a new Vec per iteration, and clones the iterator elements.
+    /// produces a new `Vec` per iteration, and clones the iterator elements.
     ///
     /// If `k` is greater than the length of the input iterator, the resultant
     /// iterator adaptor will be empty.
@@ -2096,7 +2096,7 @@ pub trait Itertools: Iterator {
     /// Consume the first `n` elements from the iterator eagerly,
     /// and return the same iterator again.
     ///
-    /// It works similarly to *.skip(* `n` *)* except it is eager and
+    /// It works similarly to `.skip(n)` except it is eager and
     /// preserves the iterator type.
     ///
     /// ```
@@ -2230,7 +2230,7 @@ pub trait Itertools: Iterator {
             .count()
     }
 
-    /// Combine all iterator elements into one String, separated by `sep`.
+    /// Combine all iterator elements into one `String`, separated by `sep`.
     ///
     /// Use the `Display` implementation of each element.
     ///
@@ -4008,7 +4008,7 @@ pub trait Itertools: Iterator {
         }
     }
 
-    /// If the iterator yields no elements, Ok(None) will be returned. If the iterator yields
+    /// If the iterator yields no elements, `Ok(None)` will be returned. If the iterator yields
     /// exactly one element, that element will be returned, otherwise an error will be returned
     /// containing an iterator that has the same output as the input iterator.
     ///

--- a/src/peek_nth.rs
+++ b/src/peek_nth.rs
@@ -35,12 +35,12 @@ impl<I> PeekNth<I>
 where
     I: Iterator,
 {
-    /// Works exactly like the `peek` method in `std::iter::Peekable`
+    /// Works exactly like the `peek` method in [`std::iter::Peekable`].
     pub fn peek(&mut self) -> Option<&I::Item> {
         self.peek_nth(0)
     }
 
-    /// Works exactly like the `peek_mut` method in `std::iter::Peekable`
+    /// Works exactly like the `peek_mut` method in [`std::iter::Peekable`].
     pub fn peek_mut(&mut self) -> Option<&mut I::Item> {
         self.peek_nth_mut(0)
     }
@@ -117,7 +117,7 @@ where
         self.buf.get_mut(n)
     }
 
-    /// Works exactly like the `next_if` method in `std::iter::Peekable`
+    /// Works exactly like the `next_if` method in [`std::iter::Peekable`].
     pub fn next_if(&mut self, func: impl FnOnce(&I::Item) -> bool) -> Option<I::Item> {
         match self.next() {
             Some(item) if func(&item) => Some(item),
@@ -129,7 +129,7 @@ where
         }
     }
 
-    /// Works exactly like the `next_if_eq` method in `std::iter::Peekable`
+    /// Works exactly like the `next_if_eq` method in [`std::iter::Peekable`].
     pub fn next_if_eq<T>(&mut self, expected: &T) -> Option<I::Item>
     where
         T: ?Sized,

--- a/src/peeking_take_while.rs
+++ b/src/peeking_take_while.rs
@@ -11,11 +11,11 @@ use std::iter::Peekable;
 ///
 /// This is implemented by peeking adaptors like peekable and put back,
 /// but also by a few iterators that can be peeked natively, like the slice’s
-/// by reference iterator (`std::slice::Iter`).
+/// by reference iterator ([`std::slice::Iter`]).
 pub trait PeekingNext: Iterator {
     /// Pass a reference to the next iterator element to the closure `accept`;
-    /// if `accept` returns true, return it as the next element,
-    /// else None.
+    /// if `accept` returns `true`, return it as the next element,
+    /// else `None`.
     fn peeking_next<F>(&mut self, accept: F) -> Option<Self::Item>
     where
         Self: Sized,

--- a/src/put_back_n_impl.rs
+++ b/src/put_back_n_impl.rs
@@ -28,7 +28,8 @@ where
 }
 
 impl<I: Iterator> PutBackN<I> {
-    /// Puts x in front of the iterator.
+    /// Puts `x` in front of the iterator.
+    ///
     /// The values are yielded in order of the most recently put back
     /// values first.
     ///

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -41,7 +41,10 @@ use std::mem;
 ///                         vec![1, 1, 2, 3, 5, 8, 13, 21]);
 /// assert_eq!(fibonacci.last(), Some(2_971_215_073))
 /// ```
-#[deprecated(note = "Use std from_fn() instead", since = "0.13.0")]
+#[deprecated(
+    note = "Use [std::iter::from_fn](https://doc.rust-lang.org/std/iter/fn.from_fn.html) instead",
+    since = "0.13.0"
+)]
 pub fn unfold<A, St, F>(initial_state: St, f: F) -> Unfold<St, F>
 where
     F: FnMut(&mut St) -> Option<A>,
@@ -62,7 +65,10 @@ where
 /// See [`unfold`](crate::unfold) for more information.
 #[derive(Clone)]
 #[must_use = "iterators are lazy and do nothing unless consumed"]
-#[deprecated(note = "Use std from_fn() instead", since = "0.13.0")]
+#[deprecated(
+    note = "Use [std::iter::FromFn](https://doc.rust-lang.org/std/iter/struct.FromFn.html) instead",
+    since = "0.13.0"
+)]
 pub struct Unfold<St, F> {
     f: F,
     /// Internal state that will be passed to the closure on the next iteration

--- a/src/zip_eq_impl.rs
+++ b/src/zip_eq_impl.rs
@@ -11,9 +11,7 @@ pub struct ZipEq<I, J> {
     b: J,
 }
 
-/// Iterate `i` and `j` in lock step.
-///
-/// **Panics** if the iterators are not of the same length.
+/// Zips two iterators but **panics** if they are not of the same length.
 ///
 /// [`IntoIterator`] enabled version of [`Itertools::zip_eq`](crate::Itertools::zip_eq).
 ///

--- a/src/zip_eq_impl.rs
+++ b/src/zip_eq_impl.rs
@@ -1,6 +1,7 @@
 use super::size_hint;
 
 /// An iterator which iterates two other iterators simultaneously
+/// and panic if they have different lengths.
 ///
 /// See [`.zip_eq()`](crate::Itertools::zip_eq) for more information.
 #[derive(Clone, Debug)]

--- a/src/zip_longest.rs
+++ b/src/zip_longest.rs
@@ -8,6 +8,7 @@ use crate::either_or_both::EitherOrBoth;
 // and dedicated to itertools https://github.com/rust-lang/rust/pull/19283
 
 /// An iterator which iterates two other iterators simultaneously
+/// and wraps the elements in [`EitherOrBoth`].
 ///
 /// This iterator is *fused*.
 ///

--- a/src/ziptuple.rs
+++ b/src/ziptuple.rs
@@ -7,7 +7,7 @@ pub struct Zip<T> {
     t: T,
 }
 
-/// An iterator that generalizes *.zip()* and allows running multiple iterators in lockstep.
+/// An iterator that generalizes `.zip()` and allows running multiple iterators in lockstep.
 ///
 /// The iterator `Zip<(I, J, ..., M)>` is formed from a tuple of iterators (or values that
 /// implement [`IntoIterator`]) and yields elements
@@ -20,7 +20,7 @@ pub struct Zip<T> {
 /// ..)>` of each component iterator `I, J, ...`) if each component iterator is
 /// nameable.
 ///
-/// Prefer [`izip!()`] over `multizip` for the performance benefits of using the
+/// Prefer [`izip!()`](crate::izip) over `multizip` for the performance benefits of using the
 /// standard library `.zip()`. Prefer `multizip` if a nameable type is needed.
 ///
 /// ```
@@ -36,7 +36,6 @@ pub struct Zip<T> {
 ///
 /// assert_eq!(results, [0 + 3, 10 + 7, 29, 36]);
 /// ```
-/// [`izip!()`]: crate::izip
 pub fn multizip<T, U>(t: U) -> Zip<T>
 where
     Zip<T>: From<U> + Iterator,


### PR DESCRIPTION
I (quickly enough) went through all pages of https://docs.rs/itertools/

Use more backticks, new/fix links, few more empty lines, few reformulations.