### PR TITLE
Implement `with_hasher` adaptors

### DIFF
--- a/src/duplicates_impl.rs
+++ b/src/duplicates_impl.rs
@@ -1,31 +1,39 @@
+use core::hash::BuildHasher;
+use std::collections::hash_map::RandomState;
 use std::hash::Hash;
 
 mod private {
+    use core::hash::BuildHasher;
+    use std::collections::hash_map::RandomState;
     use std::collections::HashMap;
     use std::fmt;
     use std::hash::Hash;
 
     #[derive(Clone)]
     #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-    pub struct DuplicatesBy<I: Iterator, Key, F> {
+    pub struct DuplicatesBy<I: Iterator, Key, F, S = RandomState>
+    where
+        S: BuildHasher,
+    {
         pub(crate) iter: I,
-        pub(crate) meta: Meta<Key, F>,
+        pub(crate) meta: Meta<Key, F, S>,
     }
 
-    impl<I, V, F> fmt::Debug for DuplicatesBy<I, V, F>
+    impl<I, V, F, S> fmt::Debug for DuplicatesBy<I, V, F, S>
     where
         I: Iterator + fmt::Debug,
         V: fmt::Debug + Hash + Eq,
+        S: BuildHasher,
     {
         debug_fmt_fields!(DuplicatesBy, iter, meta.used);
     }
 
-    impl<I: Iterator, Key: Eq + Hash, F> DuplicatesBy<I, Key, F> {
-        pub(crate) fn new(iter: I, key_method: F) -> Self {
+    impl<I: Iterator, Key: Eq + Hash, F, S: BuildHasher> DuplicatesBy<I, Key, F, S> {
+        pub(crate) fn new(iter: I, key_method: F, hash_builder: S) -> Self {
             Self {
                 iter,
                 meta: Meta {
-                    used: HashMap::new(),
+                    used: HashMap::with_hasher(hash_builder),
                     pending: 0,
                     key_method,
                 },
@@ -34,15 +42,16 @@ mod private {
     }
 
     #[derive(Clone)]
-    pub struct Meta<Key, F> {
-        used: HashMap<Key, bool>,
+    pub struct Meta<Key, F, S> {
+        used: HashMap<Key, bool, S>,
         pending: usize,
         key_method: F,
     }
 
-    impl<Key, F> Meta<Key, F>
+    impl<Key, F, S> Meta<Key, F, S>
     where
         Key: Eq + Hash,
+        S: BuildHasher,
     {
         /// Takes an item and returns it back to the caller if it's the second time we see it.
         /// Otherwise the item is consumed and None is returned
@@ -68,11 +77,12 @@ mod private {
         }
     }
 
-    impl<I, Key, F> Iterator for DuplicatesBy<I, Key, F>
+    impl<I, Key, F, S> Iterator for DuplicatesBy<I, Key, F, S>
     where
         I: Iterator,
         Key: Eq + Hash,
         F: KeyMethod<Key, I::Item>,
+        S: BuildHasher,
     {
         type Item = I::Item;
 
@@ -102,11 +112,12 @@ mod private {
         }
     }
 
-    impl<I, Key, F> DoubleEndedIterator for DuplicatesBy<I, Key, F>
+    impl<I, Key, F, S> DoubleEndedIterator for DuplicatesBy<I, Key, F, S>
     where
         I: DoubleEndedIterator,
         Key: Eq + Hash,
         F: KeyMethod<Key, I::Item>,
+        S: BuildHasher,
     {
         fn next_back(&mut self) -> Option<Self::Item> {
             let Self { iter, meta } = self;
@@ -189,28 +200,35 @@ mod private {
 /// An iterator adapter to filter for duplicate elements.
 ///
 /// See [`.duplicates_by()`](crate::Itertools::duplicates_by) for more information.
-pub type DuplicatesBy<I, V, F> = private::DuplicatesBy<I, V, private::ByFn<F>>;
+pub type DuplicatesBy<I, V, F, S = RandomState> = private::DuplicatesBy<I, V, private::ByFn<F>, S>;
 
-/// Create a new `DuplicatesBy` iterator.
-pub fn duplicates_by<I, Key, F>(iter: I, f: F) -> DuplicatesBy<I, Key, F>
+/// Create a new `DuplicatesBy` iterator with a specified hash builder.
+pub fn duplicates_by_with_hasher<I, Key, F, S>(
+    iter: I,
+    f: F,
+    hash_builder: S,
+) -> DuplicatesBy<I, Key, F, S>
 where
     Key: Eq + Hash,
     F: FnMut(&I::Item) -> Key,
     I: Iterator,
+    S: BuildHasher,
 {
-    DuplicatesBy::new(iter, private::ByFn(f))
+    DuplicatesBy::new(iter, private::ByFn(f), hash_builder)
 }
 
 /// An iterator adapter to filter out duplicate elements.
 ///
 /// See [`.duplicates()`](crate::Itertools::duplicates) for more information.
-pub type Duplicates<I> = private::DuplicatesBy<I, <I as Iterator>::Item, private::ById>;
+pub type Duplicates<I, S = RandomState> =
+    private::DuplicatesBy<I, <I as Iterator>::Item, private::ById, S>;
 
-/// Create a new `Duplicates` iterator.
-pub fn duplicates<I>(iter: I) -> Duplicates<I>
+/// Create a new `Duplicates` iterator with a specified hash builder.
+pub fn duplicates_with_hasher<I, S>(iter: I, hash_builder: S) -> Duplicates<I, S>
 where
     I: Iterator,
     I::Item: Eq + Hash,
+    S: BuildHasher,
 {
-    Duplicates::new(iter, private::ById)
+    Duplicates::new(iter, private::ById, hash_builder)
 }

--- a/src/group_map.rs
+++ b/src/group_map.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "use_std")]
 
+use core::hash::BuildHasher;
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::iter::Iterator;
@@ -8,12 +9,13 @@ use std::iter::Iterator;
 ///
 /// See [`.into_group_map()`](crate::Itertools::into_group_map)
 /// for more information.
-pub fn into_group_map<I, K, V>(iter: I) -> HashMap<K, Vec<V>>
+pub fn into_group_map_with_hasher<I, K, V, S>(iter: I, hash_builder: S) -> HashMap<K, Vec<V>, S>
 where
     I: Iterator<Item = (K, V)>,
     K: Hash + Eq,
+    S: BuildHasher,
 {
-    let mut lookup = HashMap::<K, Vec<V>>::new();
+    let mut lookup = HashMap::<K, Vec<V>, S>::with_hasher(hash_builder);
 
     iter.for_each(|(key, val)| {
         lookup.entry(key).or_default().push(val);
@@ -22,11 +24,16 @@ where
     lookup
 }
 
-pub fn into_group_map_by<I, K, V, F>(iter: I, mut f: F) -> HashMap<K, Vec<V>>
+pub fn into_group_map_by_with_hasher<I, K, V, F, S>(
+    iter: I,
+    mut f: F,
+    hash_builder: S,
+) -> HashMap<K, Vec<V>, S>
 where
     I: Iterator<Item = V>,
     K: Hash + Eq,
     F: FnMut(&V) -> K,
+    S: BuildHasher,
 {
-    into_group_map(iter.map(|v| (f(&v), v)))
+    into_group_map_with_hasher(iter.map(|v| (f(&v), v)), hash_builder)
 }

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -2,11 +2,12 @@ use crate::{
     adaptors::map::{MapSpecialCase, MapSpecialCaseFn},
     MinMaxResult,
 };
-use std::cmp::Ordering;
+use core::hash::BuildHasher;
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::iter::Iterator;
 use std::ops::{Add, Mul};
+use std::{cmp::Ordering, collections::hash_map::RandomState};
 
 /// A wrapper to allow for an easy [`into_grouping_map_by`](crate::Itertools::into_grouping_map_by)
 pub type MapForGrouping<I, F> = MapSpecialCase<I, GroupingMapFn<F>>;
@@ -36,18 +37,19 @@ pub(crate) fn new_map_for_grouping<K, I: Iterator, F: FnMut(&I::Item) -> K>(
 }
 
 /// Creates a new `GroupingMap` from `iter`
-pub fn new<I, K, V>(iter: I) -> GroupingMap<I>
+pub fn new<I, K, V, S>(iter: I, hash_builder: S) -> GroupingMap<I, S>
 where
     I: Iterator<Item = (K, V)>,
     K: Hash + Eq,
+    S: BuildHasher,
 {
-    GroupingMap { iter }
+    GroupingMap { iter, hash_builder }
 }
 
 /// `GroupingMapBy` is an intermediate struct for efficient group-and-fold operations.
 ///
 /// See [`GroupingMap`] for more information.
-pub type GroupingMapBy<I, F> = GroupingMap<MapForGrouping<I, F>>;
+pub type GroupingMapBy<I, F, S = RandomState> = GroupingMap<MapForGrouping<I, F>, S>;
 
 /// `GroupingMap` is an intermediate struct for efficient group-and-fold operations.
 /// It groups elements by their key and at the same time fold each group
@@ -56,14 +58,19 @@ pub type GroupingMapBy<I, F> = GroupingMap<MapForGrouping<I, F>>;
 /// No method on this struct performs temporary allocations.
 #[derive(Clone, Debug)]
 #[must_use = "GroupingMap is lazy and do nothing unless consumed"]
-pub struct GroupingMap<I> {
+pub struct GroupingMap<I, S = RandomState>
+where
+    S: BuildHasher,
+{
     iter: I,
+    hash_builder: S,
 }
 
-impl<I, K, V> GroupingMap<I>
+impl<I, K, V, S> GroupingMap<I, S>
 where
     I: Iterator<Item = (K, V)>,
     K: Hash + Eq,
+    S: BuildHasher,
 {
     /// This is the generic way to perform any operation on a `GroupingMap`.
     /// It's suggested to use this method only to implement custom operations
@@ -105,11 +112,11 @@ where
     /// assert_eq!(lookup[&3], 7);
     /// assert_eq!(lookup.len(), 3);      // The final keys are only 0, 1 and 2
     /// ```
-    pub fn aggregate<FO, R>(self, mut operation: FO) -> HashMap<K, R>
+    pub fn aggregate<FO, R>(self, mut operation: FO) -> HashMap<K, R, S>
     where
         FO: FnMut(Option<R>, &K, V) -> Option<R>,
     {
-        let mut destination_map = HashMap::new();
+        let mut destination_map = HashMap::with_hasher(self.hash_builder);
 
         self.iter.for_each(|(key, val)| {
             let acc = destination_map.remove(&key);
@@ -154,7 +161,7 @@ where
     /// assert_eq!(lookup[&2].acc, 2 + 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn fold_with<FI, FO, R>(self, mut init: FI, mut operation: FO) -> HashMap<K, R>
+    pub fn fold_with<FI, FO, R>(self, mut init: FI, mut operation: FO) -> HashMap<K, R, S>
     where
         FI: FnMut(&K, &V) -> R,
         FO: FnMut(R, &K, V) -> R,
@@ -190,7 +197,7 @@ where
     /// assert_eq!(lookup[&2], 2 + 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn fold<FO, R>(self, init: R, operation: FO) -> HashMap<K, R>
+    pub fn fold<FO, R>(self, init: R, operation: FO) -> HashMap<K, R, S>
     where
         R: Clone,
         FO: FnMut(R, &K, V) -> R,
@@ -225,7 +232,7 @@ where
     /// assert_eq!(lookup[&2], 2 + 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn reduce<FO>(self, mut operation: FO) -> HashMap<K, V>
+    pub fn reduce<FO>(self, mut operation: FO) -> HashMap<K, V, S>
     where
         FO: FnMut(V, &K, V) -> V,
     {
@@ -239,7 +246,7 @@ where
 
     /// See [`.reduce()`](GroupingMap::reduce).
     #[deprecated(note = "Use .reduce() instead", since = "0.13.0")]
-    pub fn fold_first<FO>(self, operation: FO) -> HashMap<K, V>
+    pub fn fold_first<FO>(self, operation: FO) -> HashMap<K, V, S>
     where
         FO: FnMut(V, &K, V) -> V,
     {
@@ -264,11 +271,11 @@ where
     /// assert_eq!(lookup[&2], vec![2, 5].into_iter().collect::<HashSet<_>>());
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn collect<C>(self) -> HashMap<K, C>
+    pub fn collect<C>(self) -> HashMap<K, C, S>
     where
         C: Default + Extend<V>,
     {
-        let mut destination_map = HashMap::new();
+        let mut destination_map = HashMap::with_hasher(self.hash_builder);
 
         self.iter.for_each(|(key, val)| {
             destination_map
@@ -298,7 +305,7 @@ where
     /// assert_eq!(lookup[&2], 8);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn max(self) -> HashMap<K, V>
+    pub fn max(self) -> HashMap<K, V, S>
     where
         V: Ord,
     {
@@ -324,7 +331,7 @@ where
     /// assert_eq!(lookup[&2], 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn max_by<F>(self, mut compare: F) -> HashMap<K, V>
+    pub fn max_by<F>(self, mut compare: F) -> HashMap<K, V, S>
     where
         F: FnMut(&K, &V, &V) -> Ordering,
     {
@@ -353,7 +360,7 @@ where
     /// assert_eq!(lookup[&2], 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn max_by_key<F, CK>(self, mut f: F) -> HashMap<K, V>
+    pub fn max_by_key<F, CK>(self, mut f: F) -> HashMap<K, V, S>
     where
         F: FnMut(&K, &V) -> CK,
         CK: Ord,
@@ -379,7 +386,7 @@ where
     /// assert_eq!(lookup[&2], 5);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn min(self) -> HashMap<K, V>
+    pub fn min(self) -> HashMap<K, V, S>
     where
         V: Ord,
     {
@@ -405,7 +412,7 @@ where
     /// assert_eq!(lookup[&2], 8);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn min_by<F>(self, mut compare: F) -> HashMap<K, V>
+    pub fn min_by<F>(self, mut compare: F) -> HashMap<K, V, S>
     where
         F: FnMut(&K, &V, &V) -> Ordering,
     {
@@ -434,7 +441,7 @@ where
     /// assert_eq!(lookup[&2], 8);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn min_by_key<F, CK>(self, mut f: F) -> HashMap<K, V>
+    pub fn min_by_key<F, CK>(self, mut f: F) -> HashMap<K, V, S>
     where
         F: FnMut(&K, &V) -> CK,
         CK: Ord,
@@ -469,7 +476,7 @@ where
     /// assert_eq!(lookup[&2], OneElement(5));
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn minmax(self) -> HashMap<K, MinMaxResult<V>>
+    pub fn minmax(self) -> HashMap<K, MinMaxResult<V>, S>
     where
         V: Ord,
     {
@@ -499,7 +506,7 @@ where
     /// assert_eq!(lookup[&2], OneElement(5));
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn minmax_by<F>(self, mut compare: F) -> HashMap<K, MinMaxResult<V>>
+    pub fn minmax_by<F>(self, mut compare: F) -> HashMap<K, MinMaxResult<V>, S>
     where
         F: FnMut(&K, &V, &V) -> Ordering,
     {
@@ -550,7 +557,7 @@ where
     /// assert_eq!(lookup[&2], OneElement(5));
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn minmax_by_key<F, CK>(self, mut f: F) -> HashMap<K, MinMaxResult<V>>
+    pub fn minmax_by_key<F, CK>(self, mut f: F) -> HashMap<K, MinMaxResult<V>, S>
     where
         F: FnMut(&K, &V) -> CK,
         CK: Ord,
@@ -577,7 +584,7 @@ where
     /// assert_eq!(lookup[&2], 5 + 8);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn sum(self) -> HashMap<K, V>
+    pub fn sum(self) -> HashMap<K, V, S>
     where
         V: Add<V, Output = V>,
     {
@@ -603,7 +610,7 @@ where
     /// assert_eq!(lookup[&2], 5 * 8);
     /// assert_eq!(lookup.len(), 3);
     /// ```
-    pub fn product(self) -> HashMap<K, V>
+    pub fn product(self) -> HashMap<K, V, S>
     where
         V: Mul<V, Output = V>,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4042,7 +4042,36 @@ pub trait Itertools: Iterator {
         Self: Iterator<Item = (K, V)> + Sized,
         K: Hash + Eq,
     {
-        group_map::into_group_map(self)
+        group_map::into_group_map_with_hasher(self, RandomState::new())
+    }
+
+    /// Return a `HashMap` of keys mapped to `Vec`s of values, using the hash builder for hashing.
+    /// See [.into_group_map()](crate::Itertools::into_group_map) for more information.
+    ///
+    /// Warning: `hash_builder` is normally randomly generated, and is designed to allow it's
+    /// users to be resistant to attacks that cause many collisions and very poor performance.
+    /// Setting it manually using this function can expose a DoS attack vector.
+    ///
+    /// ```
+    /// use std::hash::RandomState;
+    /// use itertools::Itertools;
+    ///
+    /// let data = vec![(0, 10), (2, 12), (3, 13), (0, 20), (3, 33), (2, 42)];
+    /// let lookup = data.into_iter().into_group_map_with_hasher(RandomState::new());
+    ///
+    /// assert_eq!(lookup[&0], vec![10, 20]);
+    /// assert_eq!(lookup.get(&1), None);
+    /// assert_eq!(lookup[&2], vec![12, 42]);
+    /// assert_eq!(lookup[&3], vec![13, 33]);
+    /// ```
+    #[cfg(feature = "use_std")]
+    fn into_group_map_with_hasher<K, V, S>(self, hash_builder: S) -> HashMap<K, Vec<V>, S>
+    where
+        Self: Iterator<Item = (K, V)> + Sized,
+        K: Hash + Eq,
+        S: BuildHasher,
+    {
+        group_map::into_group_map_with_hasher(self, hash_builder)
     }
 
     /// Return a `HashMap` of keys mapped to `Vec`s of values. The key is specified
@@ -4079,7 +4108,52 @@ pub trait Itertools: Iterator {
         K: Hash + Eq,
         F: FnMut(&V) -> K,
     {
-        group_map::into_group_map_by(self, f)
+        group_map::into_group_map_by_with_hasher(self, f, RandomState::new())
+    }
+
+    /// Return a `HashMap` of keys mapped to `Vec`s of values, using the hash builder for hashing.
+    /// See [.into_group_map_by()](crate::Itertools::into_group_map_by) for more information.
+    ///
+    /// Warning: `hash_builder` is normally randomly generated, and is designed to allow it's
+    /// users to be resistant to attacks that cause many collisions and very poor performance.
+    /// Setting it manually using this function can expose a DoS attack vector.
+    ///
+    /// ```
+    /// use itertools::Itertools;
+    /// use std::collections::HashMap;
+    /// use std::hash::RandomState;
+    ///
+    /// let data = vec![(0, 10), (2, 12), (3, 13), (0, 20), (3, 33), (2, 42)];
+    /// let lookup: HashMap<u32,Vec<(u32, u32)>, RandomState> =
+    ///     data.clone().into_iter().into_group_map_by_with_hasher(|a| a.0, RandomState::new());
+    ///
+    /// assert_eq!(lookup[&0], vec![(0,10), (0,20)]);
+    /// assert_eq!(lookup.get(&1), None);
+    /// assert_eq!(lookup[&2], vec![(2,12), (2,42)]);
+    /// assert_eq!(lookup[&3], vec![(3,13), (3,33)]);
+    ///
+    /// assert_eq!(
+    ///     data.into_iter()
+    ///         .into_group_map_by_with_hasher(|x| x.0, RandomState::new())
+    ///         .into_iter()
+    ///         .map(|(key, values)| (key, values.into_iter().fold(0,|acc, (_,v)| acc + v )))
+    ///         .collect::<HashMap<u32,u32>>()[&0],
+    ///     30,
+    /// );
+    /// ```
+    #[cfg(feature = "use_std")]
+    fn into_group_map_by_with_hasher<K, V, F, S>(
+        self,
+        f: F,
+        hash_builder: S,
+    ) -> HashMap<K, Vec<V>, S>
+    where
+        Self: Iterator<Item = V> + Sized,
+        K: Hash + Eq,
+        F: FnMut(&V) -> K,
+        S: BuildHasher,
+    {
+        group_map::into_group_map_by_with_hasher(self, f, hash_builder)
     }
 
     /// Constructs a `GroupingMap` to be used later with one of the efficient

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2582,7 +2582,32 @@ pub trait Itertools: Iterator {
         Self: Sized,
         Self::Item: Eq + Hash,
     {
-        let mut used = HashSet::new();
+        self.all_unique_with_hasher(RandomState::new())
+    }
+
+    /// Check whether all elements are unique (non equal). The specified hash builder is used for
+    /// hashing the elements. See [.all_unique](crate::Itertools::all_unique).
+    ///
+    /// ```
+    /// use std::hash::RandomState;
+    /// use itertools::Itertools;
+    ///
+    /// let data = vec![1, 2, 3, 4, 1, 5];
+    /// assert!(!data.iter().all_unique_with_hasher(RandomState::new()));
+    /// assert!(data[0..4].iter().all_unique_with_hasher(RandomState::new()));
+    /// assert!(data[1..6].iter().all_unique_with_hasher(RandomState::new()));
+    ///
+    /// let data : Option<usize> = None;
+    /// assert!(data.into_iter().all_unique_with_hasher(RandomState::new()));
+    /// ```
+    #[cfg(feature = "use_std")]
+    fn all_unique_with_hasher<S>(&mut self, hash_builder: S) -> bool
+    where
+        Self: Sized,
+        Self::Item: Eq + Hash,
+        S: BuildHasher,
+    {
+        let mut used = HashSet::with_hasher(hash_builder);
         self.all(move |elt| used.insert(elt))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,11 +64,13 @@ use alloc::{collections::VecDeque, string::String, vec::Vec};
 pub use either::Either;
 
 use core::borrow::Borrow;
+#[cfg(feature = "use_std")]
+use core::hash::BuildHasher;
 use std::cmp::Ordering;
 #[cfg(feature = "use_std")]
-use std::collections::HashMap;
-#[cfg(feature = "use_std")]
 use std::collections::HashSet;
+#[cfg(feature = "use_std")]
+use std::collections::{hash_map::RandomState, HashMap};
 use std::fmt;
 #[cfg(feature = "use_alloc")]
 use std::fmt::Write;
@@ -1575,7 +1577,33 @@ pub trait Itertools: Iterator {
         Self: Sized,
         Self::Item: Eq + Hash,
     {
-        duplicates_impl::duplicates(self)
+        duplicates_impl::duplicates_with_hasher(self, RandomState::new())
+    }
+
+    /// Return an iterator which yields the same elements as the one returned by
+    /// [.duplicates()](crate::Itertools::duplicates), but uses the specified hash builder to hash
+    /// the elements for comparison.
+    ///
+    /// Warning: `hash_builder` is normally randomly generated, and is designed to allow it's
+    /// users to be resistant to attacks that cause many collisions and very poor performance.
+    /// Setting it manually using this function can expose a DoS attack vector.
+    ///
+    /// ```
+    /// use ahash::RandomState;
+    /// use itertools::Itertools;
+    ///
+    /// let data = vec![10, 20, 30, 20, 40, 10, 50];
+    /// itertools::assert_equal(data.into_iter().duplicates_with_hasher(RandomState::new()),
+    ///                         vec![20,10]);
+    /// ```
+    #[cfg(feature = "use_std")]
+    fn duplicates_with_hasher<S>(self, hash_builder: S) -> Duplicates<Self, S>
+    where
+        Self: Sized,
+        Self::Item: Eq + Hash,
+        S: BuildHasher,
+    {
+        duplicates_impl::duplicates_with_hasher(self, hash_builder)
     }
 
     /// Return an iterator adaptor that produces elements that appear more than once during the
@@ -1602,7 +1630,38 @@ pub trait Itertools: Iterator {
         V: Eq + Hash,
         F: FnMut(&Self::Item) -> V,
     {
-        duplicates_impl::duplicates_by(self, f)
+        duplicates_impl::duplicates_by_with_hasher(self, f, RandomState::new())
+    }
+
+    /// Return an iterator which yields the same elements as the one returned by
+    /// [.duplicates()](crate::Itertools::duplicates), but uses the specified hash builder to hash
+    /// the keys for comparison.
+    ///
+    /// Warning: `hash_builder` is normally randomly generated, and is designed to allow it's
+    /// users to be resistant to attacks that cause many collisions and very poor performance.
+    /// Setting it manually using this function can expose a DoS attack vector.
+    ///
+    /// ```
+    /// use ahash::RandomState;
+    /// use itertools::Itertools;
+    ///
+    /// let data = vec!["a", "bb", "aa", "c", "ccc"];
+    /// itertools::assert_equal(data.into_iter().duplicates_by_with_hasher(|s| s.len(),RandomState::new()),
+    ///                         vec!["aa", "c"]);
+    /// ```
+    #[cfg(feature = "use_std")]
+    fn duplicates_by_with_hasher<V, F, S>(
+        self,
+        f: F,
+        hash_builder: S,
+    ) -> DuplicatesBy<Self, V, F, S>
+    where
+        Self: Sized,
+        V: Eq + Hash,
+        F: FnMut(&Self::Item) -> V,
+        S: BuildHasher,
+    {
+        duplicates_impl::duplicates_by_with_hasher(self, f, hash_builder)
     }
 
     /// Return an iterator adaptor that filters out elements that have

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1589,7 +1589,7 @@ pub trait Itertools: Iterator {
     /// Setting it manually using this function can expose a DoS attack vector.
     ///
     /// ```
-    /// use ahash::RandomState;
+    /// use std::hash::RandomState;
     /// use itertools::Itertools;
     ///
     /// let data = vec![10, 20, 30, 20, 40, 10, 50];
@@ -1634,15 +1634,15 @@ pub trait Itertools: Iterator {
     }
 
     /// Return an iterator which yields the same elements as the one returned by
-    /// [.duplicates()](crate::Itertools::duplicates), but uses the specified hash builder to hash
-    /// the keys for comparison.
+    /// [.duplicates_by()](crate::Itertools::duplicates_by), but uses the specified hash builder to
+    /// hash the keys for comparison.
     ///
     /// Warning: `hash_builder` is normally randomly generated, and is designed to allow it's
     /// users to be resistant to attacks that cause many collisions and very poor performance.
     /// Setting it manually using this function can expose a DoS attack vector.
     ///
     /// ```
-    /// use ahash::RandomState;
+    /// use std::hash::RandomState;
     /// use itertools::Itertools;
     ///
     /// let data = vec!["a", "bb", "aa", "c", "ccc"];
@@ -1688,7 +1688,33 @@ pub trait Itertools: Iterator {
         Self: Sized,
         Self::Item: Clone + Eq + Hash,
     {
-        unique_impl::unique(self)
+        unique_impl::unique_with_hasher(self, RandomState::new())
+    }
+
+    /// Return an iterator which yields the same elements as the one returned by
+    /// [.unique()](crate::Itertools::unique), but uses the specified hash builder to hash the
+    /// elements for comparison.
+    ///
+    /// Warning: `hash_builder` is normally randomly generated, and is designed to allow it's
+    /// users to be resistant to attacks that cause many collisions and very poor performance.
+    /// Setting it manually using this function can expose a DoS attack vector.
+    ///
+    /// ```
+    /// use std::hash::RandomState;
+    /// use itertools::Itertools;
+    ///
+    /// let data = vec![10, 20, 30, 20, 40, 10, 50];
+    /// itertools::assert_equal(data.into_iter().unique_with_hasher(RandomState::new()),
+    ///                         vec![10, 20, 30, 40, 50]);
+    /// ```
+    #[cfg(feature = "use_std")]
+    fn unique_with_hasher<S>(self, hash_builder: S) -> Unique<Self, S>
+    where
+        Self: Sized,
+        Self::Item: Clone + Eq + Hash,
+        S: BuildHasher,
+    {
+        unique_impl::unique_with_hasher(self, hash_builder)
     }
 
     /// Return an iterator adaptor that filters out elements that have
@@ -1716,7 +1742,34 @@ pub trait Itertools: Iterator {
         V: Eq + Hash,
         F: FnMut(&Self::Item) -> V,
     {
-        unique_impl::unique_by(self, f)
+        unique_impl::unique_by_with_hasher(self, f, RandomState::new())
+    }
+
+    /// Return an iterator which yields the same elements as the one returned by
+    /// [.unique_by()](crate::Itertools::unique_by), but uses the specified hash builder to hash
+    /// the elements for comparison.
+    ///
+    /// Warning: `hash_builder` is normally randomly generated, and is designed to allow it's
+    /// users to be resistant to attacks that cause many collisions and very poor performance.
+    /// Setting it manually using this function can expose a DoS attack vector.
+    ///
+    /// ```
+    /// use std::hash::RandomState;
+    /// use itertools::Itertools;
+    ///
+    /// let data = vec!["a", "bb", "aa", "c", "ccc"];
+    /// itertools::assert_equal(data.into_iter().unique_by_with_hasher(|s| s.len(), RandomState::new()),
+    ///                         vec!["a", "bb", "ccc"]);
+    /// ```
+    #[cfg(feature = "use_std")]
+    fn unique_by_with_hasher<V, F, S>(self, f: F, hash_builder: S) -> UniqueBy<Self, V, F, S>
+    where
+        Self: Sized,
+        V: Eq + Hash,
+        F: FnMut(&Self::Item) -> V,
+        S: BuildHasher,
+    {
+        unique_impl::unique_by_with_hasher(self, f, hash_builder)
     }
 
     /// Return an iterator adaptor that borrows from this iterator and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4997,7 +4997,19 @@ pub trait Itertools: Iterator {
         Self: Sized,
         Self::Item: Eq + Hash,
     {
-        let mut counts = HashMap::new();
+        self.counts_with_hasher(RandomState::new())
+    }
+
+    /// Collect the items in this iterator and return a `HashMap` the same way
+    /// [.counts()](crate::Itertools::counts) does, but use the specified hash builder for hashing.
+    #[cfg(feature = "use_std")]
+    fn counts_with_hasher<S>(self, hash_builder: S) -> HashMap<Self::Item, usize, S>
+    where
+        Self: Sized,
+        Self::Item: Eq + Hash,
+        S: BuildHasher,
+    {
+        let mut counts = HashMap::with_hasher(hash_builder);
         self.for_each(|item| *counts.entry(item).or_default() += 1);
         counts
     }
@@ -5042,7 +5054,20 @@ pub trait Itertools: Iterator {
         K: Eq + Hash,
         F: FnMut(Self::Item) -> K,
     {
-        self.map(f).counts()
+        self.counts_by_with_hasher(f, RandomState::new())
+    }
+
+    /// Collect the items in this iterator and return a `HashMap` the same way
+    /// [.counts_by()](crate::Itertools::counts_by) does, but use the specified hash builder for hashing.
+    #[cfg(feature = "use_std")]
+    fn counts_by_with_hasher<K, F, S>(self, f: F, hash_builder: S) -> HashMap<K, usize, S>
+    where
+        Self: Sized,
+        K: Eq + Hash,
+        F: FnMut(Self::Item) -> K,
+        S: BuildHasher,
+    {
+        self.map(f).counts_with_hasher(hash_builder)
     }
 
     /// Converts an iterator of tuples into a tuple of containers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4171,7 +4171,21 @@ pub trait Itertools: Iterator {
         Self: Iterator<Item = (K, V)> + Sized,
         K: Hash + Eq,
     {
-        grouping_map::new(self)
+        grouping_map::new(self, RandomState::new())
+    }
+
+    /// Constructs a `GroupingMap` to be used later with one of the efficient
+    /// group-and-fold operations it allows to perform, using the specified hash builder for
+    /// hashing the elements.
+    /// See [.into_grouping_map()](crate::Itertools::into_grouping_map) for more information.
+    #[cfg(feature = "use_std")]
+    fn into_grouping_map_with_hasher<K, V, S>(self, hash_builder: S) -> GroupingMap<Self, S>
+    where
+        Self: Iterator<Item = (K, V)> + Sized,
+        K: Hash + Eq,
+        S: BuildHasher,
+    {
+        grouping_map::new(self, hash_builder)
     }
 
     /// Constructs a `GroupingMap` to be used later with one of the efficient
@@ -4189,7 +4203,32 @@ pub trait Itertools: Iterator {
         K: Hash + Eq,
         F: FnMut(&V) -> K,
     {
-        grouping_map::new(grouping_map::new_map_for_grouping(self, key_mapper))
+        grouping_map::new(
+            grouping_map::new_map_for_grouping(self, key_mapper),
+            RandomState::new(),
+        )
+    }
+
+    /// Constructs a `GroupingMap` to be used later with one of the efficient
+    /// group-and-fold operations it allows to perform, using the specified hash builder for
+    /// hashing the keys.
+    /// See [.into_grouping_map_by()](crate::Itertools::into_grouping_map_by) for more information.
+    #[cfg(feature = "use_std")]
+    fn into_grouping_map_by_with_hasher<K, V, F, S>(
+        self,
+        key_mapper: F,
+        hash_builder: S,
+    ) -> GroupingMapBy<Self, F, S>
+    where
+        Self: Iterator<Item = V> + Sized,
+        K: Hash + Eq,
+        F: FnMut(&V) -> K,
+        S: BuildHasher,
+    {
+        grouping_map::new(
+            grouping_map::new_map_for_grouping(self, key_mapper),
+            hash_builder,
+        )
     }
 
     /// Return all minimum elements of an iterator.

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -1,5 +1,5 @@
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::hash::Hash;
 use std::iter::FusedIterator;

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -1,5 +1,7 @@
+use core::hash::BuildHasher;
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
+use std::collections::hash_map::RandomState;
+use std::collections::HashMap;
 use std::fmt;
 use std::hash::Hash;
 use std::iter::FusedIterator;
@@ -9,42 +11,48 @@ use std::iter::FusedIterator;
 /// See [`.unique_by()`](crate::Itertools::unique) for more information.
 #[derive(Clone)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-pub struct UniqueBy<I: Iterator, V, F> {
+pub struct UniqueBy<I: Iterator, V, F, S = RandomState>
+where
+    S: BuildHasher,
+{
     iter: I,
     // Use a Hashmap for the Entry API in order to prevent hashing twice.
     // This can maybe be replaced with a HashSet once `get_or_insert_with`
     // or a proper Entry API for Hashset is stable and meets this msrv
-    used: HashMap<V, ()>,
+    used: HashMap<V, (), S>,
     f: F,
 }
 
-impl<I, V, F> fmt::Debug for UniqueBy<I, V, F>
+impl<I, V, F, S> fmt::Debug for UniqueBy<I, V, F, S>
 where
     I: Iterator + fmt::Debug,
     V: fmt::Debug + Hash + Eq,
+    S: BuildHasher,
 {
     debug_fmt_fields!(UniqueBy, iter, used);
 }
 
 /// Create a new `UniqueBy` iterator.
-pub fn unique_by<I, V, F>(iter: I, f: F) -> UniqueBy<I, V, F>
+pub fn unique_by_with_hasher<I, V, F, S>(iter: I, f: F, hash_builder: S) -> UniqueBy<I, V, F, S>
 where
     V: Eq + Hash,
     F: FnMut(&I::Item) -> V,
     I: Iterator,
+    S: BuildHasher,
 {
     UniqueBy {
         iter,
-        used: HashMap::new(),
+        used: HashMap::with_hasher(hash_builder),
         f,
     }
 }
 
 // count the number of new unique keys in iterable (`used` is the set already seen)
-fn count_new_keys<I, K>(mut used: HashMap<K, ()>, iterable: I) -> usize
+fn count_new_keys<I, K, S>(mut used: HashMap<K, (), S>, iterable: I) -> usize
 where
     I: IntoIterator<Item = K>,
     K: Hash + Eq,
+    S: BuildHasher,
 {
     let iter = iterable.into_iter();
     let current_used = used.len();
@@ -52,11 +60,12 @@ where
     used.len() - current_used
 }
 
-impl<I, V, F> Iterator for UniqueBy<I, V, F>
+impl<I, V, F, S> Iterator for UniqueBy<I, V, F, S>
 where
     I: Iterator,
     V: Eq + Hash,
     F: FnMut(&I::Item) -> V,
+    S: BuildHasher,
 {
     type Item = I::Item;
 
@@ -77,11 +86,12 @@ where
     }
 }
 
-impl<I, V, F> DoubleEndedIterator for UniqueBy<I, V, F>
+impl<I, V, F, S> DoubleEndedIterator for UniqueBy<I, V, F, S>
 where
     I: DoubleEndedIterator,
     V: Eq + Hash,
     F: FnMut(&I::Item) -> V,
+    S: BuildHasher,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         let Self { iter, used, f } = self;
@@ -89,18 +99,20 @@ where
     }
 }
 
-impl<I, V, F> FusedIterator for UniqueBy<I, V, F>
+impl<I, V, F, S> FusedIterator for UniqueBy<I, V, F, S>
 where
     I: FusedIterator,
     V: Eq + Hash,
     F: FnMut(&I::Item) -> V,
+    S: BuildHasher,
 {
 }
 
-impl<I> Iterator for Unique<I>
+impl<I, S> Iterator for Unique<I, S>
 where
     I: Iterator,
     I::Item: Eq + Hash + Clone,
+    S: BuildHasher,
 {
     type Item = I::Item;
 
@@ -127,10 +139,11 @@ where
     }
 }
 
-impl<I> DoubleEndedIterator for Unique<I>
+impl<I, S> DoubleEndedIterator for Unique<I, S>
 where
     I: DoubleEndedIterator,
     I::Item: Eq + Hash + Clone,
+    S: BuildHasher,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         let UniqueBy { iter, used, .. } = &mut self.iter;
@@ -145,10 +158,11 @@ where
     }
 }
 
-impl<I> FusedIterator for Unique<I>
+impl<I, S> FusedIterator for Unique<I, S>
 where
     I: FusedIterator,
     I::Item: Eq + Hash + Clone,
+    S: BuildHasher,
 {
 }
 
@@ -157,31 +171,34 @@ where
 /// See [`.unique()`](crate::Itertools::unique) for more information.
 #[derive(Clone)]
 #[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
-pub struct Unique<I>
+pub struct Unique<I, S = RandomState>
 where
     I: Iterator,
     I::Item: Eq + Hash + Clone,
+    S: BuildHasher,
 {
-    iter: UniqueBy<I, I::Item, ()>,
+    iter: UniqueBy<I, I::Item, (), S>,
 }
 
-impl<I> fmt::Debug for Unique<I>
+impl<I, S> fmt::Debug for Unique<I, S>
 where
     I: Iterator + fmt::Debug,
     I::Item: Hash + Eq + fmt::Debug + Clone,
+    S: BuildHasher,
 {
     debug_fmt_fields!(Unique, iter);
 }
 
-pub fn unique<I>(iter: I) -> Unique<I>
+pub fn unique_with_hasher<I, S>(iter: I, hash_builder: S) -> Unique<I, S>
 where
     I: Iterator,
     I::Item: Eq + Hash + Clone,
+    S: BuildHasher,
 {
     Unique {
         iter: UniqueBy {
             iter,
-            used: HashMap::new(),
+            used: HashMap::with_hasher(hash_builder),
             f: (),
         },
     }

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -20,7 +20,30 @@ use rand::{
     Rng, SeedableRng,
 };
 use rand::{seq::SliceRandom, thread_rng};
+use std::collections::HashMap;
+use std::hash::BuildHasher;
+use std::hash::RandomState;
+use std::iter::empty;
 use std::{cmp::min, fmt::Debug, marker::PhantomData};
+
+// A Hasher which forwards it's calls to RandomState to make sure different hashers
+// are accepted in the various *_with_hasher methods.
+#[derive(Default)]
+struct TestHasher(RandomState);
+
+impl TestHasher {
+    fn new() -> Self {
+        TestHasher(RandomState::new())
+    }
+}
+
+impl BuildHasher for TestHasher {
+    type Hasher = <RandomState as BuildHasher>::Hasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        self.0.build_hasher()
+    }
+}
 
 #[test]
 fn product3() {
@@ -76,6 +99,10 @@ fn duplicates_by() {
         ys_rev.iter(),
         xs.iter().duplicates_by(|x| x[..2].to_string()).rev(),
     );
+
+    let _ = empty::<u8>()
+        .duplicates_by_with_hasher(|x| *x, TestHasher::new())
+        .next();
 }
 
 #[test]
@@ -103,6 +130,10 @@ fn duplicates() {
     );
     let ys_rev = vec![2, 1];
     assert_eq!(ys_rev, xs.iter().duplicates().rev().cloned().collect_vec());
+
+    let _ = empty::<u8>()
+        .duplicates_with_hasher(TestHasher::new())
+        .next();
 }
 
 #[test]
@@ -119,6 +150,8 @@ fn unique_by() {
         ys_rev.iter(),
         xs.iter().unique_by(|x| x[..2].to_string()).rev(),
     );
+
+    let _ = empty::<u8>().unique_by_with_hasher(|x| *x, TestHasher::new());
 }
 
 #[test]
@@ -136,6 +169,8 @@ fn unique() {
     it::assert_equal(ys.iter(), xs.iter().rev().unique().rev());
     let ys_rev = [1, 0];
     it::assert_equal(ys_rev.iter(), xs.iter().unique().rev());
+
+    let _ = empty::<u8>().unique_with_hasher(TestHasher::new());
 }
 
 #[test]
@@ -301,6 +336,8 @@ fn all_unique() {
     assert!("ABCDEFGH".chars().all_unique());
     assert!(!"ABCDEFGA".chars().all_unique());
     assert!(::std::iter::empty::<usize>().all_unique());
+
+    let _ = empty::<u8>().all_unique_with_hasher(TestHasher::new());
 }
 
 #[test]
@@ -1596,4 +1633,41 @@ fn multiunzip() {
             vec![11]
         )
     );
+}
+
+#[test]
+fn into_group_map_with_hasher() {
+    let _: HashMap<_, _, TestHasher> =
+        empty::<(u8, u8)>().into_group_map_with_hasher(TestHasher::new());
+}
+
+#[test]
+fn into_group_map_by_with_hasher() {
+    let _: HashMap<_, _, TestHasher> =
+        empty::<(u8, u8)>().into_group_map_by_with_hasher(|x| *x, TestHasher::new());
+}
+
+#[test]
+fn into_grouping_map_with_hasher() {
+    let _: HashMap<_, Vec<_>, TestHasher> = empty::<(u8, u8)>()
+        .into_grouping_map_with_hasher(TestHasher::new())
+        .collect();
+}
+
+#[test]
+fn into_grouping_map_by_with_hasher() {
+    let _: HashMap<_, Vec<_>, TestHasher> = empty::<(u8, u8)>()
+        .into_grouping_map_by_with_hasher(|x| *x, TestHasher::new())
+        .collect();
+}
+
+#[test]
+fn counts_with_hasher() {
+    let _: HashMap<_, _, TestHasher> = empty::<u8>().counts_with_hasher(TestHasher::new());
+}
+
+#[test]
+fn counts_by_with_hasher() {
+    let _: HashMap<_, _, TestHasher> =
+        empty::<u8>().counts_by_with_hasher(|x| x, TestHasher::new());
 }


### PR DESCRIPTION
Closes #998

Implementations for the following methods:

- duplicates_with_hasher
- duplicates_by_with_hasher
- unique_with_hasher
- unique_by_with_hasher
- all_unique_with_hasher
- into_group_map_with_hasher
- into_group_map_by_with_hasher
- into_grouping_map_with_hasher
- into_grouping_map_by_with_hasher
- counts_with_hasher
- counts_by_with_hasher