### PR TITLE
into_group_map: make code more idiomatic

### DIFF
--- a/src/group_map.rs
+++ b/src/group_map.rs
@@ -13,10 +13,10 @@ where
     I: Iterator<Item = (K, V)>,
     K: Hash + Eq,
 {
-    let mut lookup = HashMap::new();
+    let mut lookup = HashMap::<K, Vec<V>>::new();
 
     iter.for_each(|(key, val)| {
-        lookup.entry(key).or_insert_with(Vec::new).push(val);
+        lookup.entry(key).or_default().push(val);
     });
 
     lookup


### PR DESCRIPTION
This shouldn't change any runtime. I just noticed this while using the function, as i replaced exactly this (new) code, with the itertools version and wanted to contribute it back.