### PR TITLE
PeekNth: don't panic on peek_nth(usize::MAX)

### DIFF
--- a/src/peek_nth.rs
+++ b/src/peek_nth.rs
@@ -69,7 +69,7 @@ where
     /// assert_eq!(iter.peek_nth(1), None);
     /// ```
     pub fn peek_nth(&mut self, n: usize) -> Option<&I::Item> {
-        let unbuffered_items = (n + 1).saturating_sub(self.buf.len());
+        let unbuffered_items = n.checked_add(1)?.saturating_sub(self.buf.len());
 
         self.buf.extend(self.iter.by_ref().take(unbuffered_items));
 
@@ -110,7 +110,7 @@ where
     /// assert_eq!(iter.peek_nth_mut(1), None);
     /// ```
     pub fn peek_nth_mut(&mut self, n: usize) -> Option<&mut I::Item> {
-        let unbuffered_items = (n + 1).saturating_sub(self.buf.len());
+        let unbuffered_items = n.checked_add(1)?.saturating_sub(self.buf.len());
 
         self.buf.extend(self.iter.by_ref().take(unbuffered_items));
 

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -829,6 +829,12 @@ fn test_peek_nth() {
 
     assert_eq!(iter.peek_nth(0), None);
     assert_eq!(iter.peek_nth(1), None);
+
+    // Issue #1067: peek_nth(usize::MAX) used to panic in debug builds
+    // because of the n + 1 overflow. Should just return None now.
+    let mut iter = peek_nth(nums.iter().copied());
+    assert_eq!(iter.peek_nth(usize::MAX), None);
+    assert_eq!(iter.peek_nth_mut(usize::MAX), None);
 }
 
 #[test]


### PR DESCRIPTION
`(n + 1).saturating_sub(...)` overflows when n is `usize::MAX`, panicking in debug builds. We can't actually peek at index `usize::MAX` (would need `usize::MAX + 1` buffered items), so return `None` up front via `checked_add`.

Same fix in `peek_nth_mut` since it has the same expression.

Closes #1067.