### PR TITLE
Add TimedIterator that tracks durations of calls to next()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,8 @@ pub mod structs {
     pub use crate::take_while_inclusive::TakeWhileInclusive;
     #[cfg(feature = "use_alloc")]
     pub use crate::tee::Tee;
+    #[cfg(feature = "use_std")]
+    pub use crate::timed::TimedIterator;
     pub use crate::tuple_impl::{CircularTupleWindows, TupleBuffer, TupleWindows, Tuples};
     #[cfg(feature = "use_std")]
     pub use crate::unique_impl::{Unique, UniqueBy};
@@ -238,6 +240,8 @@ mod sources;
 mod take_while_inclusive;
 #[cfg(feature = "use_alloc")]
 mod tee;
+#[cfg(feature = "use_std")]
+mod timed;
 mod tuple_impl;
 #[cfg(feature = "use_std")]
 mod unique_impl;
@@ -5191,6 +5195,62 @@ pub trait Itertools: Iterator {
                 mismatch,
             }),
         }
+    }
+
+    /// Computes the duration of each call to `next()` and yields it alongside
+    /// each element. The first time the input iterator returns None from
+    /// `next()`, the duration is also computed and returned. This has two
+    /// consequences:
+    /// - The Item type of the timed iterator contains an extra option, i.e.
+    ///   the `Item` associated type is `(Option<I::Item>, Duration)`.
+    /// - For finite iterators, the timed iterator always yields one more
+    ///   element than the input iterator. Since this makes the iterator
+    ///   longer, we don't implement the `ExactSizeIterator` trait even if
+    ///   the input iterator does.
+    /// 
+    /// Note that this iterator implicitly assumes that its input is fused
+    /// (see [`std::iter::FusedIterator`] for details). Once the consumed
+    /// iterator's `next()` method returns `None`, it is never called again.
+    /// In most cases, the input iterator is then unretrievable (unless
+    /// `(&mut iter).timed()` or `Itertools::timed(&mut iter)` is called
+    /// explicitly). In this case, if the TimedIterator is exhausted, the
+    /// underlying iterator could be accessible and would be in the state
+    /// right after returning `None` for the first time.
+    /// 
+    /// ```
+    /// use itertools::Itertools;
+    /// use std::{thread, time::Duration};
+    /// 
+    /// struct YieldsOnce {
+    ///     yielded_yet: bool
+    /// }
+    /// impl Iterator for YieldsOnce {
+    ///     type Item = ();
+    ///     fn next(&mut self) -> Option<()> {
+    ///         if self.yielded_yet {
+    ///             thread::sleep(Duration::from_micros(2));
+    ///             None
+    ///         } else {
+    ///             thread::sleep(Duration::from_micros(1));
+    ///             self.yielded_yet = true;
+    ///             Some(())
+    ///         }
+    ///     }
+    /// }
+    /// let iter = YieldsOnce{yielded_yet: false};
+    /// let iter = iter.timed();
+    /// let results: Vec<(Option<()>, Duration)> = iter.collect();
+    /// assert_eq!(results.len(), 2);
+    /// let (first_value, first_duration) = results[0];
+    /// assert_eq!(first_value, Some(()));
+    /// assert!(first_duration >= Duration::from_micros(1));
+    /// let (second_value, second_duration) = results[1];
+    /// assert_eq!(second_value, None);
+    /// assert!(second_duration >= Duration::from_micros(2));
+    /// ```
+    #[cfg(feature = "use_std")]
+    fn timed(self) -> TimedIterator<Self> where Self: Sized {
+        TimedIterator::new(self)
     }
 }
 

--- a/src/timed.rs
+++ b/src/timed.rs
@@ -1,0 +1,59 @@
+use std::{iter::FusedIterator, time::{Duration, Instant}};
+
+
+/// Tracks and returns durations of each call to `next()`.
+/// 
+/// See [`crate::Itertools::timed()`] for more details.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+#[derive(Debug, Clone)]
+pub struct TimedIterator<I> {
+    iter: I,
+    exhausted: bool,
+}
+
+impl<I: Iterator> TimedIterator<I> {
+    /// Creates a new TimedIterator that times the given input
+    /// iterator's calls to `next()` when iterated over.
+    pub fn new(iter: I) -> Self {
+        Self {
+            iter,
+            exhausted: false,
+        }
+    }
+}
+
+impl<I: Iterator> Iterator for TimedIterator<I> {
+    type Item = (Option<I::Item>, Duration);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.exhausted {
+            None
+        } else {
+            let start = Instant::now();
+            let item = self.iter.next();
+            let duration = start.elapsed();
+            self.exhausted = item.is_none();
+            Some((item, duration))
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.exhausted {
+            (0, Some(0))
+        } else {
+            let (lower_limit, upper_limit) = self.iter.size_hint();
+            let lower_limit = match lower_limit {
+                usize::MAX => usize::MAX,
+                lower_limit => lower_limit + 1,
+            };
+            let upper_limit = match upper_limit {
+                None => None,
+                Some(usize::MAX) => None,
+                Some(upper_limit) => Some(upper_limit + 1),
+            };
+            (lower_limit, upper_limit)
+        }
+    }
+}
+
+impl<I: Iterator> FusedIterator for TimedIterator<I> {}

--- a/tests/laziness.rs
+++ b/tests/laziness.rs
@@ -309,4 +309,7 @@ must_use_tests! {
     rciter {
         let _ = itertools::rciter(Panicking);
     }
+    timed {
+        let _ = Panicking.timed();
+    }
 }

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -25,6 +25,8 @@ use std::collections::HashMap;
 use std::hash::BuildHasher;
 use std::hash::RandomState;
 use std::iter::empty;
+use std::thread;
+use std::time::Duration;
 use std::{cmp::min, fmt::Debug, marker::PhantomData};
 
 // A Hasher which forwards it's calls to RandomState to make sure different hashers
@@ -1674,4 +1676,126 @@ fn counts_with_hasher() {
 fn counts_by_with_hasher() {
     let _: HashMap<_, _, TestHasher> =
         empty::<u8>().counts_by_with_hasher(|x| x, TestHasher::new());
+}
+
+#[test]
+fn timed_empty() {
+    struct EmptyIterator;
+    impl Iterator for EmptyIterator {
+        type Item = ();
+        fn next(&mut self) -> Option<Self::Item> {
+            thread::sleep(Duration::from_micros(1));
+            None
+        }
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (0, Some(0))
+        }
+    }
+    let mut iter = EmptyIterator.timed();
+    assert_eq!(iter.size_hint(), (1, Some(1)));
+    let (item, duration) = iter.next().unwrap();
+    assert_eq!(item, None);
+    assert!(duration.as_micros() >= 1);
+    assert_eq!(iter.size_hint(), (0, Some(0)));
+    assert_eq!(iter.next(), None);
+    assert_eq!(iter.size_hint(), (0, Some(0)));
+}
+
+#[test]
+fn timed_infinite() {
+    struct InfiniteIterator(usize);
+    impl Iterator for InfiniteIterator {
+        type Item = usize;
+        fn next(&mut self) -> Option<Self::Item> {
+            thread::sleep(Duration::from_micros(1));
+            let result = Some(self.0);
+            self.0 += 1;
+            result
+        }
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (usize::MAX, None)
+        }
+    }
+    let mut iter = InfiniteIterator(0).timed();
+    for cur in 0..100 {
+        assert_eq!(iter.size_hint(), (usize::MAX, None));
+        let (item, duration) = iter.next().unwrap();
+        assert_eq!(item.unwrap(), cur);
+        assert!(duration.as_micros() >= 1);
+    }
+}
+
+#[test]
+fn timed_finite() {
+    struct MockIterator(usize);
+    impl Iterator for MockIterator {
+        type Item = usize;
+        fn next(&mut self) -> Option<Self::Item> {
+            match self.0 {
+                0 => {
+                    thread::sleep(Duration::from_micros(10));
+                    None
+                },
+                _ => {
+                    thread::sleep(Duration::from_micros(self.0 as u64));
+                    self.0 -= 1;
+                    Some(self.0)
+                }
+            }
+        }
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (self.0, Some(self.0))
+        }
+    }
+    let mut iter = MockIterator(4).timed();
+    for cur in (0..4).rev() {
+        assert_eq!(iter.size_hint(), (cur + 2, Some(cur + 2)));
+        let (item, duration) = iter.next().unwrap();
+        assert_eq!(item.unwrap(), cur);
+        assert!(duration >= Duration::from_micros((cur as u64) + 1));
+    }
+    assert_eq!(iter.size_hint(), (1, Some(1)));
+    let (item, duration) = iter.next().unwrap();
+    assert!(item.is_none());
+    assert!(duration >= Duration::from_micros(10));
+    assert!(iter.next().is_none());
+}
+
+#[test]
+fn timed_unfused_iterator() {
+    struct MockIterator(usize);
+    impl Iterator for MockIterator {
+        type Item = usize;
+        fn next(&mut self) -> Option<Self::Item> {
+            let result = if (self.0 % 2) == 0 {
+                thread::sleep(Duration::from_micros(2));
+                None
+            } else {
+                thread::sleep(Duration::from_micros(1));
+                Some(self.0)
+            };
+            if self.0 != 0 {
+                self.0 -= 1;
+            }
+            result
+        }
+    }
+    let mut iter = MockIterator(3);
+    let first = (&mut iter).timed().collect::<Vec<_>>();
+    let second = (&mut iter).timed().collect::<Vec<_>>();
+    let third = (&mut iter).timed().collect::<Vec<_>>();
+    assert_eq!(first.len(), 2);
+    assert_eq!(first[0].0, Some(3));
+    assert!(first[0].1 > Duration::from_micros(1));
+    assert_eq!(first[1].0, None);
+    assert!(first[1].1 > Duration::from_micros(2));
+    assert_eq!(second.len(), 2);
+    assert_eq!(second[0].0, Some(1));
+    assert!(second[0].1 > Duration::from_micros(1));
+    assert_eq!(second.len(), 2);
+    assert_eq!(second[1].0, None);
+    assert!(second[1].1 > Duration::from_micros(2));
+    assert_eq!(third.len(), 1);
+    assert_eq!(third[0].0, None);
+    assert!(third[0].1 > Duration::from_micros(2));
 }


### PR DESCRIPTION
This pull request adds a new iterator adaptor named `TimedIterator` (accessed via `Itertools::timed()`). This iterator wraps each call to `next()` with duration tracking code. In particular, each call to `next()` is forwarded to the wrapped iterator until it returns `None`. In each of these cases, the return of the `<TimedIterator as Iterator>::next()` is `(inner_next_output, duration)` (where `inner_next_output` is an `Option`). Once these iterations are done, the `TimedIterator` will return `None` on every call to `next()` until it is dropped.

Items considered:

- [x] `TimedIterator` implements `Debug` and `Clone` (assuming the wrapped iterator does).
- [x] `TimedIterator` implements `FusedIterator`, notably even if the inner iterator does not.
- [x] `TimedIterator` cannot implement `ExactSizeIterator` even if the inner iterator does because it makes the adaptor is a longer iterator than the wrapped one (see [the docs for `ExactSizeIterator`](https://doc.rust-lang.org/std/iter/trait.ExactSizeIterator.html#when-shouldnt-an-adapter-be-exactsizeiterator) for details).
- [x] `TimedIterator` is lazy. This behavior is tested in `tests/laziness.rs` and the `must_use` macro decorates the struct.
- [x] `TimedIterator` is behind the `use_std` feature because it requires `Instant` and `Duration` from `std::time`.
- [x] The `Itertools::timed()` method consumes `self`.
- [x] The `Itertools::timed()` method is tested in `tests/test_std.rs` in the cases of (1) an infinite iterator (2) an empty iterator (3) a finite (implicitly fused iterator) and (4) a specially crafted unfused iterator