### PR TITLE
Canonicalize `all_equal_value`'s error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking
 - Restructure `Position` as struct instead of enum (#1042, #1043)
+- Canonicalize `all_equal_value`'s error type (#1032)
 
 ### Added
 - Add `*_with_hasher` adaptors (#1007)

--- a/src/all_equal_value_err.rs
+++ b/src/all_equal_value_err.rs
@@ -1,0 +1,3 @@
+/// Value returned for the error case of `Itertools::all_equal_value()`.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AllEqualValueError<Item>(pub Option<[Item; 2]>);

--- a/src/all_equal_value_err.rs
+++ b/src/all_equal_value_err.rs
@@ -1,3 +1,31 @@
-/// Value returned for the error case of `Itertools::all_equal_value()`.
+#[cfg(doc)]
+use crate::Itertools;
+#[cfg(feature = "use_std")]
+use std::error::Error;
+use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
+
+/// Value returned for the error case of [`Itertools::all_equal_value`].
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AllEqualValueError<Item>(pub Option<[Item; 2]>);
+
+impl<Item> Display for AllEqualValueError<Item> {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        match self.0 {
+            None => {
+                write!(
+                    f,
+                    "got zero elements when all elements were expected to be equal"
+                )
+            }
+            Some([_, _]) => {
+                write!(
+                    f,
+                    "got different elements when all elements were expected to be equal"
+                )
+            }
+        }
+    }
+}
+
+#[cfg(feature = "use_std")]
+impl<Item> Error for AllEqualValueError<Item> where Item: Debug {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ pub mod structs {
         FilterOk, Interleave, InterleaveShortest, MapInto, MapOk, Positions, Product, PutBack,
         TakeWhileRef, TupleCombinations, Update, WhileSome,
     };
+    pub use crate::all_equal_value_err::AllEqualValueError;
     pub use crate::array_impl::{ArrayWindows, CircularArrayWindows};
     #[cfg(feature = "use_alloc")]
     pub use crate::combinations::{ArrayCombinations, Combinations};
@@ -184,6 +185,7 @@ pub use crate::either_or_both::EitherOrBoth;
 pub mod free;
 #[doc(inline)]
 pub use crate::free::*;
+mod all_equal_value_err;
 #[cfg(feature = "use_alloc")]
 mod combinations;
 #[cfg(feature = "use_alloc")]
@@ -2535,27 +2537,27 @@ pub trait Itertools: Iterator {
     /// two non-equal elements found.
     ///
     /// ```
-    /// use itertools::Itertools;
+    /// use itertools::{Itertools, AllEqualValueError};
     ///
     /// let data = vec![1, 1, 1, 2, 2, 3, 3, 3, 4, 5, 5];
-    /// assert_eq!(data.iter().all_equal_value(), Err(Some((&1, &2))));
+    /// assert_eq!(data.iter().all_equal_value(), Err(AllEqualValueError(Some([&1, &2]))));
     /// assert_eq!(data[0..3].iter().all_equal_value(), Ok(&1));
     /// assert_eq!(data[3..5].iter().all_equal_value(), Ok(&2));
     /// assert_eq!(data[5..8].iter().all_equal_value(), Ok(&3));
     ///
     /// let data: Option<usize> = None;
-    /// assert_eq!(data.into_iter().all_equal_value(), Err(None));
+    /// assert_eq!(data.into_iter().all_equal_value(), Err(AllEqualValueError(None)));
     /// ```
     #[allow(clippy::type_complexity)]
-    fn all_equal_value(&mut self) -> Result<Self::Item, Option<(Self::Item, Self::Item)>>
+    fn all_equal_value(&mut self) -> Result<Self::Item, AllEqualValueError<Self::Item>>
     where
         Self: Sized,
         Self::Item: PartialEq,
     {
-        let first = self.next().ok_or(None)?;
+        let first = self.next().ok_or(AllEqualValueError(None))?;
         let other = self.find(|x| x != &first);
         if let Some(other) = other {
-            Err(Some((first, other)))
+            Err(AllEqualValueError(Some([first, other])))
         } else {
             Ok(first)
         }

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -9,6 +9,7 @@ use crate::it::multipeek;
 use crate::it::multizip;
 use crate::it::peek_nth;
 use crate::it::repeat_n;
+use crate::it::AllEqualValueError;
 use crate::it::ExactlyOneError;
 use crate::it::FoldWhile;
 use crate::it::Itertools;
@@ -317,14 +318,17 @@ fn all_equal() {
 
 #[test]
 fn all_equal_value() {
-    assert_eq!("".chars().all_equal_value(), Err(None));
+    assert_eq!("".chars().all_equal_value(), Err(AllEqualValueError(None)));
     assert_eq!("A".chars().all_equal_value(), Ok('A'));
-    assert_eq!("AABBCCC".chars().all_equal_value(), Err(Some(('A', 'B'))));
+    assert_eq!(
+        "AABBCCC".chars().all_equal_value(),
+        Err(AllEqualValueError(Some(['A', 'B'])))
+    );
     assert_eq!("AAAAAAA".chars().all_equal_value(), Ok('A'));
     {
         let mut it = [1, 2, 3].iter().copied();
         let result = it.all_equal_value();
-        assert_eq!(result, Err(Some((1, 2))));
+        assert_eq!(result, Err(AllEqualValueError(Some([1, 2]))));
         let remaining = it.next();
         assert_eq!(remaining, Some(3));
         assert!(it.next().is_none());


### PR DESCRIPTION
Similar to `exactly_one_error`'s error type, `all_equal_value`'s error type now implements `std::error::Error`. (I saw the discrepancy because [`exactly_one_error` works with `anyhow`, whereas `all_equal_value` does not](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=1a7b1ab8181cc5345ecc2461709b8cf6).)

Since I had to introduce a new type anyways, I converted from `(Item, Item)` to `[Item; 2]`. I suggest we generally lean towards arrays instead of tuples if the components have the same type.