### PR TITLE
Use `ControlFlow` in `fold_while` implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3169,7 +3169,7 @@ pub trait Itertools: Iterator {
         Self: Sized,
         F: FnMut(B, Self::Item) -> FoldWhile<B>,
     {
-        use Result::{Err as Break, Ok as Continue};
+        use core::ops::ControlFlow::{Break, Continue};
 
         let result = self.try_fold(
             init,


### PR DESCRIPTION
Now that the MSRV is high enough, might as well.

(inspired by https://github.com/rust-itertools/itertools/issues/1106#issuecomment-4536154233)