### PR TITLE
Macro hygiene: `chain!` and qualified paths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,16 +393,16 @@ macro_rules! izip {
 /// ```
 macro_rules! chain {
     () => {
-        core::iter::empty()
+        $crate::__std_iter::empty()
     };
     ($first:expr $(, $rest:expr )* $(,)?) => {
         {
-            let iter = core::iter::IntoIterator::into_iter($first);
+            let iter = $crate::__std_iter::IntoIterator::into_iter($first);
             $(
                 let iter =
-                    core::iter::Iterator::chain(
+                    $crate::__std_iter::Iterator::chain(
                         iter,
-                        core::iter::IntoIterator::into_iter($rest));
+                        $crate::__std_iter::IntoIterator::into_iter($rest));
             )*
             iter
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,10 @@ macro_rules! iproduct {
         $crate::__std_iter::once(())
     );
     ($I:expr $(,)?) => (
-        $crate::__std_iter::IntoIterator::into_iter($I).map(|elt| (elt,))
+        $crate::__std_iter::Iterator::map(
+            $crate::__std_iter::IntoIterator::into_iter($I),
+            |elt| (elt,)
+        )
     );
     ($I:expr, $J:expr $(,)?) => (
         $crate::Itertools::cartesian_product(
@@ -330,19 +333,24 @@ macro_rules! izip {
 
     // binary
     ($first:expr, $second:expr $(,)*) => {
-        $crate::izip!($first)
-            .zip($second)
+        $crate::__std_iter::Iterator::zip(
+            $crate::__std_iter::IntoIterator::into_iter($first),
+            $second,
+        )
     };
 
     // n-ary where n > 2
     ( $first:expr $( , $rest:expr )* $(,)* ) => {
-        $crate::izip!($first)
+        {
+            let iter = $crate::__std_iter::IntoIterator::into_iter($first);
             $(
-                .zip($rest)
+                let iter = $crate::__std_iter::Iterator::zip(iter, $rest);
             )*
-            .map(
+            $crate::__std_iter::Iterator::map(
+                iter,
                 $crate::izip!(@closure a => (a) $( , $rest )*)
             )
+        }
     };
 }
 

--- a/tests/macros_hygiene.rs
+++ b/tests/macros_hygiene.rs
@@ -1,3 +1,8 @@
+mod alloc {}
+mod core {}
+mod either {}
+mod std {}
+
 #[test]
 fn iproduct_hygiene() {
     let _ = itertools::iproduct!();
@@ -11,4 +16,12 @@ fn izip_hygiene() {
     let _ = itertools::izip!(0..6);
     let _ = itertools::izip!(0..6, 0..9);
     let _ = itertools::izip!(0..6, 0..9, 0..12);
+}
+
+#[test]
+fn chain_hygiene() {
+    let _: ::std::iter::Empty<i32> = itertools::chain!();
+    let _ = itertools::chain!(0..6);
+    let _ = itertools::chain!(0..6, 0..9);
+    let _ = itertools::chain!(0..6, 0..9, 0..12);
 }


### PR DESCRIPTION
#942 lead me to check our macro hygiene.

1. If someone has a module named `core` and uses `itertools::chain!` then there is a conflict!
  I improve our macro hygiene test by adding (empty) modules with all the names we might be tempted to use.
  Without changing `core` in `chain!`, the test failed!
2. Qualified paths only? Is conflict with `.map` and `.zip` absolutely impossible? Seems more bulletproof to me that way.
  EDIT: Found https://github.com/rust-itertools/itertools/pull/525#discussion_r584338246 which seems to indicate I'm right to use qualified paths.

**PS:** This is my 💯<sup>th</sup> merged PR. 🎉