### PR TITLE
clippy: fix manual_option_zip lint

### DIFF
--- a/tests/test_core.rs
+++ b/tests/test_core.rs
@@ -226,7 +226,7 @@ fn batching() {
     let pit = xs
         .iter()
         .cloned()
-        .batching(|it| it.next().and_then(|x| it.next().map(|y| (x, y))));
+        .batching(|it| it.next_array::<2>().map(|[a, b]| (a, b)));
     it::assert_equal(pit, ys.iter().cloned());
 }
 


### PR DESCRIPTION
fix warn-by-default lint in Rust 1.95

https://rust-lang.github.io/rust-clippy/master/index.html#manual_option_zip