### PR TITLE
Give `take_while_inclusive` a more intuitive doc alias

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1594,6 +1594,7 @@ pub trait Itertools: Iterator {
     ///     .collect();
     /// let expected: Vec<_> = vec![1, 2, 3].into_iter().map(NoCloneImpl).collect();
     /// assert_eq!(filtered, expected);
+    #[doc(alias = "take_until")]
     fn take_while_inclusive<F>(self, accept: F) -> TakeWhileInclusive<Self, F>
     where
         Self: Sized,


### PR DESCRIPTION
I could not for the life of me find this function lmao, it's called take until most places so I think an alias for searchability would be nice