### PR TITLE
Fix warnings apparent as of Rust 1.90

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -523,7 +523,7 @@ where
 }
 
 /// Create a new `TakeWhileRef` from a reference to clonable iterator.
-pub fn take_while_ref<I, F>(iter: &mut I, f: F) -> TakeWhileRef<I, F>
+pub fn take_while_ref<I, F>(iter: &mut I, f: F) -> TakeWhileRef<'_, I, F>
 where
     I: Iterator + Clone,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1518,7 +1518,7 @@ pub trait Itertools: Iterator {
     ///
     /// See also [`.take_while_ref()`](Itertools::take_while_ref)
     /// which is a similar adaptor.
-    fn peeking_take_while<F>(&mut self, accept: F) -> PeekingTakeWhile<Self, F>
+    fn peeking_take_while<F>(&mut self, accept: F) -> PeekingTakeWhile<'_, Self, F>
     where
         Self: Sized + PeekingNext,
         F: FnMut(&Self::Item) -> bool,
@@ -1543,7 +1543,7 @@ pub trait Itertools: Iterator {
     /// assert_eq!(decimals, "0123456789");
     /// assert_eq!(hexadecimals.next(), Some('a'));
     /// ```
-    fn take_while_ref<F>(&mut self, accept: F) -> TakeWhileRef<Self, F>
+    fn take_while_ref<F>(&mut self, accept: F) -> TakeWhileRef<'_, Self, F>
     where
         Self: Clone,
         F: FnMut(&Self::Item) -> bool,
@@ -2506,7 +2506,7 @@ pub trait Itertools: Iterator {
     ///     format!("{:.2}", data.iter().format(", ")),
     ///            "1.10, 2.72, -3.00");
     /// ```
-    fn format(self, sep: &str) -> Format<Self>
+    fn format(self, sep: &str) -> Format<'_, Self>
     where
         Self: Sized,
     {
@@ -2545,7 +2545,7 @@ pub trait Itertools: Iterator {
     ///
     ///
     /// ```
-    fn format_with<F>(self, sep: &str, format: F) -> FormatWith<Self, F>
+    fn format_with<F>(self, sep: &str, format: F) -> FormatWith<'_, Self, F>
     where
         Self: Sized,
         F: FnMut(Self::Item, &mut dyn FnMut(&dyn fmt::Display) -> fmt::Result) -> fmt::Result,

--- a/src/peeking_take_while.rs
+++ b/src/peeking_take_while.rs
@@ -126,7 +126,7 @@ where
 }
 
 /// Create a `PeekingTakeWhile`
-pub fn peeking_take_while<I, F>(iter: &mut I, f: F) -> PeekingTakeWhile<I, F>
+pub fn peeking_take_while<I, F>(iter: &mut I, f: F) -> PeekingTakeWhile<'_, I, F>
 where
     I: Iterator,
 {

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -443,13 +443,13 @@ fn kmerge_empty() {
 
 #[test]
 fn kmerge_size_hint() {
-    let its = (0..5).map(|_| (0..10));
+    let its = (0..5).map(|_| 0..10);
     assert_eq!(its.kmerge().size_hint(), (50, Some(50)));
 }
 
 #[test]
 fn kmerge_empty_size_hint() {
-    let its = (0..5).map(|_| (0..0));
+    let its = (0..5).map(|_| 0..0);
     assert_eq!(its.kmerge().size_hint(), (0, Some(0)));
 }
 


### PR DESCRIPTION
I compiled with `cargo check -j8 --all-targets` and fixed the warnings popping up.