### PR TITLE
make chunk iterator implement clone

### DIFF
--- a/src/groupbylazy.rs
+++ b/src/groupbylazy.rs
@@ -647,6 +647,20 @@ where
     first: Option<I::Item>,
 }
 
+impl<'a, I> Clone for Chunk<'a, I>
+where
+    I: Iterator,
+    I::Item: 'a + Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            parent: self.parent,
+            index: self.index,
+            first: self.first.clone(),
+        }
+    }
+}
+
 impl<'a, I> Drop for Chunk<'a, I>
 where
     I: Iterator,


### PR DESCRIPTION
Hi, I had a reason that I wanted to `Clone` a `Chunk` iterator from the `chunks(...)` adapter.

I can't see a reason that this impl would be bad, so I figured I would send a PR.

Let me know what you think, thanks