### PR TITLE
Remove `Clone` bound from `{array,tuple}_combinations`

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -629,7 +629,7 @@ pub trait HasCombination<I>: Sized {
 /// Create a new `TupleCombinations` from a clonable iterator.
 pub fn tuple_combinations<T, I>(iter: I) -> TupleCombinations<I, T>
 where
-    I: Iterator + Clone,
+    I: Iterator,
     I::Item: Clone,
     T: HasCombination<I>,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1715,7 +1715,7 @@ pub trait Itertools: Iterator {
     #[cfg(feature = "use_alloc")]
     fn array_combinations<const K: usize>(self) -> ArrayCombinations<Self, K>
     where
-        Self: Sized + Clone,
+        Self: Sized,
         Self::Item: Clone,
     {
         combinations::array_combinations(self)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1667,7 +1667,7 @@ pub trait Itertools: Iterator {
     /// ```
     fn tuple_combinations<T>(self) -> TupleCombinations<Self, T>
     where
-        Self: Sized + Clone,
+        Self: Sized,
         Self::Item: Clone,
         T: adaptors::HasCombination<Self>,
     {


### PR DESCRIPTION
Not sure why it was there on `tuple_combinations` in the first place, and pretty sure it was copied over by mistake on `array_combinations`.