### PR TITLE
Fix/ignore warnings within doctests

### DIFF
--- a/src/free.rs
+++ b/src/free.rs
@@ -36,7 +36,7 @@ pub use crate::zip_eq_impl::zip_eq;
 /// ```
 /// use itertools::intersperse;
 ///
-/// itertools::assert_equal(intersperse((0..3), 8), vec![0, 8, 1, 8, 2]);
+/// itertools::assert_equal(intersperse(0..3, 8), vec![0, 8, 1, 8, 2]);
 /// ```
 pub fn intersperse<I>(iterable: I, element: I::Item) -> Intersperse<I::IntoIter>
 where
@@ -55,7 +55,7 @@ where
 /// use itertools::intersperse_with;
 ///
 /// let mut i = 10;
-/// itertools::assert_equal(intersperse_with((0..3), || { i -= 1; i }), vec![0, 9, 1, 8, 2]);
+/// itertools::assert_equal(intersperse_with(0..3, || { i -= 1; i }), vec![0, 9, 1, 8, 2]);
 /// assert_eq!(i, 8);
 /// ```
 pub fn intersperse_with<I, F>(iterable: I, element: F) -> IntersperseWith<I::IntoIter, F>
@@ -75,6 +75,7 @@ where
 ///
 /// for (i, elt) in enumerate(&[1, 2, 3]) {
 ///     /* loop body */
+///     # let _ = (i, elt);
 /// }
 /// ```
 pub fn enumerate<I>(iterable: I) -> iter::Enumerate<I::IntoIter>
@@ -93,6 +94,7 @@ where
 ///
 /// for elt in rev(&[1, 2, 3]) {
 ///     /* loop body */
+///     # let _ = elt;
 /// }
 /// ```
 pub fn rev<I>(iterable: I) -> iter::Rev<I::IntoIter>

--- a/src/kmerge_impl.rs
+++ b/src/kmerge_impl.rs
@@ -134,6 +134,7 @@ impl<T, F: FnMut(&T, &T) -> bool> KMergePredicate<T> for F {
 ///
 /// for elt in kmerge(vec![vec![0, 2, 4], vec![1, 3, 5], vec![6, 7]]) {
 ///     /* loop body */
+///     # let _ = elt;
 /// }
 /// ```
 pub fn kmerge<I>(iterable: I) -> KMerge<<I::Item as IntoIterator>::IntoIter>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(missing_docs, clippy::default_numeric_fallback)]
 #![crate_name = "itertools"]
 #![cfg_attr(not(feature = "use_std"), no_std)]
+#![doc(test(attr(deny(warnings), allow(deprecated, unstable_name_collisions))))]
 
 //! Extra iterator adaptors, functions and macros.
 //!
@@ -8,6 +9,7 @@
 //! the [`Itertools`] trait:
 //!
 //! ```
+//! # #[allow(unused_imports)]
 //! use itertools::Itertools;
 //! ```
 //!
@@ -29,6 +31,7 @@
 //!
 //! for elt in interleave(&[1, 2, 3], &[2, 3, 4]) {
 //!     /* loop body */
+//!     # let _ = elt;
 //! }
 //! ```
 //!
@@ -248,6 +251,7 @@ mod ziptuple;
 /// // from (0, 0, 0), (0, 0, 1), .., (0, 1, 0), (0, 1, 1), .. etc until (3, 3, 3)
 /// for (i, j, k) in iproduct!(0..4, 0..4, 0..4) {
 ///    // ..
+///    # let _ = (i, j, k);
 /// }
 /// # }
 /// ```
@@ -375,16 +379,16 @@ macro_rules! izip {
 ///
 /// Invocations of `chain!` with one argument expand to [`arg.into_iter()`](IntoIterator):
 /// ```
-/// use std::{ops::Range, slice};
+/// use std::ops::Range;
 /// use itertools::chain;
-/// let _: <Range<_> as IntoIterator>::IntoIter = chain!((2..6),); // trailing comma optional!
+/// let _: <Range<_> as IntoIterator>::IntoIter = chain!(2..6,); // trailing comma optional!
 /// let _:     <&[_] as IntoIterator>::IntoIter = chain!(&[2, 3, 4]);
 /// ```
 ///
 /// Invocations of `chain!` with multiple arguments [`.into_iter()`](IntoIterator) each
 /// argument, and then [`chain`] them together:
 /// ```
-/// use std::{iter::*, ops::Range, slice};
+/// use std::{iter::*, slice};
 /// use itertools::{assert_equal, chain};
 ///
 /// // e.g., this:
@@ -1902,7 +1906,7 @@ pub trait Itertools: Iterator {
     /// use itertools::Itertools;
     ///
     /// let input = vec![vec![1], vec![3, 2, 1]];
-    /// let it = input.into_iter().update(|mut v| v.push(0));
+    /// let it = input.into_iter().update(|v| v.push(0));
     /// itertools::assert_equal(it, vec![vec![1, 0], vec![3, 2, 1, 0]]);
     /// ```
     fn update<F>(self, updater: F) -> Update<Self, F>
@@ -2162,7 +2166,7 @@ pub trait Itertools: Iterator {
     /// ```
     /// use itertools::Itertools;
     ///
-    /// let mut iter = "αβγ".chars().dropping(2);
+    /// let iter = "αβγ".chars().dropping(2);
     /// itertools::assert_equal(iter, "γ".chars());
     /// ```
     ///
@@ -2246,14 +2250,17 @@ pub trait Itertools: Iterator {
     ///
     /// fn process_dir_entries(entries: &[fs::DirEntry]) {
     ///     // ...
+    ///     # let _ = entries;
     /// }
     ///
-    /// fn do_stuff() -> std::io::Result<()> {
+    /// fn do_stuff() -> io::Result<()> {
     ///     let entries: Vec<_> = fs::read_dir(".")?.try_collect()?;
     ///     process_dir_entries(&entries);
     ///
     ///     Ok(())
     /// }
+    ///
+    /// # let _ = do_stuff;
     /// ```
     fn try_collect<T, U, E>(self) -> Result<U, E>
     where
@@ -2404,6 +2411,7 @@ pub trait Itertools: Iterator {
     /// accum = f(accum, 1);
     /// accum = f(accum, 2);
     /// accum = f(accum, 3);
+    /// # let _ = accum;
     /// ```
     ///
     /// With a `start` value of 0 and an addition as folding function,
@@ -2554,16 +2562,16 @@ pub trait Itertools: Iterator {
     /// assert_eq!((1..8).map(|x| x.to_string()).tree_reduce(f),
     ///            Some(String::from("f(f(f(1, 2), f(3, 4)), f(f(5, 6), 7))")));
     ///
-    /// // Like fold1, an empty iterator produces None
+    /// // Like reduce, an empty iterator produces None
     /// assert_eq!((0..0).tree_reduce(|x, y| x * y), None);
     ///
-    /// // tree_reduce matches fold1 for associative operations...
+    /// // tree_reduce matches reduce for associative operations...
     /// assert_eq!((0..10).tree_reduce(|x, y| x + y),
-    ///     (0..10).fold1(|x, y| x + y));
+    ///     (0..10).reduce(|x, y| x + y));
     ///
     /// // ...but not for non-associative ones
     /// assert_ne!((0..10).tree_reduce(|x, y| x - y),
-    ///     (0..10).fold1(|x, y| x - y));
+    ///     (0..10).reduce(|x, y| x - y));
     ///
     /// let mut total_len_reduce = 0;
     /// let reduce_res = (1..100).map(|x| x.to_string())
@@ -4163,7 +4171,7 @@ pub trait Itertools: Iterator {
     /// # Examples
     /// ```
     /// # use itertools::Itertools;
-    /// let counts = [1, 1, 1, 3, 3, 5].into_iter().counts();
+    /// let counts = [1, 1, 1, 3, 3, 5].iter().counts();
     /// assert_eq!(counts[&1], 3);
     /// assert_eq!(counts[&3], 2);
     /// assert_eq!(counts[&5], 1);
@@ -4189,6 +4197,7 @@ pub trait Itertools: Iterator {
     /// # use itertools::Itertools;
     /// struct Character {
     ///   first_name: &'static str,
+    ///   # #[allow(dead_code)]
     ///   last_name:  &'static str,
     /// }
     ///

--- a/src/merge_join.rs
+++ b/src/merge_join.rs
@@ -31,6 +31,7 @@ pub type Merge<I, J> = MergeBy<I, J, MergeLte>;
 ///
 /// for elt in merge(&[1, 2, 3], &[2, 3, 4]) {
 ///     /* loop body */
+///     # let _ = elt;
 /// }
 /// ```
 pub fn merge<I, J>(

--- a/src/zip_eq_impl.rs
+++ b/src/zip_eq_impl.rs
@@ -21,6 +21,7 @@ pub struct ZipEq<I, J> {
 /// let data = [1, 2, 3, 4, 5];
 /// for (a, b) in zip_eq(&data[..data.len() - 1], &data[1..]) {
 ///     /* loop body */
+///     # let _ = (a, b);
 /// }
 /// ```
 pub fn zip_eq<I, J>(i: I, j: J) -> ZipEq<I::IntoIter, J::IntoIter>


### PR DESCRIPTION
#963 lead me to know about [`#![doc(test(attr(...)))]`](https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#testattr).

Our doctests have some warnings that are ignored by default.
Here, I fix some, sometimes silently (comment out), and globally ignore `deprecated` and `unstable_name_collisions`.
Maybe I should `allow(unused_variables)` instead of many `# let _ = ...;`?