### PR TITLE
Make "cargo-semver-checks" action faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - uses: obi1kenobi/cargo-semver-checks-action@v2.4
         with:
-          rust-toolchain: stable
+          rust-toolchain: manual
           feature-group: all-features
 
   # Used to signal to branch protections that all other jobs have succeeded.


### PR DESCRIPTION
"cargo-semver-checks-action" previously took 2mn30s in CI which sure is not that much but is still slower than all the rest. It was slowly (PR after PR) driving me nuts.
After installing `cargo-semver-checks` locally, I witnessed that run the binary was fast. I eventually looked at the CI log and I thought _the installation of the toolchain_ could be the **bottleneck**.
For it (and other things), the semver-checks action uses "actions-rs/core" which has been recently archived and is therefore unmaintained and might be not as performant as alternatives.

So here, I install it with `dtolnay/rust-toolchain@stable` (same as other jobs) and set the toolchain to "manual" for "cargo-semver-checks-action". And now it's 🚀blazingly fast🔥!

**tldr;** CI is overall twice faster.