### PR TITLE
Prepare 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@
 - Add `array_combinations_with_replacement` (#1033)
 - Implement `Debug` for remaining public types (#1038)
 - Specialize `ExactlyOneError::count` (#1046)
-- Implement `PeekingNext` for more types (#1073)
+- Implement `PeekingNext` for more types, in particular `vec::IntoIter` (#1059, #1073)
 - Fix `PadUsing::next_back` (#1082)
 - Introduce `[circular_]array_windows`, deprecate `tuple_windows` (#1086)
+- Deprecate `tuple_combinations` (replaced by `array_combinations`) (#1085)
 
 ### Notable Internal Changes
 - Make `into_group_map` code more idiomatic (#1027)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Added
 - Add `*_with_hasher` adaptors (#1007)
+
 ### Changed
 - Remove `Clone` bounds from `tuple_combinations` and `array_combinations`(#1011)
 - `must_use` for `collect_vec` (#1009)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,25 +2,23 @@
 
 ## 0.15.0
 
+### Breaking
+- Restructure `Position` as struct instead of enum (#1042, #1043)
+
 ### Changed
 - Remove `Clone` bounds from `tuple_combinations` and `array_combinations`(#1011)
 - `must_use` for `collect_vec` (#1009)
 - Make `izip!` temporary friendly (#1021)
 - Add `array_combinations_with_replacement` (#1033)
 - Implement `Debug` for remaining public types (#1038)
-- Improve `ExactlyOneError` (#1046, #1049)
-- Improve documentation for `multizip` (#1053)
+- Specialize `ExactlyOneError::count` (#1046)
 - Implement `PeekingNext` for more types (#1073)
-- Improve documentation
-- Fix `PadUsing::next_back` (#1065)
+- Fix `PadUsing::next_back` (#1082)
 - Introduce `[circular_]array_windows`, deprecate `tuple_windows` (#1086)
-
-### Breaking
-- Improve `Position` (#1042, #1043)
 
 ### Notable Internal Changes
 - Make `into_group_map` code more idiomatic (#1027)
-- Fix clippy lints (#1076)
+- Fix clippy lints (#1017, #1029, #1076)
 
 ## 0.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Breaking
 - Restructure `Position` as struct instead of enum (#1042, #1043)
 
+### Added
+- Add `*_with_hasher` adaptors (#1007)
 ### Changed
 - Remove `Clone` bounds from `tuple_combinations` and `array_combinations`(#1011)
 - `must_use` for `collect_vec` (#1009)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.15.0
+
+### Changed
+- Remove `Clone` bounds from `tuple_combinations` and `array_combinations`(#1011)
+- `must_use` for `collect_vec` (#1009)
+- Make `izip!` temporary friendly (#1021)
+- Add `array_combinations_with_replacement` (#1033)
+- Implement `Debug` for remaining public types (#1038)
+- Improve `ExactlyOneError` (#1046, #1049)
+- Improve documentation for `multizip` (#1053)
+- Implement `PeekingNext` for more types (#1073)
+- Improve documentation
+- Fix `PadUsing::next_back` (#1065)
+- Introduce `[circular_]array_windows`, deprecate `tuple_windows` (#1086)
+
+### Breaking
+- Improve `Position` (#1042, #1043)
+
+### Notable Internal Changes
+- Make `into_group_map` code more idiomatic (#1027)
+- Fix clippy lints (#1076)
+
 ## 0.14.0
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### Notable Internal Changes
 - Make `into_group_map` code more idiomatic (#1027)
-- Fix clippy lints (#1017, #1029, #1076)
+- Fix clippy lints (#1017, #1029, #1076, #1099)
 
 ## 0.14.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-itertools/itertools"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ How to use with Cargo:
 
 ```toml
 [dependencies]
-itertools = "0.14.0"
+itertools = "0.15.0"
 ```
 
 How to use in your crate:


### PR DESCRIPTION
As agreed upon in https://github.com/rust-itertools/itertools/pull/1085#issuecomment-4164507037.

I adapted things from a015a6831525ee1637df747d3f530a627d9741bf (the 0.14.0 one).

I concur, it's a bit of work to create the CHANGELOG.