### PR TITLE
Migrate to edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "Extra iterator adaptors, iterator methods, free functions, and ma
 keywords = ["iterator", "data-structure", "zip", "product"]
 categories = ["algorithms", "rust-patterns", "no-std", "no-std::no-alloc"]
 
-edition = "2018"
+edition = "2021"
 
 # When bumping, please resolve all `#[allow(clippy::*)]` that are newly resolvable.
 rust-version = "1.63.0"

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -43,7 +43,7 @@ where
     I: Iterator + Clone,
 {
     macro_rules! check_specialized {
-        ($src:expr, |$it:pat| $closure:expr) => {
+        ($src:expr, |$it:pat_param| $closure:expr) => {
             // Many iterators special-case the first elements, so we test specializations for iterators that have already been advanced.
             let mut src = $src.clone();
             for _ in 0..5 {
@@ -101,7 +101,7 @@ where
     I: DoubleEndedIterator + Clone,
 {
     macro_rules! check_specialized {
-        ($src:expr, |$it:pat| $closure:expr) => {
+        ($src:expr, |$it:pat_param| $closure:expr) => {
             // Many iterators special-case the first elements, so we test specializations for iterators that have already been advanced.
             let mut src = $src.clone();
             for step in 0..8 {
@@ -481,7 +481,7 @@ quickcheck! {
 
         fn helper(it: impl DoubleEndedIterator<Item = Result<u8, u8>> + Clone) {
             macro_rules! check_results_specialized {
-                ($src:expr, |$it:pat| $closure:expr) => {
+                ($src:expr, |$it:pat_param| $closure:expr) => {
                     assert_eq!(
                         itertools::process_results($src.clone(), |$it| $closure),
                         itertools::process_results($src.clone(), |i| {


### PR DESCRIPTION
I noted 5 months ago that edition 2021 requires rustc 1.56+ so it's now possible.
_Is there any reason to not update?_