### PR TITLE
Fix `clippy::question_mark` warnings

### DIFF
--- a/src/adaptors/mod.rs
+++ b/src/adaptors/mod.rs
@@ -405,13 +405,9 @@ where
         let elt_b = match b.next() {
             None => {
                 *b = b_orig.clone();
-                match b.next() {
-                    None => return None,
-                    Some(x) => {
-                        *a_cur = Some(a.next());
-                        x
-                    }
-                }
+                let x = b.next()?;
+                *a_cur = Some(a.next());
+                x
             }
             Some(x) => x,
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2899,10 +2899,7 @@ pub trait Itertools: Iterator {
         F: FnMut(B, A) -> B,
     {
         for elt in self {
-            match elt {
-                Ok(v) => start = f(start, v),
-                Err(u) => return Err(u),
-            }
+            start = f(start, elt?)
         }
         Ok(start)
     }
@@ -2932,10 +2929,7 @@ pub trait Itertools: Iterator {
         F: FnMut(B, A) -> B,
     {
         for elt in self {
-            match elt {
-                Some(v) => start = f(start, v),
-                None => return None,
-            }
+            start = f(start, elt?)
         }
         Some(start)
     }

--- a/src/multipeek_impl.rs
+++ b/src/multipeek_impl.rs
@@ -51,13 +51,9 @@ impl<I: Iterator> MultiPeek<I> {
         let ret = if self.index < self.buf.len() {
             Some(&self.buf[self.index])
         } else {
-            match self.iter.next() {
-                Some(x) => {
-                    self.buf.push_back(x);
-                    Some(&self.buf[self.index])
-                }
-                None => return None,
-            }
+            let x = self.iter.next()?;
+            self.buf.push_back(x);
+            Some(&self.buf[self.index])
         };
 
         self.index += 1;


### PR DESCRIPTION
These were affecting the CI in every recent PR, and the resulting code does seem better. All were instances of the [`question_mark`](https://rust-lang.github.io/rust-clippy/master/index.html?search=question#question_mark) lint.