### PR TITLE
Fix `pad_using` bug producing items when it shouldn't

### DIFF
--- a/src/pad_tail.rs
+++ b/src/pad_tail.rs
@@ -87,12 +87,15 @@ where
     where
         G: FnMut(B, Self::Item) -> B,
     {
-        let mut pos = self.elements_from_next;
+        let mut start = self.elements_from_next;
         init = self.iter.fold(init, |acc, item| {
-            pos += 1;
+            start += 1;
             f(acc, item)
         });
-        (pos..self.elements_required).map(self.filler).fold(init, f)
+
+        let end = self.elements_required - self.elements_from_next_back;
+
+        (start..end).map(self.filler).fold(init, f)
     }
 }
 

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -144,7 +144,7 @@ where
     let mut fwd = it.clone();
     let mut bwd = it.clone();
 
-    for _ in fwd.by_ref() {}
+    while fwd.next().is_some() {}
 
     assert_eq!(
         fwd.next_back(),

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -119,6 +119,15 @@ where
         }
     }
     check_specialized!(it, |i| {
+        let mut parameters_from_fold = vec![];
+        let fold_result = i.fold(vec![], |mut acc, v: I::Item| {
+            parameters_from_fold.push((acc.clone(), v.clone()));
+            acc.push(v);
+            acc
+        });
+        (parameters_from_fold, fold_result)
+    });
+    check_specialized!(it, |i| {
         let mut parameters_from_rfold = vec![];
         let rfold_result = i.rfold(vec![], |mut acc, v: I::Item| {
             parameters_from_rfold.push((acc.clone(), v.clone()));

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -131,6 +131,25 @@ where
     for n in 0..size + 2 {
         check_specialized!(it, |mut i| i.nth_back(n));
     }
+
+    let mut fwd = it.clone();
+    let mut bwd = it.clone();
+
+    for _ in fwd.by_ref() {}
+
+    assert_eq!(
+        fwd.next_back(),
+        None,
+        "iterator leaks elements after consuming forwards"
+    );
+
+    while bwd.next_back().is_some() {}
+
+    assert_eq!(
+        bwd.next(),
+        None,
+        "iterator leaks elements after consuming backwards"
+    );
 }
 
 quickcheck! {


### PR DESCRIPTION
I added a test to the double ended iterator specialization that catches this bug in `pad_using`, where if exhaust the iterator from either calling `next` or `next_back` and then call the other pair, it would still produce elements.

If you just add that test, you'll see `pad_using` fails. Next, I fixed `pad_using` to keep track of how many items from the back it's taken, so we can use that to correctly exhaust the iterator when needed.

~~Question: since this adds fields + debug formatted fields to a public struct, this is a breaking change, right?~~ Apparently not.

Fixes: #1065 