### PR TITLE
Add `pairwise` as an alias for `tuple_windows` when iterating over a pair

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -832,6 +832,24 @@ pub trait Itertools: Iterator {
         tuple_impl::tuple_windows(self)
     }
 
+    /// Alias for `tuple_windows` when iterating over two elements at once.
+    /// ```
+    /// use itertools::Itertools;
+    /// let mut v = Vec::new();
+    ///
+    /// for (a, b) in (1..5).pairwise() {
+    ///     v.push((a, b));
+    /// }
+    /// assert_eq!(v, vec![(1, 2), (2, 3), (3, 4)]);
+    /// ```
+    fn pairwise(self) -> TupleWindows<Self, (Self::Item, Self::Item)>
+    where
+        Self: Sized + Iterator,
+        Self::Item: Clone,
+    {
+        tuple_impl::tuple_windows(self)
+    }
+
     /// Return an iterator over all windows, wrapping back to the first
     /// elements when the window would otherwise exceed the length of the
     /// iterator, producing tuples of a specific size (up to 12).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -797,15 +797,12 @@ pub trait Itertools: Iterator {
     /// part of successive windows, this makes it most suited for iterators
     /// of references and other values that are cheap to copy.
     ///
+    /// This is a generalization `pairwise`, which iterates over tuples of
+    /// size 2.
+    ///
     /// ```
     /// use itertools::Itertools;
     /// let mut v = Vec::new();
-    ///
-    /// // pairwise iteration
-    /// for (a, b) in (1..5).tuple_windows() {
-    ///     v.push((a, b));
-    /// }
-    /// assert_eq!(v, vec![(1, 2), (2, 3), (3, 4)]);
     ///
     /// let mut it = (1..5).tuple_windows();
     /// assert_eq!(Some((1, 2, 3)), it.next());

--- a/tests/tuples.rs
+++ b/tests/tuples.rs
@@ -62,6 +62,18 @@ fn tuple_windows() {
 }
 
 #[test]
+fn pairwise() {
+    let v = [1, 2, 3, 4, 5];
+
+    let mut iter = v.iter().cloned().pairwise();
+    assert_eq!(Some((1, 2)), iter.next());
+    assert_eq!(Some((2, 3)), iter.next());
+    assert_eq!(Some((3, 4)), iter.next());
+    assert_eq!(Some((4, 5)), iter.next());
+    assert_eq!(None, iter.next());
+}
+
+#[test]
 fn next_tuple() {
     let v = [1, 2, 3, 4, 5];
     let mut iter = v.iter();


### PR DESCRIPTION
Closes #388, where most of the discussion is.

### Reasons for this pull request
- lots of people look for `pairwise` because they come from Python
- people reading Rust code will find `pairwise` more intuitive than `tuple_windows`
- it uses `tuple_windows` for the implementation to reduce duplication