### PR TITLE
InterleaveShortest: don't overflow size_hint lower bound

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -179,7 +179,7 @@ where
         let (combined_lower, combined_upper) =
             size_hint::mul_scalar(size_hint::min(curr_hint, next_hint), 2);
         let lower = if curr_lower > next_lower {
-            combined_lower + 1
+            combined_lower.saturating_add(1)
         } else {
             combined_lower
         };

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -83,6 +83,14 @@ fn interleave_shortest() {
     let i1 = ::std::iter::repeat(1);
     let it = v0.into_iter().interleave_shortest(i1);
     assert_eq!(it.size_hint(), (6, Some(6)));
+
+    // Issue #1068: combined lower bound used to overflow when both halves
+    // reported saturating lower bounds, panicking in debug builds.
+    let i0 = ::std::iter::repeat(0).take(usize::MAX);
+    let i1 = ::std::iter::repeat(1);
+    let it = i0.interleave_shortest(i1);
+    let (lower, _) = it.size_hint();
+    assert_eq!(lower, usize::MAX);
 }
 
 #[test]


### PR DESCRIPTION
`combined_lower` is computed with `saturating_mul`, so it can already sit at `usize::MAX`. The next line then does an unchecked `combined_lower + 1` when the current half has a larger lower bound, which panics in debug builds. Hit it with something like `iter::repeat(0).take(usize::MAX).interleave_shortest(iter::repeat(1))`.

Swap the `+` for `saturating_add`.

Closes #1068.