### PR TITLE
Deprecate `fold_while()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3165,6 +3165,7 @@ pub trait Itertools: Iterator {
     /// The big difference between the computations of `result2` and `result3` is that while
     /// `fold()` called the provided closure for every item of the callee iterator,
     /// `fold_while()` actually stopped iterating as soon as it encountered `Fold::Done(_)`.
+    #[deprecated(note = "use .try_fold() instead", since = "0.16.0")]
     fn fold_while<B, F>(&mut self, init: B, mut f: F) -> FoldWhile<B>
     where
         Self: Sized,

--- a/tests/test_std.rs
+++ b/tests/test_std.rs
@@ -1531,6 +1531,7 @@ fn while_some() {
     it::assert_equal(ns, vec![1, 2, 3, 4]);
 }
 
+#[allow(deprecated)]
 #[test]
 fn fold_while() {
     let mut iterations = 0;


### PR DESCRIPTION
Closes #1106. I've guessed the next breaking release for the `since` field, some guidance about this would be useful.