### PR TITLE
feat(`FilterMapOk`): implement `DoubleEndedIterator`

### DIFF
--- a/benches/specializations.rs
+++ b/benches/specializations.rs
@@ -647,6 +647,7 @@ bench_specializations! {
         v.iter().copied().filter_ok(|x| x % 3 == 0)
     }
     filter_map_ok {
+        DoubleEndedIterator
         {
             let v = black_box((0_u32..1024)
                 .map(|x| if x % 2 == 1 { Err(x) } else { Ok(x) })

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -1017,6 +1017,30 @@ where
     }
 }
 
+impl<I, F, T, U, E> DoubleEndedIterator for FilterMapOk<I, F>
+where
+    I: DoubleEndedIterator<Item = Result<T, E>>,
+    F: FnMut(T) -> Option<U>,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let f = &mut self.f;
+        self.iter.by_ref().rev().find_map(|res| match res {
+            Ok(t) => f(t).map(Ok),
+            Err(e) => Some(Err(e)),
+        })
+    }
+
+    fn rfold<Acc, Fold>(self, init: Acc, fold_f: Fold) -> Acc
+    where
+        Fold: FnMut(Acc, Self::Item) -> Acc,
+    {
+        let mut f = self.f;
+        self.iter
+            .filter_map(|v| transpose_result(v.map(&mut f)))
+            .rfold(init, fold_f)
+    }
+}
+
 impl<I, F, T, U, E> FusedIterator for FilterMapOk<I, F>
 where
     I: FusedIterator<Item = Result<T, E>>,

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -451,7 +451,9 @@ quickcheck! {
     }
 
     fn filter_map_ok(v: Vec<Result<u8, char>>) -> () {
-        test_specializations(&v.into_iter().filter_map_ok(|i| if i < 20 { Some(i * 2) } else { None }));
+        let it = v.into_iter().filter_map_ok(|i| if i < 20 { Some(i * 2) } else { None });
+        test_specializations(&it);
+        test_double_ended_specializations(&it);
     }
 
     // `SmallIter2<u8>` because `Vec<u8>` is too slow and we get bad coverage from a singleton like Option<u8>


### PR DESCRIPTION
`DoubleEndedIterator` implementation for `FilterMapOk` analog to #948.

Hope `rev()` is the right thing here, as `rfind_map` does not exist (#949).

Refs: #947