### PR TITLE
Change an instance of `default_features` in `Cargo.toml` to `default-features`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rand = "0.7"
 criterion = { version = "0.4.0", features = ["html_reports"] }
 paste = "1.0.0"  # Used in test_std to instantiate generic tests
 permutohedron = "0.2"
-quickcheck = { version = "0.9", default_features = false }
+quickcheck = { version = "0.9", default-features = false }
 
 [features]
 default = ["use_std"]


### PR DESCRIPTION
As per cargo itself when running a `cargo build`:

> `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition (in the `quickcheck` dependency)

Since `default_features` and `default-features` work the same, this should not change any functionality beyond removing the warning when building itertools. To be sure, however, I ran `cargo test` after the change, and all tests passed.