### PR TITLE
Implement `Debug` for remaining public types

### DIFF
--- a/src/adaptors/coalesce.rs
+++ b/src/adaptors/coalesce.rs
@@ -110,8 +110,10 @@ where
 {
 }
 
+#[derive(Debug)]
 pub struct NoCount;
 
+#[derive(Debug)]
 pub struct WithCount;
 
 pub trait CountItem<T> {

--- a/src/groupbylazy.rs
+++ b/src/groupbylazy.rs
@@ -1,5 +1,6 @@
 use alloc::vec::{self, Vec};
 use std::cell::{Cell, RefCell};
+use std::fmt::Debug;
 
 /// A trait to unify `FnMut` for `ChunkBy` with the chunk key in `IntoChunks`
 trait KeyFunction<A> {
@@ -74,6 +75,27 @@ where
     /// index of last group iter that was dropped,
     /// `usize::MAX` initially when no group was dropped
     dropped_group: usize,
+}
+
+impl<K, I, F> Debug for GroupInner<K, I, F>
+where
+    K: Debug,
+    I: Iterator + Debug,
+    I::Item: Debug,
+{
+    debug_fmt_fields!(
+        GroupInner,
+        // key, omitted because functions are almost never Debug
+        iter,
+        current_key,
+        current_elt,
+        done,
+        top_group,
+        oldest_buffered_group,
+        bottom_group,
+        buffer,
+        dropped_group
+    );
 }
 
 impl<K, I, F> GroupInner<K, I, F>
@@ -311,6 +333,15 @@ where
     index: Cell<usize>,
 }
 
+impl<K, I, F> Debug for ChunkBy<K, I, F>
+where
+    K: Debug,
+    I: Iterator + Debug,
+    I::Item: Debug,
+{
+    debug_fmt_fields!(ChunkBy, inner, index);
+}
+
 /// Create a new
 pub fn new<K, J, F>(iter: J, f: F) -> ChunkBy<K, J::IntoIter, F>
 where
@@ -385,6 +416,15 @@ where
     parent: &'a ChunkBy<K, I, F>,
 }
 
+impl<'a, K, I, F> Debug for Groups<'a, K, I, F>
+where
+    K: Debug,
+    I: Iterator + Debug,
+    I::Item: Debug,
+{
+    debug_fmt_fields!(Groups, parent);
+}
+
 impl<'a, K, I, F> Iterator for Groups<'a, K, I, F>
 where
     I: Iterator,
@@ -436,6 +476,15 @@ where
     fn drop(&mut self) {
         self.parent.drop_group(self.index);
     }
+}
+
+impl<'a, K, I, F> Debug for Group<'a, K, I, F>
+where
+    K: Debug,
+    I: Iterator + Debug,
+    I::Item: Debug,
+{
+    debug_fmt_fields!(Group, parent, index, first);
 }
 
 impl<'a, K, I, F> Iterator for Group<'a, K, I, F>
@@ -503,6 +552,14 @@ where
     index: Cell<usize>,
 }
 
+impl<I> Debug for IntoChunks<I>
+where
+    I: Iterator + Debug,
+    I::Item: Debug,
+{
+    debug_fmt_fields!(IntoChunks, inner, index);
+}
+
 impl<I> Clone for IntoChunks<I>
 where
     I: Clone + Iterator,
@@ -554,6 +611,14 @@ where
     parent: &'a IntoChunks<I>,
 }
 
+impl<'a, I> Debug for Chunks<'a, I>
+where
+    I: Iterator + Debug,
+    I::Item: Debug,
+{
+    debug_fmt_fields!(Chunks, parent);
+}
+
 impl<'a, I> Iterator for Chunks<'a, I>
 where
     I: Iterator,
@@ -577,6 +642,7 @@ where
 /// An iterator for the elements in a single chunk.
 ///
 /// Iterator element type is `I::Item`.
+#[derive(Debug)]
 pub struct Chunk<'a, I>
 where
     I: Iterator + 'a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs, clippy::default_numeric_fallback)]
+#![warn(missing_debug_implementations)]
 #![crate_name = "itertools"]
 #![cfg_attr(not(feature = "use_std"), no_std)]
 #![doc(test(attr(deny(warnings), allow(deprecated, unstable_name_collisions))))]


### PR DESCRIPTION
Implement `Debug` for the `ChunkBy`-related types.  Also derive it for two `Coalesce`-related types; I'm not sure they are actually exposed but the compiler thinks so, and it's easy to do.

There are no more public types without a `Debug` impl (at least a conditional one) so enable warning for missing `Debug` implementations.