### PR TITLE
Derive `Copy` for `EitherOrBoth`

### DIFF
--- a/src/either_or_both.rs
+++ b/src/either_or_both.rs
@@ -5,7 +5,7 @@ use crate::EitherOrBoth::*;
 use either::Either;
 
 /// Value that either holds a single A or B, or both.
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum EitherOrBoth<A, B = A> {
     /// Both values are present.
     Both(A, B),


### PR DESCRIPTION
It's been missing since the original implementation but I see no reason it shouldn't be `Copy` when both `A` and `B` are.