### PR TITLE
Fix denied warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -888,7 +888,10 @@ pub trait Itertools: Iterator {
     /// ```rust
     /// use itertools::Itertools;
     ///
-    /// (1i32..42i32).map_into::<f64>().collect_vec();
+    /// assert_eq!(
+    ///     (1i32..4i32).map_into::<f64>().collect_vec(),
+    ///     vec![1f64, 2f64, 3f64]
+    /// );
     /// ```
     fn map_into<R>(self) -> MapInto<Self, R>
     where


### PR DESCRIPTION
Follow-up to https://github.com/rust-itertools/itertools/pull/1009.

Result of collect_vec must be used, and the documentation is arguably better if we showcase the result of `map_into` via `assert_eq`.

@jswrenn In case this succeeds in CI, could you please merge it?