### PR TITLE
Allow `Q: ?Sized` in `Itertools::contains`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2068,7 +2068,7 @@ pub trait Itertools: Iterator {
     where
         Self: Sized,
         Self::Item: Borrow<Q>,
-        Q: PartialEq,
+        Q: PartialEq + ?Sized,
     {
         self.any(|x| x.borrow() == query)
     }


### PR DESCRIPTION
To enable `.contains("foo")` on an `Iterator<Item = String>` and similar