### PR TITLE
Add doc alias "single" to "exactly_one"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4909,6 +4909,7 @@ pub trait Itertools: Iterator {
     /// assert!((0..10).filter(|&x| x > 1 && x < 5).exactly_one().unwrap_err().eq(2..5));
     /// assert!((0..10).filter(|&_| false).exactly_one().unwrap_err().eq(0..0));
     /// ```
+    #[doc(alias("single"))]
     fn exactly_one(mut self) -> Result<Self::Item, ExactlyOneError<Self>>
     where
         Self: Sized,


### PR DESCRIPTION
"Single" seems like an obvious name for "exactly_one", so I feel like adding this alias makes it more discoverable.

It's notable that "single" doesn't appear in the documentation for exactly_one either.

I found a few issues that show that indeed this change might help people:

* https://github.com/rust-itertools/itertools/issues/595
* https://github.com/rust-itertools/itertools/issues/334
* https://github.com/rust-itertools/itertools/issues/566