### PR TITLE
Increase discoverability of `merge_join_by` (Unix-like `comm`)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1091,7 +1091,9 @@ pub trait Itertools: Iterator {
     /// let b = (0..10).step_by(3);
     ///
     /// itertools::assert_equal(
-    ///     a.merge_join_by(b, |i, j| i.cmp(j)),
+    ///     // This performs a diff in the style of the Unix command comm(1),
+    ///     // generalized to arbitrary types rather than text.
+    ///     a.merge_join_by(b, Ord::cmp),
     ///     vec![Both(0, 0), Left(2), Right(3), Left(4), Both(6, 6), Left(1), Right(9)]
     /// );
     /// ```
@@ -1123,6 +1125,7 @@ pub trait Itertools: Iterator {
     /// );
     /// ```
     #[inline]
+    #[doc(alias = "comm")]
     fn merge_join_by<J, F, T>(self, other: J, cmp_fn: F) -> MergeJoinBy<Self, J::IntoIter, F>
     where
         J: IntoIterator,


### PR DESCRIPTION
Fixes #963 

I suggest we follow the same policy as the stdlib: https://std-dev-guide.rust-lang.org/policy/doc-alias.html
And I agree with @VorpalBlade that [`comm`](https://www.man7.org/linux/man-pages/man1/comm.1.html) is a fitting alias.

PS: Doc aliases requires rust 1.48 so we are good now.