### PR TITLE
Deprecate `while_some()`

### DIFF
--- a/benches/specializations.rs
+++ b/benches/specializations.rs
@@ -495,13 +495,6 @@ bench_specializations! {
         }
         v.iter().powerset()
     }
-    while_some {
-        {}
-        (0..)
-            .map(black_box)
-            .map(|i| char::from_digit(i, 16))
-            .while_some()
-    }
     with_position {
         ExactSizeIterator
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1902,7 +1902,7 @@ pub trait Itertools: Iterator {
     ///     "0123456789abcdef".chars(),
     /// );
     /// ```
-    #[deprecated(note="Use .map_while() instead", since="0.16.0")]
+    #[deprecated(note = "Use .map_while() instead", since = "0.16.0")]
     fn while_some<A>(self) -> WhileSome<Self>
     where
         Self: Sized + Iterator<Item = Option<A>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1902,6 +1902,7 @@ pub trait Itertools: Iterator {
     ///     "0123456789abcdef".chars(),
     /// );
     /// ```
+    #[deprecated(note="Use .map_while() instead", since="0.16.0")]
     fn while_some<A>(self) -> WhileSome<Self>
     where
         Self: Sized + Iterator<Item = Option<A>>,

--- a/tests/laziness.rs
+++ b/tests/laziness.rs
@@ -205,6 +205,7 @@ must_use_tests! {
     take_while_inclusive {
         let _ = Panicking.take_while_inclusive(|x| x % 2 == 0);
     }
+    #[allow(deprecated)]
     while_some {
         let _ = Panicking.map(Some).while_some();
     }

--- a/tests/specializations.rs
+++ b/tests/specializations.rs
@@ -228,6 +228,7 @@ quickcheck! {
         test_specializations(&v.iter().copied().take_while_inclusive(|&x| x < 100));
     }
 
+    #[allow(deprecated)]
     fn while_some(v: Vec<u8>) -> () {
         test_specializations(&v.iter().map(|&x| if x < 100 { Some(2 * x) } else { None }).while_some());
     }

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -1522,6 +1522,7 @@ fn format() {
     assert_eq!(t3, "1.10e0, 5.72e0, -2.20e1");
 }
 
+#[allow(deprecated)]
 #[test]
 fn while_some() {
     let ns = (1..10)


### PR DESCRIPTION
Closes #1120. I guessed the next breaking release for the `since` field, some guidance about this would be helpful.