### PR TITLE
Our non-lazy adaptors

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -612,7 +612,7 @@ where
 /// See [`.tuple_combinations()`](crate::Itertools::tuple_combinations) for more
 /// information.
 #[derive(Clone, Debug)]
-#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[must_use = "this iterator adaptor is not lazy but does nearly nothing unless consumed"]
 pub struct TupleCombinations<I, T>
 where
     I: Iterator,

--- a/src/kmerge_impl.rs
+++ b/src/kmerge_impl.rs
@@ -153,7 +153,7 @@ where
 ///
 /// See [`.kmerge_by()`](crate::Itertools::kmerge_by) for more
 /// information.
-#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[must_use = "this iterator adaptor is not lazy but does nearly nothing unless consumed"]
 pub struct KMergeBy<I, F>
 where
     I: Iterator,

--- a/tests/laziness.rs
+++ b/tests/laziness.rs
@@ -143,11 +143,11 @@ must_use_tests! {
         let _ = Panicking.merge_join_by(Panicking, |_, _| true);
         let _ = Panicking.merge_join_by(Panicking, Ord::cmp);
     }
-    #[ignore]
+    #[should_panic]
     kmerge {
         let _ = Panicking.map(|_| Panicking).kmerge();
     }
-    #[ignore]
+    #[should_panic]
     kmerge_by {
         let _ = Panicking.map(|_| Panicking).kmerge_by(|_, _| true);
     }

--- a/tests/laziness.rs
+++ b/tests/laziness.rs
@@ -196,10 +196,15 @@ must_use_tests! {
     while_some {
         let _ = Panicking.map(Some).while_some();
     }
-    #[ignore]
-    tuple_combinations {
+    tuple_combinations1 {
         let _ = Panicking.tuple_combinations::<(_,)>();
+    }
+    #[should_panic]
+    tuple_combinations2 {
         let _ = Panicking.tuple_combinations::<(_, _)>();
+    }
+    #[should_panic]
+    tuple_combinations3 {
         let _ = Panicking.tuple_combinations::<(_, _, _)>();
     }
     combinations {


### PR DESCRIPTION
Fixes #791

`Itertools::{kmerge, kmerge_by, tuple_combinations}` are neither lazy nor eager. But they must be used since not doing so does almost nothing (and it would be suspicious code to me).
I therefore update the message of the `must_use` attributes and the laziness tests.

Unless we are willing to roughly wrap those in a `LazyInit` type (see https://github.com/rust-itertools/itertools/issues/791#issuecomment-1822364744) that would probably slow down iteration ("Is it initialized?" each time `next` is called), I don't see an alternative.