### PR TITLE
Specialize ExactlyOneError::count

### DIFF
--- a/src/exactly_one_err.rs
+++ b/src/exactly_one_err.rs
@@ -64,6 +64,13 @@ where
         size_hint::add_scalar(self.inner.size_hint(), self.additional_len())
     }
 
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.additional_len() + self.inner.count()
+    }
+
     fn fold<B, F>(self, mut init: B, mut f: F) -> B
     where
         F: FnMut(B, Self::Item) -> B,

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -1391,6 +1391,16 @@ quickcheck! {
 }
 
 quickcheck! {
+    fn exactly_one_count(a: Vec<i32>) -> TestResult {
+        let ret = a.iter().cloned().exactly_one();
+        match a.len() {
+            1 => TestResult::passed(),
+            len => TestResult::from_bool(len == ret.unwrap_err().count()),
+        }
+    }
+}
+
+quickcheck! {
     fn at_most_one_i32(a: Vec<i32>) -> TestResult {
         let ret = a.iter().cloned().at_most_one();
         match a.len() {


### PR DESCRIPTION
Useful because inner iterator may have `count()` specialized.