### PR TITLE
Only implement FusedIterator for TakeWhileInclusive when the inner iterator is fused

### DIFF
--- a/src/take_while_inclusive.rs
+++ b/src/take_while_inclusive.rs
@@ -90,7 +90,7 @@ where
 
 impl<I, F> FusedIterator for TakeWhileInclusive<I, F>
 where
-    I: Iterator,
+    I: FusedIterator,
     F: FnMut(&I::Item) -> bool,
 {
 }

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -1986,6 +1986,12 @@ quickcheck! {
         is_fused(a.fuse().interleave_shortest(b.fuse()))
     }
 
+    fn fused_take_while_inclusive(a: Iter<i16>) -> bool
+    {
+        !is_fused(a.clone().take_while_inclusive(|_| true)) &&
+        is_fused(a.fuse().take_while_inclusive(|_| true))
+    }
+
     fn fused_product(a: Iter<i16>, b: Iter<i16>) -> bool
     {
         is_fused(a.fuse().cartesian_product(b.fuse()))


### PR DESCRIPTION
Fixes #1088.

`TakeWhileInclusive` sets its `done` flag only when the predicate rejects an element. It does not set it when the inner iterator returns `None`, so with a non-fused inner iterator the adaptor can return `Some` again after a `None`. The `FusedIterator` impl is currently unconditional (`where I: Iterator`), so that contract is violated.

This bounds the impl on `I: FusedIterator`, which is the same approach `std::iter::TakeWhile` takes (option 3 in the issue) and matches how the other conditionally-fused adaptors here are written (for example `InterleaveShortest`).

Note this is technically breaking: `TakeWhileInclusive` no longer implements `FusedIterator` when the inner iterator isn't fused. The previous impl was unsound in that case, so I left the changelog placement for release prep.

Added a `fused_take_while_inclusive` quickcheck test mirroring `fused_interleave_shortest`: not fused over the deliberately non-fused `Iter`, fused once the inner iterator is `.fuse()`d. `cargo test`, `cargo fmt --check`, and `cargo clippy --all-features --all-targets` all pass.