### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3991,8 +3991,8 @@ pub trait Itertools: Iterator {
     /// - `NoElements` if the iterator is empty.
     /// - `OneElement(x)` if the iterator has exactly one element.
     /// - `MinMax(x, y)` is returned otherwise, where `x <= y`. Two
-    ///    values are equal if and only if there is more than one
-    ///    element in the iterator and all elements are equal.
+    ///   values are equal if and only if there is more than one
+    ///   element in the iterator and all elements are equal.
     ///
     /// On an iterator of length `n`, `minmax` does `1.5 * n` comparisons,
     /// and so is faster than calling `min` and `max` separately which does
@@ -4251,9 +4251,9 @@ pub trait Itertools: Iterator {
     /// - `NoElements` if the iterator is empty.
     /// - `OneElement(xpos)` if the iterator has exactly one element.
     /// - `MinMax(xpos, ypos)` is returned otherwise, where the
-    ///    element at `xpos` ≤ the element at `ypos`. While the
-    ///    referenced elements themselves may be equal, `xpos` cannot
-    ///    be equal to `ypos`.
+    ///   element at `xpos` ≤ the element at `ypos`. While the
+    ///   referenced elements themselves may be equal, `xpos` cannot
+    ///   be equal to `ypos`.
     ///
     /// On an iterator of length `n`, `position_minmax` does `1.5 * n`
     /// comparisons, and so is faster than calling `position_min` and

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -450,7 +450,13 @@ quickcheck! {
         }
         assert_eq!(answer, actual);
 
-        assert_eq!(answer.into_iter().last(), a.multi_cartesian_product().last());
+        assert_eq!(
+            {
+                #[allow(clippy::double_ended_iterator_last)]
+                answer.into_iter().last()
+            },
+            a.multi_cartesian_product().last()
+        );
     }
 
     fn correct_empty_multi_product() -> () {

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -503,7 +503,10 @@ quickcheck! {
             }
 
             check_results_specialized!(it, |i| i.count());
-            check_results_specialized!(it, |i| i.last());
+            check_results_specialized!(it, |i| {
+                #[allow(clippy::double_ended_iterator_last)]
+                i.last()
+            });
             check_results_specialized!(it, |i| i.collect::<Vec<_>>());
             check_results_specialized!(it, |i| i.rev().collect::<Vec<_>>());
             check_results_specialized!(it, |i| {

--- a/tests/test_core.rs
+++ b/tests/test_core.rs
@@ -281,6 +281,7 @@ fn count_clones() {
         let f = Foo { n: Cell::new(0) };
         let it = it::repeat_n(f, n);
         // drain it
+        #[allow(clippy::double_ended_iterator_last)]
         let last = it.last();
         if n == 0 {
             assert_eq!(last, None);


### PR DESCRIPTION
* Overindented list items in doc
* Allow calling `last` on `DoubleEndedIterator` in tests