### PR TITLE
Support `hashbrown` hash maps and sets with or without `use_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ test = false
 
 [dependencies]
 either = { version = "1.0", default-features = false }
+hashbrown = { version = "0.15", optional = true, default-features = false, features = [
+    "alloc",
+    "default-hasher",
+] }
 
 [dev-dependencies]
 rand = "0.7"
@@ -36,6 +40,7 @@ quickcheck = { version = "0.9", default-features = false }
 default = ["use_std"]
 use_std = ["use_alloc", "either/use_std"]
 use_alloc = []
+hashbrown = ["dep:hashbrown", "use_alloc"]
 
 [profile]
 bench = { debug = true }

--- a/src/duplicates_impl.rs
+++ b/src/duplicates_impl.rs
@@ -1,6 +1,9 @@
 use std::hash::Hash;
 
 mod private {
+    #[cfg(feature = "hashbrown")]
+    use hashbrown::HashMap;
+    #[cfg(not(feature = "hashbrown"))]
     use std::collections::HashMap;
     use std::fmt;
     use std::hash::Hash;

--- a/src/group_map.rs
+++ b/src/group_map.rs
@@ -1,5 +1,9 @@
-#![cfg(feature = "use_std")]
+#![cfg(any(feature = "use_std", feature = "hashbrown"))]
 
+use alloc::vec::Vec;
+#[cfg(feature = "hashbrown")]
+use hashbrown::HashMap;
+#[cfg(not(feature = "hashbrown"))]
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::iter::Iterator;

--- a/src/grouping_map.rs
+++ b/src/grouping_map.rs
@@ -2,7 +2,10 @@ use crate::{
     adaptors::map::{MapSpecialCase, MapSpecialCaseFn},
     MinMaxResult,
 };
+#[cfg(feature = "hashbrown")]
+use hashbrown::HashMap;
 use std::cmp::Ordering;
+#[cfg(not(feature = "hashbrown"))]
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::iter::Iterator;

--- a/src/unique_impl.rs
+++ b/src/unique_impl.rs
@@ -1,5 +1,7 @@
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+#[cfg(feature = "hashbrown")]
+use hashbrown::{hash_map::Entry, HashMap};
+#[cfg(not(feature = "hashbrown"))]
+use std::collections::{hash_map::Entry, HashMap};
 use std::fmt;
 use std::hash::Hash;
 use std::iter::FusedIterator;


### PR DESCRIPTION
Add an optional `hashbrown` feature that switches the underlying hash map implementation from `std::collections` to `hashbrown` and makes items that depend on hash maps available without `use_std` (although it still requires and implicitly enables `use_alloc`).

This addresses the motivating use case of [#605][] (which is the same use case that I am interested in) but does not implement a generic approach as the issue suggests. [#901][] would be a better solution long term and would make these changes obsolete, but the PR appears to be stalled and I wanted a simple solution that allows using APIs like `unique`/`unique_by` with `no_std` now.

It also partially addresses [#322][] because enabling this feature does switch to *a* faster hash algorithm, it just doesn't allow to specify which one exactly (currently the default hasher in `hashbrown` is `foldhash`, so this is what's going to be used until/unless changed upstream in the future).

[#605]: https://github.com/rust-itertools/itertools/issues/605
[#901]: https://github.com/rust-itertools/itertools/pull/901
[#322]: https://github.com/rust-itertools/itertools/issues/322

--- 

TODO:
- [ ] fix tests compilation with `--all-features`/`-F hashbrown`
- [ ] run tests on CI with both hash map implementations
- [ ] adjust contributor doc in the section about `use_std`

I'm opening a draft PR early because I'd like to get feedback on whether it's something you want to have.