### PR TITLE
Add track_caller attr for asser_equal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4571,6 +4571,7 @@ where
 /// assert_equal("exceed".split('c'), "excess".split('c'));
 /// // ^PANIC: panicked at 'Failed assertion Some("eed") == Some("ess") for iteration 1'.
 /// ```
+#[track_caller]
 pub fn assert_equal<I, J>(a: I, b: J)
 where
     I: IntoIterator,


### PR DESCRIPTION
Without the attribute the panic location is useless, see [playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=ec0c46b6130b1ada4049e2bc0a046b3f):

```
thread 'main' panicked at /playground/.cargo/registry/src/index.crates.io-6f17d22bba15001f/itertools-0.13.0/src/lib.rs:4289:17:
Failed assertion Some(1) == Some(2) for iteration 0
```

Stable since 1.44: https://github.com/rust-lang/rust/pull/72445
