### PR TITLE
Remove authors from Cargo metadata (per RFC 3052)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ version = "0.14.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-itertools/itertools"
 documentation = "https://docs.rs/itertools/"
-authors = ["bluss"]
 readme = "README.md"
 
 description = "Extra iterator adaptors, iterator methods, free functions, and macros."


### PR DESCRIPTION
The `authors` field has been deprecated since https://github.com/rust-lang/cargo/pull/15068.