### PR TITLE
impl DoubleEndedIterator for ExactlyOneError

### DIFF
--- a/src/exactly_one_err.rs
+++ b/src/exactly_one_err.rs
@@ -2,7 +2,7 @@
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 
-use std::iter::ExactSizeIterator;
+use std::iter::{ExactSizeIterator, Fuse};
 
 use either::Either;
 
@@ -22,7 +22,7 @@ where
     I: Iterator,
 {
     first_two: Option<Either<[I::Item; 2], I::Item>>,
-    inner: I,
+    inner: Fuse<I>,
 }
 
 impl<I> ExactlyOneError<I>
@@ -31,7 +31,10 @@ where
 {
     /// Creates a new `ExactlyOneErr` iterator.
     pub(crate) fn new(first_two: Option<Either<[I::Item; 2], I::Item>>, inner: I) -> Self {
-        Self { first_two, inner }
+        Self {
+            first_two,
+            inner: inner.fuse(),
+        }
     }
 
     fn additional_len(&self) -> usize {
@@ -88,6 +91,22 @@ where
 }
 
 impl<I> ExactSizeIterator for ExactlyOneError<I> where I: ExactSizeIterator {}
+
+impl<I: DoubleEndedIterator> DoubleEndedIterator for ExactlyOneError<I> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if let Some(next) = self.inner.next_back() {
+            return Some(next);
+        };
+        match self.first_two.take() {
+            Some(Either::Left([first, second])) => {
+                self.first_two = Some(Either::Right(first));
+                Some(second)
+            }
+            Some(Either::Right(second)) => Some(second),
+            None => None,
+        }
+    }
+}
 
 impl<I> Display for ExactlyOneError<I>
 where

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -1401,6 +1401,16 @@ quickcheck! {
 }
 
 quickcheck! {
+    fn exactly_one_double_ended(a: Vec<i32>) -> TestResult {
+        let ret = a.iter().copied().exactly_one();
+        match a.len() {
+            1 => TestResult::passed(),
+            _ => TestResult::from_bool(a.iter().rev().copied().eq(ret.unwrap_err().rev())),
+        }
+    }
+}
+
+quickcheck! {
     fn at_most_one_i32(a: Vec<i32>) -> TestResult {
         let ret = a.iter().cloned().at_most_one();
         match a.len() {


### PR DESCRIPTION
For completeness.

#1046 discusses alternative signature of `.exactly_one`, but while current API exists, why not make it more flexible.