### PR TITLE
Add "[must-use]" attribute into collect vec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2299,6 +2299,7 @@ pub trait Itertools: Iterator {
 
     /// `.collect_vec()` is simply a type specialization of [`Iterator::collect`],
     /// for convenience.
+    #[must_use = "if you really need to exhaust the iterator, consider `.for_each(drop)` instead"]
     #[cfg(feature = "use_alloc")]
     fn collect_vec(self) -> Vec<Self::Item>
     where
@@ -2330,6 +2331,7 @@ pub trait Itertools: Iterator {
     ///
     /// # let _ = do_stuff;
     /// ```
+    #[must_use = "if you really need to exhaust the iterator, consider `.for_each(drop)` instead"]
     fn try_collect<T, U, E>(self) -> Result<U, E>
     where
         Self: Sized + Iterator<Item = Result<T, E>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2331,7 +2331,6 @@ pub trait Itertools: Iterator {
     ///
     /// # let _ = do_stuff;
     /// ```
-    #[must_use = "if you really need to exhaust the iterator, consider `.for_each(drop)` instead"]
     fn try_collect<T, U, E>(self) -> Result<U, E>
     where
         Self: Sized + Iterator<Item = Result<T, E>>,


### PR DESCRIPTION
This might lead to the problems as following:

```
    pub fn unique_id(&self) -> impl Hash + PartialEq + Eq {
        self.items.iter().map(|x| x.id_string.clone()).collect::<Vec<_>>();
    }
```

This code has a typo and rust warns against it:

> unused return value of `collect` that must be used
> if you really need to exhaust the iterator, consider `.for_each(drop)` instead
> `#[warn(unused_must_use)]` on by defaultrustc[Click for full compiler diagnostic](rust-analyzer-diagnostics-view:/diagnostic%20message%20[0]?0#file:///Users/pzixel/Documents/Repos/backend-garden/src/models/mod.rs)
> mod.rs(964, 9): use `let _ = ...` to ignore the resulting value: `let _ = `

If you replace it with following:

```
    pub fn unique_id(&self) -> impl Hash + PartialEq + Eq {
        self.items.iter().map(|x| x.id_string.clone()).collect_vec();
    }
```

No warning will be generated, as no `must_use` attribute exist on the function.

This PR adds it, while small, it can lead to huge problems, since `()` implements a lot of traits and `impl Trait` are used very often with iterators, so you can erroneously use one instead of another.


P.S. I also noticed that `try_collect` only works with `#[cfg(feature = "use_alloc")]`, but `try_collect` doesn't. I'm not sure if this is intended.