### PR TITLE
Untangle `InterleaveShortest::size_hint` and fix #1068

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -176,8 +176,14 @@ where
         };
         let (curr_lower, curr_upper) = curr_hint;
         let (next_lower, next_upper) = next_hint;
+        fn size_hint_mul_scalar(sh: SizeHint, x: usize) -> SizeHint {
+            let (mut low, mut hi) = sh;
+            low = low.saturating_mul(x);
+            hi = hi.and_then(|elt| elt.checked_mul(x));
+            (low, hi)
+        }
         let (combined_lower, combined_upper) =
-            size_hint::mul_scalar(size_hint::min(curr_hint, next_hint), 2);
+            size_hint_mul_scalar(size_hint::min(curr_hint, next_hint), 2);
         let lower = if curr_lower > next_lower {
             combined_lower + 1
         } else {

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -181,24 +181,17 @@ where
         } else {
             curr_lower.saturating_mul(2)
         };
-        let upper = {
-            let (extra_elem, combined_upper) = match (curr_upper, next_upper) {
-                (Some(curr_max), Some(next_max)) => {
-                    if curr_max > next_max {
-                        (true, next_max.checked_mul(2))
-                    } else {
-                        (false, curr_max.checked_mul(2))
-                    }
+        let upper = match (curr_upper, next_upper) {
+            (Some(curr_max), Some(next_max)) => {
+                if curr_max > next_max {
+                    next_max.checked_mul(2).and_then(|x| x.checked_add(1))
+                } else {
+                    curr_max.checked_mul(2)
                 }
-                (Some(curr_max), None) => (false, curr_max.checked_mul(2)),
-                (None, Some(next_max)) => (true, next_max.checked_mul(2)),
-                (None, None) => (false, None),
-            };
-            if extra_elem {
-                combined_upper.and_then(|x| x.checked_add(1))
-            } else {
-                combined_upper
             }
+            (Some(curr_max), None) => curr_max.checked_mul(2),
+            (None, Some(next_max)) => next_max.checked_mul(2).and_then(|x| x.checked_add(1)),
+            (None, None) => None,
         };
         (lower, upper)
     }

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -176,24 +176,21 @@ where
         };
         let (curr_lower, curr_upper) = curr_hint;
         let (next_lower, next_upper) = next_hint;
-        pub fn size_hint_min(a: SizeHint, b: SizeHint) -> SizeHint {
-            let (a_lower, a_upper) = a;
-            let (b_lower, b_upper) = b;
-            let lower = std::cmp::min(a_lower, b_lower);
-            let upper = match (a_upper, b_upper) {
+        let size_hint_min = {
+            let lower = std::cmp::min(curr_lower, next_lower);
+            let upper = match (curr_upper, next_upper) {
                 (Some(u1), Some(u2)) => Some(std::cmp::min(u1, u2)),
-                _ => a_upper.or(b_upper),
+                _ => curr_upper.or(next_upper),
             };
             (lower, upper)
-        }
+        };
         fn size_hint_mul_scalar(sh: SizeHint, x: usize) -> SizeHint {
             let (mut low, mut hi) = sh;
             low = low.saturating_mul(x);
             hi = hi.and_then(|elt| elt.checked_mul(x));
             (low, hi)
         }
-        let (combined_lower, combined_upper) =
-            size_hint_mul_scalar(size_hint_min(curr_hint, next_hint), 2);
+        let (combined_lower, combined_upper) = size_hint_mul_scalar(size_hint_min, 2);
         let lower = if curr_lower > next_lower {
             combined_lower + 1
         } else {

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -184,13 +184,12 @@ where
             };
             (lower, upper)
         };
-        fn size_hint_mul_scalar(sh: SizeHint, x: usize) -> SizeHint {
-            let (mut low, mut hi) = sh;
-            low = low.saturating_mul(x);
-            hi = hi.and_then(|elt| elt.checked_mul(x));
+        let (combined_lower, combined_upper) = {
+            let (mut low, mut hi) = size_hint_min;
+            low = low.saturating_mul(2);
+            hi = hi.and_then(|elt| elt.checked_mul(2));
             (low, hi)
-        }
-        let (combined_lower, combined_upper) = size_hint_mul_scalar(size_hint_min, 2);
+        };
         let lower = if curr_lower > next_lower {
             combined_lower + 1
         } else {

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -177,12 +177,7 @@ where
         let (curr_lower, curr_upper) = curr_hint;
         let (next_lower, next_upper) = next_hint;
         let size_hint_min_lower = std::cmp::min(curr_lower, next_lower);
-        let size_hint_min_upper = match (curr_upper, next_upper) {
-            (Some(u1), Some(u2)) => Some(std::cmp::min(u1, u2)),
-            _ => curr_upper.or(next_upper),
-        };
         let combined_lower = size_hint_min_lower.saturating_mul(2);
-        let combined_upper = size_hint_min_upper.and_then(|elt| elt.checked_mul(2));
         let lower = if curr_lower > next_lower {
             combined_lower + 1
         } else {
@@ -194,6 +189,11 @@ where
                 (None, Some(_)) => true,
                 (Some(curr_max), Some(next_max)) => curr_max > next_max,
             };
+            let size_hint_min_upper = match (curr_upper, next_upper) {
+                (Some(u1), Some(u2)) => Some(std::cmp::min(u1, u2)),
+                _ => curr_upper.or(next_upper),
+            };
+            let combined_upper = size_hint_min_upper.and_then(|elt| elt.checked_mul(2));
             if extra_elem {
                 combined_upper.and_then(|x| x.checked_add(1))
             } else {

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -182,19 +182,18 @@ where
             curr_lower.saturating_mul(2)
         };
         let upper = {
-            let (extra_elem, size_hint_min_upper) = match (curr_upper, next_upper) {
+            let (extra_elem, combined_upper) = match (curr_upper, next_upper) {
                 (Some(curr_max), Some(next_max)) => {
                     if curr_max > next_max {
-                        (true, Some(next_max))
+                        (true, next_max.checked_mul(2))
                     } else {
-                        (false, Some(curr_max))
+                        (false, curr_max.checked_mul(2))
                     }
                 }
-                (Some(curr_max), None) => (false, Some(curr_max)),
-                (None, Some(next_max)) => (true, Some(next_max)),
+                (Some(curr_max), None) => (false, curr_max.checked_mul(2)),
+                (None, Some(next_max)) => (true, next_max.checked_mul(2)),
                 (None, None) => (false, None),
             };
-            let combined_upper = size_hint_min_upper.and_then(|elt| elt.checked_mul(2));
             if extra_elem {
                 combined_upper.and_then(|x| x.checked_add(1))
             } else {

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -176,20 +176,13 @@ where
         };
         let (curr_lower, curr_upper) = curr_hint;
         let (next_lower, next_upper) = next_hint;
-        let size_hint_min = {
-            let lower = std::cmp::min(curr_lower, next_lower);
-            let upper = match (curr_upper, next_upper) {
-                (Some(u1), Some(u2)) => Some(std::cmp::min(u1, u2)),
-                _ => curr_upper.or(next_upper),
-            };
-            (lower, upper)
+        let size_hint_min_lower = std::cmp::min(curr_lower, next_lower);
+        let size_hint_min_upper = match (curr_upper, next_upper) {
+            (Some(u1), Some(u2)) => Some(std::cmp::min(u1, u2)),
+            _ => curr_upper.or(next_upper),
         };
-        let (combined_lower, combined_upper) = {
-            let (mut low, mut hi) = size_hint_min;
-            low = low.saturating_mul(2);
-            hi = hi.and_then(|elt| elt.checked_mul(2));
-            (low, hi)
-        };
+        let combined_lower = size_hint_min_lower.saturating_mul(2);
+        let combined_upper = size_hint_min_upper.and_then(|elt| elt.checked_mul(2));
         let lower = if curr_lower > next_lower {
             combined_lower + 1
         } else {

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -176,12 +176,10 @@ where
         };
         let (curr_lower, curr_upper) = curr_hint;
         let (next_lower, next_upper) = next_hint;
-        let size_hint_min_lower = std::cmp::min(curr_lower, next_lower);
-        let combined_lower = size_hint_min_lower.saturating_mul(2);
         let lower = if curr_lower > next_lower {
-            combined_lower + 1
+            next_lower.saturating_mul(2) + 1
         } else {
-            combined_lower
+            curr_lower.saturating_mul(2)
         };
         let upper = {
             let extra_elem = match (curr_upper, next_upper) {

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -177,7 +177,7 @@ where
         let (curr_lower, curr_upper) = curr_hint;
         let (next_lower, next_upper) = next_hint;
         let lower = if curr_lower > next_lower {
-            next_lower.saturating_mul(2) + 1
+            next_lower.saturating_mul(2).saturating_add(1)
         } else {
             curr_lower.saturating_mul(2)
         };

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -184,7 +184,11 @@ where
         let upper = {
             let (extra_elem, size_hint_min_upper) = match (curr_upper, next_upper) {
                 (Some(curr_max), Some(next_max)) => {
-                    (curr_max > next_max, Some(std::cmp::min(curr_max, next_max)))
+                    if curr_max > next_max {
+                        (true, Some(next_max))
+                    } else {
+                        (false, Some(curr_max))
+                    }
                 }
                 (Some(curr_max), None) => (false, Some(curr_max)),
                 (None, Some(next_max)) => (true, Some(next_max)),

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -182,14 +182,13 @@ where
             curr_lower.saturating_mul(2)
         };
         let upper = {
-            let extra_elem = match (curr_upper, next_upper) {
-                (_, None) => false,
-                (None, Some(_)) => true,
-                (Some(curr_max), Some(next_max)) => curr_max > next_max,
-            };
-            let size_hint_min_upper = match (curr_upper, next_upper) {
-                (Some(u1), Some(u2)) => Some(std::cmp::min(u1, u2)),
-                _ => curr_upper.or(next_upper),
+            let (extra_elem, size_hint_min_upper) = match (curr_upper, next_upper) {
+                (Some(curr_max), Some(next_max)) => {
+                    (curr_max > next_max, Some(std::cmp::min(curr_max, next_max)))
+                }
+                (Some(curr_max), None) => (false, Some(curr_max)),
+                (None, Some(next_max)) => (true, Some(next_max)),
+                (None, None) => (false, None),
             };
             let combined_upper = size_hint_min_upper.and_then(|elt| elt.checked_mul(2));
             if extra_elem {

--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -176,6 +176,16 @@ where
         };
         let (curr_lower, curr_upper) = curr_hint;
         let (next_lower, next_upper) = next_hint;
+        pub fn size_hint_min(a: SizeHint, b: SizeHint) -> SizeHint {
+            let (a_lower, a_upper) = a;
+            let (b_lower, b_upper) = b;
+            let lower = std::cmp::min(a_lower, b_lower);
+            let upper = match (a_upper, b_upper) {
+                (Some(u1), Some(u2)) => Some(std::cmp::min(u1, u2)),
+                _ => a_upper.or(b_upper),
+            };
+            (lower, upper)
+        }
         fn size_hint_mul_scalar(sh: SizeHint, x: usize) -> SizeHint {
             let (mut low, mut hi) = sh;
             low = low.saturating_mul(x);
@@ -183,7 +193,7 @@ where
             (low, hi)
         }
         let (combined_lower, combined_upper) =
-            size_hint_mul_scalar(size_hint::min(curr_hint, next_hint), 2);
+            size_hint_mul_scalar(size_hint_min(curr_hint, next_hint), 2);
         let lower = if curr_lower > next_lower {
             combined_lower + 1
         } else {

--- a/src/size_hint.rs
+++ b/src/size_hint.rs
@@ -47,15 +47,6 @@ pub fn mul(a: SizeHint, b: SizeHint) -> SizeHint {
     (low, hi)
 }
 
-/// Multiply `x` correctly with a `SizeHint`.
-#[inline]
-pub fn mul_scalar(sh: SizeHint, x: usize) -> SizeHint {
-    let (mut low, mut hi) = sh;
-    low = low.saturating_mul(x);
-    hi = hi.and_then(|elt| elt.checked_mul(x));
-    (low, hi)
-}
-
 /// Return the maximum
 #[inline]
 pub fn max(a: SizeHint, b: SizeHint) -> SizeHint {

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -87,6 +87,16 @@ fn interleave_shortest() {
 }
 
 #[test]
+fn interleave_shortest_size_hint_does_not_overflow() {
+    // The combined lower bound can exceed `usize::MAX`, which used to overflow
+    // when computing `size_hint`. It should saturate instead of panicking.
+    let i = ::std::iter::repeat(0u8).take(usize::MAX);
+    let j = ::std::iter::repeat(0u8).take(usize::MAX - 1);
+    let it = i.interleave_shortest(j);
+    assert_eq!(it.size_hint(), (usize::MAX, None));
+}
+
+#[test]
 fn duplicates_by() {
     let xs = ["aaa", "bbbbb", "aa", "ccc", "bbbb", "aaaaa", "cccc"];
     let ys = ["aa", "bbbb", "cccc"];


### PR DESCRIPTION
While reviewing #1109, I realized that `InterleaveShortest::size_hint` is hard to understand, mainly because we compare lower/upper bounds separately and with the magic `size_hint::min` methods.

I kept my commits so that you can follow step-by-step how I untangled it. At the end, we do - both for the `size_hint`'s lower and upper bound - this: Compare "current" vs "next" iterator's estimated length, and act accordingly.

- Up to the third-to-last commit: Untangling the code
- Second-to-last commits: add a test
- Last commit: fix #1068 

Thanks @patrickwehbe, @c-tonneslan and @ronnodas for your ideas on this.